### PR TITLE
refactor: simplify estimation API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,6 @@ dependencies = [
 [[package]]
 name = "kornia-3d"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "bincode",
  "faer",
@@ -803,7 +802,6 @@ dependencies = [
 [[package]]
 name = "kornia-algebra"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "glam",
  "nalgebra",
@@ -814,7 +812,6 @@ dependencies = [
 [[package]]
 name = "kornia-image"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "kornia-tensor",
  "num-traits",
@@ -825,7 +822,6 @@ dependencies = [
 [[package]]
 name = "kornia-imgproc"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "fast_image_resize",
  "kornia-algebra",
@@ -851,7 +847,6 @@ dependencies = [
 [[package]]
 name = "kornia-tensor"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "num-traits",
  "rayon",
@@ -1999,3 +1994,7 @@ checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "kornia-io"
+version = "0.1.11"

--- a/examples/orb_slam/Cargo.lock
+++ b/examples/orb_slam/Cargo.lock
@@ -4824,7 +4824,6 @@ dependencies = [
 [[package]]
 name = "kornia-3d"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "bincode 2.0.1",
  "faer",
@@ -4842,7 +4841,6 @@ dependencies = [
 [[package]]
 name = "kornia-algebra"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "glam",
  "nalgebra",
@@ -4853,7 +4851,6 @@ dependencies = [
 [[package]]
 name = "kornia-image"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "kornia-tensor",
  "num-traits",
@@ -4864,7 +4861,6 @@ dependencies = [
 [[package]]
 name = "kornia-imgproc"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "fast_image_resize",
  "kornia-algebra",
@@ -4879,7 +4875,6 @@ dependencies = [
 [[package]]
 name = "kornia-io"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "jpeg-encoder",
  "kornia-image",
@@ -4906,7 +4901,6 @@ dependencies = [
 [[package]]
 name = "kornia-tensor"
 version = "0.1.11"
-source = "git+https://github.com/kornia/kornia-rs?branch=feat%2Fslam-utils#f252be81e9cf6f4598e1751f68d29d13e144da8c"
 dependencies = [
  "num-traits",
  "rayon",

--- a/examples/orb_slam/src/config.rs
+++ b/examples/orb_slam/src/config.rs
@@ -1,10 +1,13 @@
 use kornia_slam::estimation::map_projection::MapProjectionConfig;
 use kornia_slam::estimation::two_view::TwoViewInitConfig;
+use kornia_slam::system::KeyframePolicy;
 
 /// Example-local pipeline preset used by the standalone ORB-SLAM binary.
 pub struct PipelineConfig {
     pub two_view_init: TwoViewInitConfig,
     pub map_projection: MapProjectionConfig,
+    pub keyframe_policy: KeyframePolicy,
+    pub enable_local_ba: bool,
 }
 
 impl Default for PipelineConfig {
@@ -22,6 +25,8 @@ impl Default for PipelineConfig {
         Self {
             two_view_init,
             map_projection: MapProjectionConfig::default(),
+            keyframe_policy: KeyframePolicy::default(),
+            enable_local_ba: true,
         }
     }
 }

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -217,8 +217,8 @@ impl Pipeline {
 
         if status == TrackingStatus::Tracked {
             let visible =
-                self.estimator
-                    .visible_map_points(&self.map, &candidate_pose, image_size);
+                self.map
+                    .map_points_in_frustum(self.estimator.camera(), &candidate_pose, image_size);
             self.map.update_observation_counts(&visible, &matches);
 
             if self.try_insert_keyframe(&frame, tracked_inliers, &matches) {

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -12,19 +12,26 @@ use kornia_3d::pose::{
 use kornia_algebra::Vec3F64;
 use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
 use kornia_slam::estimation::MapProjectionEstimator;
-use kornia_slam::estimation::map_projection::MapProjectionEstimateOutcome;
-use kornia_slam::estimation::two_view::{
-    TwoViewInitConfig, TwoViewInitOutcome, try_initialize_two_view,
-};
+use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
 use kornia_slam::map::{Keyframe, Map, MapPoint};
-use kornia_slam::system::{SystemMode, SystemState, TrackingResult, TrackingStatus};
+use kornia_slam::system::{
+    KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus,
+};
 use kornia_slam::{Frame, OrbFeatures};
 
 /// Top-level ORB-SLAM pipeline: orchestrates tracking, mapping, and state transitions.
 pub struct Pipeline {
+    // Primary pose estimator
     estimator: MapProjectionEstimator,
+    // Boostrap pose estimator
     two_view_init_config: TwoViewInitConfig,
+    // Keyframe insertion policy
+    keyframe_policy: KeyframePolicy,
+    // Enable local bundle adjustment after keyframe insertion
+    enable_local_ba: bool,
+    // Map object
     map: Map,
+    // System state
     state: SystemState,
 }
 
@@ -34,6 +41,8 @@ impl Pipeline {
         Self {
             estimator: MapProjectionEstimator::new(camera, config.map_projection),
             two_view_init_config: config.two_view_init,
+            keyframe_policy: config.keyframe_policy,
+            enable_local_ba: config.enable_local_ba,
             map: Map::new(),
             state: SystemState::new(),
         }
@@ -77,53 +86,47 @@ impl Pipeline {
             };
         };
 
-        let outcome = try_initialize_two_view(
+        let result = try_initialize_two_view(
             &prev_bootstrap_frame.features,
             &prev_bootstrap_frame.pose_world_to_cam,
             &curr_frame.features,
-            &curr_frame.pose_world_to_cam,
             self.estimator.camera(),
             &self.two_view_init_config,
         );
 
-        match outcome {
-            TwoViewInitOutcome::Rejected { .. } => {
+        let tv = match result {
+            Err(_) => {
                 self.state.bootstrap_frame = Some(prev_bootstrap_frame);
-                TrackingResult {
+                return TrackingResult {
                     pose_world_to_cam: self.state.pose_world_to_cam,
                     status: TrackingStatus::Skipped,
-                }
+                };
             }
-            TwoViewInitOutcome::Initialized {
-                pose_world_to_cam,
-                motion_increment,
-                matches,
-                points3d,
-                inlier_indices,
-                median_depth,
-            } => {
-                self.state.velocity = Some(motion_increment);
-                self.state.pose_world_to_cam = pose_world_to_cam;
-                curr_frame.pose_world_to_cam = self.state.pose_world_to_cam;
+            Ok(tv) => tv,
+        };
 
-                let curr_idx = curr_frame.idx;
-                self.build_initial_map(
-                    prev_bootstrap_frame,
-                    curr_frame,
-                    &matches,
-                    &points3d,
-                    &inlier_indices,
-                    median_depth,
-                );
-                self.state.current_keyframe_idx = Some(curr_idx);
-                self.state.last_keyframe_idx = Some(curr_idx);
-                self.state.mode = SystemMode::Tracking;
+        let motion_increment =
+            Pose3d::between(&curr_frame.pose_world_to_cam, &tv.estimate.pose);
+        self.state.velocity = Some(motion_increment);
+        self.state.pose_world_to_cam = tv.estimate.pose;
+        curr_frame.pose_world_to_cam = self.state.pose_world_to_cam;
 
-                TrackingResult {
-                    pose_world_to_cam: self.state.pose_world_to_cam,
-                    status: TrackingStatus::KeyframeAccepted,
-                }
-            }
+        let curr_idx = curr_frame.idx;
+        self.build_initial_map(
+            prev_bootstrap_frame,
+            curr_frame,
+            &tv.estimate.matches,
+            &tv.points3d,
+            &tv.inlier_indices,
+            tv.median_depth,
+        );
+        self.state.current_keyframe_idx = Some(curr_idx);
+        self.state.last_keyframe_idx = Some(curr_idx);
+        self.state.mode = SystemMode::Tracking;
+
+        TrackingResult {
+            pose_world_to_cam: self.state.pose_world_to_cam,
+            status: TrackingStatus::KeyframeAccepted,
         }
     }
 
@@ -194,7 +197,7 @@ impl Pipeline {
             self.state.pose_world_to_cam
         };
 
-        let estimate = self.estimator.estimate_pose(
+        let result = self.estimator.estimate_pose(
             &frame,
             &candidate_pose,
             &pose_before_tracking,
@@ -202,29 +205,21 @@ impl Pipeline {
             self.state.current_keyframe_idx,
         );
 
-        let (mut status, matches, tracked_inliers) = match estimate {
-            MapProjectionEstimateOutcome::Estimated {
-                pose_world_to_cam,
-                inliers,
-                matches,
-            } => {
+        let (mut status, matches, tracked_inliers) = match result {
+            Ok(estimate) => {
                 self.state.velocity =
-                    Some(Pose3d::between(&pose_before_tracking, &pose_world_to_cam));
-                self.state.pose_world_to_cam = pose_world_to_cam;
-                (TrackingStatus::Tracked, matches, inliers)
+                    Some(Pose3d::between(&pose_before_tracking, &estimate.pose));
+                self.state.pose_world_to_cam = estimate.pose;
+                (TrackingStatus::Tracked, estimate.matches, estimate.inliers)
             }
-            MapProjectionEstimateOutcome::Rejected { .. } => {
-                (TrackingStatus::Skipped, Vec::new(), 0)
-            }
+            Err(_) => (TrackingStatus::Skipped, Vec::new(), 0),
         };
 
         if status == TrackingStatus::Tracked {
-            self.estimator.update_map_point_observations(
-                &mut self.map,
-                &matches,
-                &candidate_pose,
-                image_size,
-            );
+            let visible =
+                self.estimator
+                    .visible_map_points(&self.map, &candidate_pose, image_size);
+            self.map.update_observation_counts(&visible, &matches);
 
             if self.try_insert_keyframe(&frame, tracked_inliers, &matches) {
                 status = TrackingStatus::KeyframeAccepted;
@@ -233,7 +228,7 @@ impl Pipeline {
 
         if status == TrackingStatus::Skipped {
             self.state.consecutive_failures += 1;
-            if self.state.consecutive_failures >= self.estimator.config().max_consecutive_failures {
+            if self.state.consecutive_failures >= self.state.max_consecutive_failures {
                 self.state.reset();
                 return self.bootstrap_step(frame);
             }
@@ -260,7 +255,7 @@ impl Pipeline {
             .map(|kf| kf.num_associated_points())
             .unwrap_or(0);
 
-        if !self.estimator.need_new_keyframe(
+        if !self.keyframe_policy.should_insert(
             frame.idx,
             self.state.last_keyframe_idx,
             tracked_inliers,
@@ -285,7 +280,7 @@ impl Pipeline {
             }
         }
 
-        let enable_local_ba = self.estimator.config().enable_local_ba;
+        let enable_local_ba = self.enable_local_ba;
         let pose_world_to_cam = self.state.pose_world_to_cam;
         let match_config = self.two_view_init_config.match_config;
         let estimation_config = self.two_view_init_config.estimation_config.clone();

--- a/src/estimation/map_projection.rs
+++ b/src/estimation/map_projection.rs
@@ -33,170 +33,24 @@ use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
 use crate::frame::Frame;
 use crate::map::{Map, MapPoint};
 
-// ── Public Types ───────────────────────────────────────────────────────────
+use super::Estimate;
 
-/// Keyframe insertion heuristics.
-#[derive(Debug, Clone)]
-pub struct KeyframePolicy {
-    /// Minimum frame gap before allowing keyframe insertion.
-    pub min_frames_between: usize,
-    /// Force a keyframe if this frame gap is reached.
-    pub max_frames_between: usize,
-    /// Relative inlier ratio threshold (vs reference keyframe tracked map points).
-    pub ref_ratio: f64,
-}
-
-impl Default for KeyframePolicy {
-    fn default() -> Self {
-        Self {
-            min_frames_between: 3,
-            max_frames_between: 8,
-            ref_ratio: 0.6,
-        }
-    }
-}
-
-/// Tunable parameters for projection-guided matching.
-#[derive(Debug, Clone, Copy)]
-pub struct ProjectionMatchConfig {
-    /// Reject projected points with depth `<= min_depth`.
-    pub min_depth: f64,
-    /// Keypoint search radius around each projected pixel.
-    pub search_radius: f32,
-    /// Maximum Hamming distance to accept a descriptor match.
-    pub max_hamming: u32,
-}
-
-impl Default for ProjectionMatchConfig {
-    fn default() -> Self {
-        Self {
-            min_depth: 0.0,
-            search_radius: 15.0,
-            max_hamming: 50,
-        }
-    }
-}
-
-/// PnP pose-estimation thresholds.
-#[derive(Debug, Clone)]
-pub struct PnpConfig {
-    /// Reprojection threshold (px) for filtering correspondences against the prior pose.
-    pub prior_reproj_threshold_px: f64,
-    /// Reprojection threshold (px) for counting final inliers after LM refinement.
-    pub final_reproj_threshold_px: f64,
-    /// Maximum acceptable rotation change in degrees between consecutive poses.
-    pub max_rot_deg: f64,
-    /// Maximum acceptable translation change (norm) between consecutive poses.
-    pub max_trans_norm: f64,
-    /// Minimum number of 3D-2D correspondences required for PnP solving.
-    pub min_correspondences: usize,
-}
-
-impl Default for PnpConfig {
-    fn default() -> Self {
-        Self {
-            prior_reproj_threshold_px: 25.0,
-            final_reproj_threshold_px: 3.0,
-            max_rot_deg: 20.0,
-            max_trans_norm: 0.50,
-            min_correspondences: 4,
-        }
-    }
-}
-
-/// Map-projection tracking thresholds.
-#[derive(Debug, Clone)]
-pub struct MapProjectionConfig {
-    /// ORB descriptor matcher settings for tracking against reference observations.
-    pub match_config: OrbMatchConfig,
-    /// Minimum pose inliers to accept a keyframe.
-    pub min_inliers: usize,
-    /// Minimum median parallax in degrees to accept a keyframe.
-    pub min_parallax_deg: f64,
-    /// Maximum consecutive tracking failures before resetting to bootstrap.
-    pub max_consecutive_failures: usize,
-    /// Enable local bundle adjustment after keyframe insertion.
-    pub enable_local_ba: bool,
-    /// Keyframe insertion policy.
-    pub keyframe_policy: KeyframePolicy,
-    /// PnP pose-estimation thresholds.
-    pub pnp: PnpConfig,
-    /// Projection matching config for initial tracking.
-    pub projection: ProjectionMatchConfig,
-    /// Projection matching config for local-map refinement (wider search).
-    pub local_projection: ProjectionMatchConfig,
-}
-
-impl Default for MapProjectionConfig {
-    fn default() -> Self {
-        Self {
-            match_config: OrbMatchConfig {
-                nn_ratio: 0.6,
-                th_low: 50,
-                check_orientation: true,
-                histo_length: 30,
-            },
-            min_inliers: 30,
-            min_parallax_deg: 1.0,
-            max_consecutive_failures: 15,
-            enable_local_ba: true,
-            keyframe_policy: KeyframePolicy::default(),
-            pnp: PnpConfig::default(),
-            projection: ProjectionMatchConfig::default(),
-            local_projection: ProjectionMatchConfig {
-                search_radius: 30.0,
-                max_hamming: 60,
-                ..ProjectionMatchConfig::default()
-            },
-        }
-    }
-}
-
-/// Rejection reasons specific to the map-projection tracker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MapProjectionRejectReason {
-    /// Too few projection-guided matches were available to run the first PnP stage.
-    LowProjectionMatches,
-    /// PnP solving failed for the provided correspondences.
-    PnpFailed,
-    /// The estimated pose changed too sharply relative to the candidate pose.
-    PnpInconsistentMotion,
-    /// PnP solved, but too few final inliers remained after validation.
-    LowPnpInliers,
-    /// Too few descriptor matches were found against the current reference keyframe.
-    LowReferenceMatches,
-    /// Too few valid 3D-2D correspondences could be built from reference matches.
-    LowReferenceCorrespondences,
-}
-
-/// Result of one map-projection pose-estimation attempt.
-#[derive(Debug, Clone)]
-pub enum MapProjectionEstimateOutcome {
-    /// Pose estimation was rejected.
-    Rejected {
-        /// Why the map-projection estimator rejected this frame.
-        reason: MapProjectionRejectReason,
-    },
-    /// Pose estimation succeeded.
-    Estimated {
-        /// Estimated world-to-camera pose for the current frame.
-        pose_world_to_cam: Pose3d,
-        /// Number of inlier correspondences supporting the estimate.
-        inliers: usize,
-        /// Map-point to keypoint matches `(map_point_idx, keypoint_idx)`.
-        matches: Vec<(usize, usize)>,
-    },
-}
 
 /// Result of matching map points against a frame.
-pub(crate) struct FrameMatchResult {
+struct FrameMatchResult {
     pub matches: Vec<(usize, usize)>,
     pub keypoints_undist: Vec<[f32; 2]>,
     pub grid: KeypointGrid,
 }
 
+/// Result of a PnP tracking attempt.
+enum TrackAttempt {
+    Success { pose: Pose3d, inliers: usize },
+    Rejected(MapProjectionRejectReason),
+}
+
 /// A 2D grid that bins keypoints by their image position for O(1) spatial queries.
-pub struct KeypointGrid {
+struct KeypointGrid {
     cells: Vec<Vec<usize>>,
     cell_w: f32,
     cell_h: f32,
@@ -206,28 +60,11 @@ pub struct KeypointGrid {
     img_h: f32,
 }
 
-/// Map-projection-based pose estimator.
-///
-/// Estimates the camera pose by projecting map points into the current frame,
-/// matching via ORB descriptors, and solving PnP.
-pub struct MapProjectionEstimator {
-    camera: PinholeCamera,
-    config: MapProjectionConfig,
-}
-
-/// Result of a PnP tracking attempt.
-enum TrackAttempt {
-    Success { pose: Pose3d, inliers: usize },
-    Rejected(MapProjectionRejectReason),
-}
-
-// ── Matching ───────────────────────────────────────────────────────────────
-
 impl KeypointGrid {
     /// Builds a grid over `keypoints_xy` (each `[x, y]`) for an image of size `img_w x img_h`.
     ///
     /// Each cell is `cell_size x cell_size` pixels. Points outside the image are clamped.
-    pub fn new(keypoints_xy: &[[f32; 2]], img_w: f32, img_h: f32, cell_size: f32) -> Self {
+    fn new(keypoints_xy: &[[f32; 2]], img_w: f32, img_h: f32, cell_size: f32) -> Self {
         let n_cols = (img_w / cell_size).ceil() as usize;
         let n_rows = (img_h / cell_size).ceil() as usize;
         let n_cells = n_cols * n_rows;
@@ -251,7 +88,7 @@ impl KeypointGrid {
     }
 
     /// Returns indices of keypoints within `radius` pixels of `(x, y)`.
-    pub fn query_radius(
+    fn query_radius(
         &self,
         x: f32,
         y: f32,
@@ -284,266 +121,107 @@ impl KeypointGrid {
     }
 }
 
-/// Matches map points to current-frame keypoints by projection and descriptor comparison.
-#[allow(clippy::too_many_arguments)]
-pub fn match_by_projection(
-    map_points: &[MapPoint],
-    keypoints_xy: &[[f32; 2]],
-    descriptors: &[[u8; 32]],
-    grid: &KeypointGrid,
-    pose_world_to_cam: &Pose3d,
-    camera: &PinholeCamera,
-    image_size: ImageSize,
-    config: ProjectionMatchConfig,
-) -> Vec<(usize, usize)> {
-    let mut matched_kp = vec![false; keypoints_xy.len()];
-    let mut matches = Vec::new();
-
-    for (mp_idx, mp) in map_points.iter().enumerate() {
-        if mp.culled {
-            continue;
-        }
-
-        let p_cam = pose_world_to_cam.transform_point(&mp.position);
-        let Ok(pixel) = camera.project_to_image(&p_cam, config.min_depth, image_size) else {
-            continue;
-        };
-        let u = pixel.x as f32;
-        let v = pixel.y as f32;
-
-        let candidates = grid.query_radius(u, v, config.search_radius, keypoints_xy);
-        let mut best_dist = u32::MAX;
-        let mut best_kp = usize::MAX;
-
-        for kp_idx in candidates {
-            if matched_kp[kp_idx] {
-                continue;
-            }
-            let dist = hamming_distance(&mp.descriptor, &descriptors[kp_idx]);
-            if dist < best_dist {
-                best_dist = dist;
-                best_kp = kp_idx;
-            }
-        }
-
-        if best_dist <= config.max_hamming && best_kp != usize::MAX {
-            matched_kp[best_kp] = true;
-            matches.push((mp_idx, best_kp));
-        }
-    }
-
-    matches
+/// Tunable parameters for projection-guided matching.
+#[derive(Debug, Clone, Copy)]
+pub struct ProjectionMatchConfig {
+    /// Reject projected points with depth `<= min_depth`.
+    pub min_depth: f64,
+    /// Keypoint search radius around each projected pixel.
+    pub search_radius: f32,
+    /// Maximum Hamming distance to accept a descriptor match.
+    pub max_hamming: u32,
 }
 
-/// Undistorts keypoints, builds a spatial grid, and runs projection matching
-/// with narrow-to-wide fallback.
-pub(crate) fn match_map_to_frame(
-    map_points: &[MapPoint],
-    frame: &Frame,
-    camera: &PinholeCamera,
-    pose: &Pose3d,
-    config: ProjectionMatchConfig,
-) -> FrameMatchResult {
-    const KEYPOINT_GRID_CELL_SIZE: f32 = 64.0;
-    const MIN_MATCHES_BEFORE_WIDE: usize = 20;
+impl Default for ProjectionMatchConfig {
+    fn default() -> Self {
+        Self {
+            min_depth: 0.0,
+            search_radius: 15.0,
+            max_hamming: 50,
+        }
+    }
+}
 
-    let keypoints_undist: Vec<[f32; 2]> = frame
-        .features
-        .keypoints_xy
-        .iter()
-        .map(|kp| {
-            let p = camera.undistort(kp[0] as f64, kp[1] as f64);
-            [p.x as f32, p.y as f32]
-        })
-        .collect();
+/// PnP pose-estimation thresholds.
+#[derive(Debug, Clone)]
+pub struct PnpConfig {
+    /// Reprojection threshold (px) for filtering correspondences against the prior pose.
+    pub prior_reproj_threshold_px: f64,
+    /// Reprojection threshold (px) for counting final inliers after LM refinement.
+    pub final_reproj_threshold_px: f64,
+    /// Minimum number of 3D-2D correspondences required for PnP solving.
+    pub min_correspondences: usize,
+    /// Minimum inliers to accept a PnP solution.
+    pub min_inliers: usize,
+}
 
-    let grid = KeypointGrid::new(
-        &keypoints_undist,
-        frame.image_size.width as f32,
-        frame.image_size.height as f32,
-        KEYPOINT_GRID_CELL_SIZE,
-    );
+impl Default for PnpConfig {
+    fn default() -> Self {
+        Self {
+            prior_reproj_threshold_px: 25.0,
+            final_reproj_threshold_px: 3.0,
+            min_correspondences: 4,
+            min_inliers: 30,
+        }
+    }
+}
 
-    let mut matches = match_by_projection(
-        map_points,
-        &keypoints_undist,
-        &frame.features.descriptors,
-        &grid,
-        pose,
-        camera,
-        frame.image_size,
-        config,
-    );
+/// Map-projection tracking thresholds.
+#[derive(Debug, Clone)]
+pub struct MapProjectionConfig {
+    /// ORB descriptor matcher settings for tracking against reference observations.
+    pub match_config: OrbMatchConfig,
+    /// PnP pose-estimation thresholds.
+    pub pnp: PnpConfig,
+    /// Projection matching config for initial tracking.
+    pub projection: ProjectionMatchConfig,
+    /// Projection matching config for local-map refinement (wider search).
+    pub local_projection: ProjectionMatchConfig,
+}
 
-    if matches.len() < MIN_MATCHES_BEFORE_WIDE {
-        matches = match_by_projection(
-            map_points,
-            &keypoints_undist,
-            &frame.features.descriptors,
-            &grid,
-            pose,
-            camera,
-            frame.image_size,
-            ProjectionMatchConfig {
-                search_radius: config.search_radius * 2.0,
-                ..config
+impl Default for MapProjectionConfig {
+    fn default() -> Self {
+        Self {
+            match_config: OrbMatchConfig {
+                nn_ratio: 0.6,
+                th_low: 50,
+                check_orientation: true,
+                histo_length: 30,
             },
-        );
-    }
-
-    FrameMatchResult {
-        matches,
-        keypoints_undist,
-        grid,
-    }
-}
-
-// ── PnP ───────────────────────────────────────────────────────────────────
-
-/// Count map-point reprojection inliers given a camera pose.
-pub fn count_reprojection_inliers(
-    pose_world_to_cam: &Pose3d,
-    points_world: &[Vec3F64],
-    points_image: &[Vec2F32],
-    camera: &PinholeCamera,
-    threshold_px: f64,
-) -> usize {
-    let th2 = threshold_px * threshold_px;
-    let mut inliers = 0usize;
-    for (pw, pi) in points_world.iter().zip(points_image.iter()) {
-        if camera
-            .reprojection_error_sq_world(pose_world_to_cam, pw, pi.x as f64, pi.y as f64)
-            .is_some_and(|err_sq| err_sq <= th2)
-        {
-            inliers += 1;
+            pnp: PnpConfig::default(),
+            projection: ProjectionMatchConfig::default(),
+            local_projection: ProjectionMatchConfig {
+                search_radius: 30.0,
+                max_hamming: 60,
+                ..ProjectionMatchConfig::default()
+            },
         }
     }
-    inliers
 }
 
-/// Check whether a pose increment is geometrically plausible.
-pub fn pose_increment_ok(prev_pose: &Pose3d, new_pose: &Pose3d, config: &PnpConfig) -> bool {
-    let r_delta = new_pose.rotation * prev_pose.rotation.transpose();
-    let trace = r_delta.col(0).x + r_delta.col(1).y + r_delta.col(2).z;
-    let cos_theta = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0);
-    let rot_deg = cos_theta.acos().to_degrees();
-    let trans_norm = (new_pose.translation - prev_pose.translation).length();
-
-    rot_deg <= config.max_rot_deg && trans_norm <= config.max_trans_norm
+/// Rejection reasons specific to the map-projection tracker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MapProjectionRejectReason {
+    /// Too few projection-guided matches were available to run the first PnP stage.
+    LowProjectionMatches,
+    /// PnP solving failed for the provided correspondences.
+    PnpFailed,
+    /// PnP solved, but too few final inliers remained after validation.
+    LowPnpInliers,
+    /// Too few descriptor matches were found against the current reference keyframe.
+    LowReferenceMatches,
+    /// Too few valid 3D-2D correspondences could be built from reference matches.
+    LowReferenceCorrespondences,
 }
 
-/// Solve PnP from map-point to keypoint correspondences using LM refinement.
-pub fn solve_pnp_from_correspondences(
-    map_points: &[MapPoint],
-    correspondences: &[(usize, usize)],
-    keypoints_undist: &[[f32; 2]],
-    pose_init: &Pose3d,
-    camera: &PinholeCamera,
-    config: &PnpConfig,
-) -> Option<(Pose3d, usize)> {
-    let mut points_world = Vec::with_capacity(correspondences.len());
-    let mut points_world_f64 = Vec::with_capacity(correspondences.len());
-    let mut points_image = Vec::with_capacity(correspondences.len());
-    for &(mp_idx, kp_idx) in correspondences {
-        if let (Some(mp), Some(&kp)) = (map_points.get(mp_idx), keypoints_undist.get(kp_idx)) {
-            points_world.push(Vec3AF32::new(
-                mp.position.x as f32,
-                mp.position.y as f32,
-                mp.position.z as f32,
-            ));
-            points_world_f64.push(mp.position);
-            points_image.push(Vec2F32::new(kp[0], kp[1]));
-        }
-    }
-    if points_world.len() < config.min_correspondences {
-        return None;
-    }
-
-    let prior_th2 = config.prior_reproj_threshold_px * config.prior_reproj_threshold_px;
-    let mut prior_inliers = Vec::new();
-    for (i, pw) in points_world_f64.iter().enumerate() {
-        if camera
-            .reprojection_error_sq_world(
-                pose_init,
-                pw,
-                points_image[i].x as f64,
-                points_image[i].y as f64,
-            )
-            .is_some_and(|err_sq| err_sq <= prior_th2)
-        {
-            prior_inliers.push(i);
-        }
-    }
-    if prior_inliers.len() < config.min_correspondences {
-        return None;
-    }
-
-    let k = Mat3AF32::from_cols(
-        Vec3AF32::new(camera.fx as f32, 0.0, 0.0),
-        Vec3AF32::new(0.0, camera.fy as f32, 0.0),
-        Vec3AF32::new(camera.cx as f32, camera.cy as f32, 1.0),
-    );
-    let mut world_inliers = Vec::with_capacity(prior_inliers.len());
-    let mut image_inliers = Vec::with_capacity(prior_inliers.len());
-    for &i in &prior_inliers {
-        world_inliers.push(points_world[i]);
-        image_inliers.push(points_image[i]);
-    }
-
-    let r_init_f32 = Mat3AF32::from_cols(
-        Vec3AF32::new(
-            pose_init.rotation.col(0).x as f32,
-            pose_init.rotation.col(0).y as f32,
-            pose_init.rotation.col(0).z as f32,
-        ),
-        Vec3AF32::new(
-            pose_init.rotation.col(1).x as f32,
-            pose_init.rotation.col(1).y as f32,
-            pose_init.rotation.col(1).z as f32,
-        ),
-        Vec3AF32::new(
-            pose_init.rotation.col(2).x as f32,
-            pose_init.rotation.col(2).y as f32,
-            pose_init.rotation.col(2).z as f32,
-        ),
-    );
-    let t_init_f32 = Vec3AF32::new(
-        pose_init.translation.x as f32,
-        pose_init.translation.y as f32,
-        pose_init.translation.z as f32,
-    );
-
-    let lm = refine_pose_lm(
-        &world_inliers,
-        &image_inliers,
-        &k,
-        &r_init_f32,
-        &t_init_f32,
-        None,
-        &LMRefineParams::default(),
-    )
-    .ok()?;
-
-    let r = &lm.rotation;
-    let t = lm.translation;
-    let r_new = Mat3F64::from_cols(
-        Vec3F64::new(r.col(0).x as f64, r.col(0).y as f64, r.col(0).z as f64),
-        Vec3F64::new(r.col(1).x as f64, r.col(1).y as f64, r.col(1).z as f64),
-        Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
-    );
-    let t_new = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
-    let pose_new = Pose3d::new(r_new, t_new);
-    let final_inliers = count_reprojection_inliers(
-        &pose_new,
-        &points_world_f64,
-        &points_image,
-        camera,
-        config.final_reproj_threshold_px,
-    );
-    Some((pose_new, final_inliers))
+/// Map-projection-based pose estimator.
+///
+/// Estimates the camera pose by projecting map points into the current frame,
+/// matching via ORB descriptors, and solving PnP.
+pub struct MapProjectionEstimator {
+    camera: PinholeCamera,
+    config: MapProjectionConfig,
 }
-
-// ── Estimator ──────────────────────────────────────────────────────────────
 
 impl MapProjectionEstimator {
     pub fn new(camera: PinholeCamera, config: MapProjectionConfig) -> Self {
@@ -566,75 +244,62 @@ impl MapProjectionEstimator {
         pose_before_tracking: &Pose3d,
         map: &Map,
         current_keyframe_idx: Option<usize>,
-    ) -> MapProjectionEstimateOutcome {
+    ) -> Result<Estimate, MapProjectionRejectReason> {
         const MIN_PNP_CORRESPONDENCES: usize = 4;
         const MIN_STAGE1_INLIERS: usize = 10;
 
-        let frame_match = match_map_to_frame(
-            map.map_points(),
-            frame,
-            &self.camera,
-            candidate_pose,
-            self.config.projection,
-        );
+        let frame_match = self.match_map_to_frame(map.map_points(), frame, candidate_pose);
         let curr_keypoints_undist = &frame_match.keypoints_undist;
         let grid = &frame_match.grid;
         let projection_matches = frame_match.matches;
 
-        // Shared logic: try_track → refine_pose → Estimated, or propagate rejection.
-        let try_track_and_refine =
-            |correspondences: Vec<(usize, usize)>,
-             pose_init: &Pose3d|
-             -> Result<MapProjectionEstimateOutcome, MapProjectionRejectReason> {
-                match try_track(
-                    map.map_points(),
-                    &self.camera,
-                    &self.config.pnp,
-                    &correspondences,
-                    curr_keypoints_undist,
-                    pose_init,
-                    candidate_pose,
-                    MIN_STAGE1_INLIERS,
-                ) {
-                    TrackAttempt::Success { pose, inliers } => {
-                        let (pose_world_to_cam, inliers, matches) = self.refine_pose(
-                            curr_keypoints_undist,
-                            &frame.features.descriptors,
-                            grid,
-                            frame.image_size,
-                            candidate_pose,
-                            pose,
-                            inliers,
-                            correspondences,
-                            map,
-                            current_keyframe_idx,
-                        );
-                        Ok(MapProjectionEstimateOutcome::Estimated {
-                            pose_world_to_cam,
-                            inliers,
-                            matches,
-                        })
-                    }
-                    TrackAttempt::Rejected(reason) => Err(reason),
+        // Shared logic: try_track → refine_pose → Estimate, or propagate rejection.
+        let try_track_and_refine = |correspondences: Vec<(usize, usize)>,
+                                    pose_init: &Pose3d|
+         -> Result<Estimate, MapProjectionRejectReason> {
+            match self.try_track(
+                map.map_points(),
+                &correspondences,
+                curr_keypoints_undist,
+                pose_init,
+                MIN_STAGE1_INLIERS,
+            ) {
+                TrackAttempt::Success { pose, inliers } => {
+                    let (pose, inliers, matches) = self.refine_pose(
+                        curr_keypoints_undist,
+                        &frame.features.descriptors,
+                        grid,
+                        frame.image_size,
+                        pose,
+                        inliers,
+                        correspondences,
+                        map,
+                        current_keyframe_idx,
+                    );
+                    Ok(Estimate {
+                        pose,
+                        inliers,
+                        matches,
+                    })
                 }
-            };
+                TrackAttempt::Rejected(reason) => Err(reason),
+            }
+        };
 
-        // Stage 2: PnP from projection matches.
+        // PnP from projection matches.
         let last_reject = if projection_matches.len() >= MIN_PNP_CORRESPONDENCES {
             match try_track_and_refine(projection_matches, candidate_pose) {
-                Ok(outcome) => return outcome,
+                Ok(estimate) => return Ok(estimate),
                 Err(reason) => reason,
             }
         } else {
             MapProjectionRejectReason::LowProjectionMatches
         };
 
-        // Stage 3: fallback — match against reference keyframe descriptors.
+        // Fallback: match against reference keyframe descriptors.
         let current_kf = current_keyframe_idx.and_then(|ki| map.get_keyframe(ki));
         let Some(current_kf) = current_kf else {
-            return MapProjectionEstimateOutcome::Rejected {
-                reason: last_reject,
-            };
+            return Err(last_reject);
         };
 
         let ref_matches = match_orb_descriptors(
@@ -647,9 +312,7 @@ impl MapProjectionEstimator {
 
         const MIN_REF_MATCHES: usize = 15;
         if ref_matches.len() < MIN_REF_MATCHES {
-            return MapProjectionEstimateOutcome::Rejected {
-                reason: MapProjectionRejectReason::LowReferenceMatches,
-            };
+            return Err(MapProjectionRejectReason::LowReferenceMatches);
         }
 
         let mut ref_correspondences = Vec::with_capacity(ref_matches.len());
@@ -662,28 +325,21 @@ impl MapProjectionEstimator {
         }
 
         if ref_correspondences.len() < MIN_PNP_CORRESPONDENCES {
-            return MapProjectionEstimateOutcome::Rejected {
-                reason: MapProjectionRejectReason::LowReferenceCorrespondences,
-            };
+            return Err(MapProjectionRejectReason::LowReferenceCorrespondences);
         }
 
-        match try_track_and_refine(ref_correspondences, pose_before_tracking) {
-            Ok(outcome) => outcome,
-            Err(reason) => MapProjectionEstimateOutcome::Rejected { reason },
-        }
+        try_track_and_refine(ref_correspondences, pose_before_tracking)
     }
 
-    /// Update `n_visible` and `n_found` for map points based on the current frame.
-    pub fn update_map_point_observations(
+    /// Returns indices of map points visible in the current camera frustum.
+    pub fn visible_map_points(
         &self,
-        map: &mut Map,
-        matched: &[(usize, usize)],
+        map: &Map,
         pose_world_to_cam: &Pose3d,
         image_size: ImageSize,
-    ) {
-        let matched_set: HashSet<usize> = matched.iter().map(|&(mp_idx, _)| mp_idx).collect();
-
-        for (mp_idx, mp) in map.map_points_mut().iter_mut().enumerate() {
+    ) -> HashSet<usize> {
+        let mut visible = HashSet::new();
+        for (mp_idx, mp) in map.map_points().iter().enumerate() {
             if mp.culled {
                 continue;
             }
@@ -691,44 +347,12 @@ impl MapProjectionEstimator {
             if self
                 .camera
                 .project_to_image(&p_cam, 0.0, image_size)
-                .is_err()
+                .is_ok()
             {
-                continue;
-            }
-            mp.n_visible = mp.n_visible.saturating_add(1);
-            if matched_set.contains(&mp_idx) {
-                mp.n_found = mp.n_found.saturating_add(1);
+                visible.insert(mp_idx);
             }
         }
-    }
-
-    /// Decide whether a new keyframe should be inserted.
-    pub fn need_new_keyframe(
-        &self,
-        curr_idx: usize,
-        last_keyframe_idx: Option<usize>,
-        tracked_inliers: usize,
-        n_ref_map_points: usize,
-    ) -> bool {
-        let Some(last_kf_idx) = last_keyframe_idx else {
-            return true;
-        };
-
-        let frames_since_last_kf = curr_idx.saturating_sub(last_kf_idx);
-        if frames_since_last_kf < self.config.keyframe_policy.min_frames_between {
-            return false;
-        }
-        if frames_since_last_kf >= self.config.keyframe_policy.max_frames_between {
-            return true;
-        }
-
-        if n_ref_map_points == 0 {
-            return true;
-        }
-
-        let weak_threshold =
-            (n_ref_map_points as f64 * self.config.keyframe_policy.ref_ratio) as usize;
-        tracked_inliers >= 15 && tracked_inliers < weak_threshold
+        visible
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -738,19 +362,15 @@ impl MapProjectionEstimator {
         curr_descriptors: &[[u8; 32]],
         grid: &KeypointGrid,
         image_size: ImageSize,
-        candidate_pose: &Pose3d,
         mut pose: Pose3d,
         mut inliers: usize,
         mut matches: Vec<(usize, usize)>,
         map: &Map,
         current_keyframe_idx: Option<usize>,
     ) -> (Pose3d, usize, Vec<(usize, usize)>) {
-        if let Some((local_matches, local_pose, local_inliers)) = refine_with_local_map(
+        if let Some(local) = self.refine_with_local_map(
             map,
             current_keyframe_idx,
-            &self.camera,
-            &self.config.pnp,
-            self.config.local_projection,
             &matches,
             curr_keypoints_undist,
             curr_descriptors,
@@ -758,157 +378,360 @@ impl MapProjectionEstimator {
             image_size,
             &pose,
         ) {
-            matches = local_matches;
-            if local_inliers >= self.config.min_inliers
-                && pose_increment_ok(candidate_pose, &local_pose, &self.config.pnp)
-            {
-                pose = local_pose;
-                inliers = local_inliers;
+            matches = local.matches;
+            if local.inliers >= self.config.pnp.min_inliers {
+                pose = local.pose;
+                inliers = local.inliers;
             }
         }
 
         (pose, inliers, matches)
     }
-}
 
-// ── Private Helpers ───────────────────────────────────────────────────────
-
-#[allow(clippy::too_many_arguments)]
-fn try_track(
-    map_points: &[MapPoint],
-    camera: &PinholeCamera,
-    pnp_config: &PnpConfig,
-    correspondences: &[(usize, usize)],
-    keypoints_undist: &[[f32; 2]],
-    pose_init: &Pose3d,
-    cand_pose: &Pose3d,
-    min_inliers: usize,
-) -> TrackAttempt {
-    match solve_pnp_from_correspondences(
-        map_points,
-        correspondences,
-        keypoints_undist,
-        pose_init,
-        camera,
-        pnp_config,
-    ) {
-        Some((new_pose, inliers)) => {
-            if inliers >= min_inliers {
-                if pose_increment_ok(cand_pose, &new_pose, pnp_config) {
+    fn try_track(
+        &self,
+        map_points: &[MapPoint],
+        correspondences: &[(usize, usize)],
+        keypoints_undist: &[[f32; 2]],
+        pose_init: &Pose3d,
+        min_inliers: usize,
+    ) -> TrackAttempt {
+        match self.solve_pnp(map_points, correspondences, keypoints_undist, pose_init) {
+            Some((new_pose, inliers)) => {
+                if inliers >= min_inliers {
                     TrackAttempt::Success {
                         pose: new_pose,
                         inliers,
                     }
                 } else {
-                    TrackAttempt::Rejected(MapProjectionRejectReason::PnpInconsistentMotion)
+                    TrackAttempt::Rejected(MapProjectionRejectReason::LowPnpInliers)
                 }
-            } else {
-                TrackAttempt::Rejected(MapProjectionRejectReason::LowPnpInliers)
+            }
+            None => TrackAttempt::Rejected(MapProjectionRejectReason::PnpFailed),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn refine_with_local_map(
+        &self,
+        map: &Map,
+        current_kf_idx: Option<usize>,
+        tracked_matches: &[(usize, usize)],
+        curr_keypoints_undist: &[[f32; 2]],
+        curr_descriptors: &[[u8; 32]],
+        grid: &KeypointGrid,
+        image_size: ImageSize,
+        pose_init: &Pose3d,
+    ) -> Option<Estimate> {
+        let current_kf = current_kf_idx.and_then(|ki| map.get_keyframe(ki));
+        let (local_map_points, local_to_global) =
+            map.build_local_map_points(tracked_matches, current_kf);
+        if local_map_points.len() < 4 {
+            return None;
+        }
+
+        let local_matches = self.match_by_projection(
+            &local_map_points,
+            curr_keypoints_undist,
+            curr_descriptors,
+            grid,
+            pose_init,
+            image_size,
+            self.config.local_projection,
+        );
+        if local_matches.len() < 4 {
+            return None;
+        }
+
+        let global_matches: Vec<(usize, usize)> = local_matches
+            .into_iter()
+            .filter_map(|(local_mp_idx, curr_idx)| {
+                local_to_global
+                    .get(local_mp_idx)
+                    .copied()
+                    .map(|global_mp_idx| (global_mp_idx, curr_idx))
+            })
+            .collect();
+        if global_matches.len() < 4 {
+            return None;
+        }
+
+        let (new_pose, inliers) = self.solve_pnp(
+            map.map_points(),
+            &global_matches,
+            curr_keypoints_undist,
+            pose_init,
+        )?;
+        Some(Estimate {
+            pose: new_pose,
+            inliers,
+            matches: global_matches,
+        })
+    }
+
+    /// Solve PnP from map-point to keypoint correspondences using LM refinement.
+    fn solve_pnp(
+        &self,
+        map_points: &[MapPoint],
+        correspondences: &[(usize, usize)],
+        keypoints_undist: &[[f32; 2]],
+        pose_init: &Pose3d,
+    ) -> Option<(Pose3d, usize)> {
+        let config = &self.config.pnp;
+        let camera = &self.camera;
+
+        let mut points_world = Vec::with_capacity(correspondences.len());
+        let mut points_world_f64 = Vec::with_capacity(correspondences.len());
+        let mut points_image = Vec::with_capacity(correspondences.len());
+        for &(mp_idx, kp_idx) in correspondences {
+            if let (Some(mp), Some(&kp)) = (map_points.get(mp_idx), keypoints_undist.get(kp_idx)) {
+                points_world.push(Vec3AF32::new(
+                    mp.position.x as f32,
+                    mp.position.y as f32,
+                    mp.position.z as f32,
+                ));
+                points_world_f64.push(mp.position);
+                points_image.push(Vec2F32::new(kp[0], kp[1]));
             }
         }
-        None => TrackAttempt::Rejected(MapProjectionRejectReason::PnpFailed),
+        if points_world.len() < config.min_correspondences {
+            return None;
+        }
+
+        let prior_th2 = config.prior_reproj_threshold_px * config.prior_reproj_threshold_px;
+        let mut prior_inliers = Vec::new();
+        for (i, pw) in points_world_f64.iter().enumerate() {
+            if camera
+                .reprojection_error_sq_world(
+                    pose_init,
+                    pw,
+                    points_image[i].x as f64,
+                    points_image[i].y as f64,
+                )
+                .is_some_and(|err_sq| err_sq <= prior_th2)
+            {
+                prior_inliers.push(i);
+            }
+        }
+        if prior_inliers.len() < config.min_correspondences {
+            return None;
+        }
+
+        let k = Mat3AF32::from_cols(
+            Vec3AF32::new(camera.fx as f32, 0.0, 0.0),
+            Vec3AF32::new(0.0, camera.fy as f32, 0.0),
+            Vec3AF32::new(camera.cx as f32, camera.cy as f32, 1.0),
+        );
+        let mut world_inliers = Vec::with_capacity(prior_inliers.len());
+        let mut image_inliers = Vec::with_capacity(prior_inliers.len());
+        for &i in &prior_inliers {
+            world_inliers.push(points_world[i]);
+            image_inliers.push(points_image[i]);
+        }
+
+        let r_init_f32 = Mat3AF32::from_cols(
+            Vec3AF32::new(
+                pose_init.rotation.col(0).x as f32,
+                pose_init.rotation.col(0).y as f32,
+                pose_init.rotation.col(0).z as f32,
+            ),
+            Vec3AF32::new(
+                pose_init.rotation.col(1).x as f32,
+                pose_init.rotation.col(1).y as f32,
+                pose_init.rotation.col(1).z as f32,
+            ),
+            Vec3AF32::new(
+                pose_init.rotation.col(2).x as f32,
+                pose_init.rotation.col(2).y as f32,
+                pose_init.rotation.col(2).z as f32,
+            ),
+        );
+        let t_init_f32 = Vec3AF32::new(
+            pose_init.translation.x as f32,
+            pose_init.translation.y as f32,
+            pose_init.translation.z as f32,
+        );
+
+        let lm = refine_pose_lm(
+            &world_inliers,
+            &image_inliers,
+            &k,
+            &r_init_f32,
+            &t_init_f32,
+            None,
+            &LMRefineParams::default(),
+        )
+        .ok()?;
+
+        let r = &lm.rotation;
+        let t = lm.translation;
+        let r_new = Mat3F64::from_cols(
+            Vec3F64::new(r.col(0).x as f64, r.col(0).y as f64, r.col(0).z as f64),
+            Vec3F64::new(r.col(1).x as f64, r.col(1).y as f64, r.col(1).z as f64),
+            Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
+        );
+        let t_new = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
+        let pose_new = Pose3d::new(r_new, t_new);
+        let final_inliers = self.count_reprojection_inliers(
+            &pose_new,
+            &points_world_f64,
+            &points_image,
+            config.final_reproj_threshold_px,
+        );
+        Some((pose_new, final_inliers))
     }
-}
 
-type LocalMapRefineOutcome = (Vec<(usize, usize)>, Pose3d, usize);
+    /// Undistorts keypoints, builds a spatial grid, and runs projection matching
+    /// with narrow-to-wide fallback.
+    fn match_map_to_frame(
+        &self,
+        map_points: &[MapPoint],
+        frame: &Frame,
+        pose: &Pose3d,
+    ) -> FrameMatchResult {
+        const KEYPOINT_GRID_CELL_SIZE: f32 = 64.0;
+        const MIN_MATCHES_BEFORE_WIDE: usize = 20;
 
-#[allow(clippy::too_many_arguments)]
-fn refine_with_local_map(
-    map: &Map,
-    current_kf_idx: Option<usize>,
-    camera: &PinholeCamera,
-    pnp_config: &PnpConfig,
-    local_projection: ProjectionMatchConfig,
-    tracked_matches: &[(usize, usize)],
-    curr_keypoints_undist: &[[f32; 2]],
-    curr_descriptors: &[[u8; 32]],
-    grid: &KeypointGrid,
-    image_size: ImageSize,
-    pose_init: &Pose3d,
-) -> Option<LocalMapRefineOutcome> {
-    let current_kf = current_kf_idx.and_then(|ki| map.get_keyframe(ki));
-    let (local_map_points, local_to_global) =
-        map.build_local_map_points(tracked_matches, current_kf);
-    if local_map_points.len() < 4 {
-        return None;
+        let keypoints_undist: Vec<[f32; 2]> = frame
+            .features
+            .keypoints_xy
+            .iter()
+            .map(|kp| {
+                let p = self.camera.undistort(kp[0] as f64, kp[1] as f64);
+                [p.x as f32, p.y as f32]
+            })
+            .collect();
+
+        let grid = KeypointGrid::new(
+            &keypoints_undist,
+            frame.image_size.width as f32,
+            frame.image_size.height as f32,
+            KEYPOINT_GRID_CELL_SIZE,
+        );
+
+        let config = self.config.projection;
+        let mut matches = self.match_by_projection(
+            map_points,
+            &keypoints_undist,
+            &frame.features.descriptors,
+            &grid,
+            pose,
+            frame.image_size,
+            config,
+        );
+
+        if matches.len() < MIN_MATCHES_BEFORE_WIDE {
+            matches = self.match_by_projection(
+                map_points,
+                &keypoints_undist,
+                &frame.features.descriptors,
+                &grid,
+                pose,
+                frame.image_size,
+                ProjectionMatchConfig {
+                    search_radius: config.search_radius * 2.0,
+                    ..config
+                },
+            );
+        }
+
+        FrameMatchResult {
+            matches,
+            keypoints_undist,
+            grid,
+        }
     }
 
-    let local_matches = match_by_projection(
-        &local_map_points,
-        curr_keypoints_undist,
-        curr_descriptors,
-        grid,
-        pose_init,
-        camera,
-        image_size,
-        local_projection,
-    );
-    if local_matches.len() < 4 {
-        return None;
+    #[allow(clippy::too_many_arguments)]
+    fn match_by_projection(
+        &self,
+        map_points: &[MapPoint],
+        keypoints_xy: &[[f32; 2]],
+        descriptors: &[[u8; 32]],
+        grid: &KeypointGrid,
+        pose_world_to_cam: &Pose3d,
+        image_size: ImageSize,
+        config: ProjectionMatchConfig,
+    ) -> Vec<(usize, usize)> {
+        let mut matched_kp = vec![false; keypoints_xy.len()];
+        let mut matches = Vec::new();
+
+        for (mp_idx, mp) in map_points.iter().enumerate() {
+            if mp.culled {
+                continue;
+            }
+
+            let p_cam = pose_world_to_cam.transform_point(&mp.position);
+            let Ok(pixel) = self.camera.project_to_image(&p_cam, config.min_depth, image_size)
+            else {
+                continue;
+            };
+            let u = pixel.x as f32;
+            let v = pixel.y as f32;
+
+            let candidates = grid.query_radius(u, v, config.search_radius, keypoints_xy);
+            let mut best_dist = u32::MAX;
+            let mut best_kp = usize::MAX;
+
+            for kp_idx in candidates {
+                if matched_kp[kp_idx] {
+                    continue;
+                }
+                let dist = hamming_distance(&mp.descriptor, &descriptors[kp_idx]);
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_kp = kp_idx;
+                }
+            }
+
+            if best_dist <= config.max_hamming && best_kp != usize::MAX {
+                matched_kp[best_kp] = true;
+                matches.push((mp_idx, best_kp));
+            }
+        }
+
+        matches
     }
 
-    let global_matches: Vec<(usize, usize)> = local_matches
-        .into_iter()
-        .filter_map(|(local_mp_idx, curr_idx)| {
-            local_to_global
-                .get(local_mp_idx)
-                .copied()
-                .map(|global_mp_idx| (global_mp_idx, curr_idx))
-        })
-        .collect();
-    if global_matches.len() < 4 {
-        return None;
+    /// Count map-point reprojection inliers given a camera pose.
+    fn count_reprojection_inliers(
+        &self,
+        pose_world_to_cam: &Pose3d,
+        points_world: &[Vec3F64],
+        points_image: &[Vec2F32],
+        threshold_px: f64,
+    ) -> usize {
+        let th2 = threshold_px * threshold_px;
+        let mut inliers = 0usize;
+        for (pw, pi) in points_world.iter().zip(points_image.iter()) {
+            if self
+                .camera
+                .reprojection_error_sq_world(pose_world_to_cam, pw, pi.x as f64, pi.y as f64)
+                .is_some_and(|err_sq| err_sq <= th2)
+            {
+                inliers += 1;
+            }
+        }
+        inliers
     }
-
-    let (new_pose, inliers) = solve_pnp_from_correspondences(
-        map.map_points(),
-        &global_matches,
-        curr_keypoints_undist,
-        pose_init,
-        camera,
-        pnp_config,
-    )?;
-    Some((global_matches, new_pose, inliers))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod estimator_tests {
-    use super::*;
+    use crate::system::KeyframePolicy;
 
     #[test]
     fn test_need_new_keyframe_forced_by_gap() {
-        let camera = PinholeCamera {
-            fx: 500.0,
-            fy: 500.0,
-            cx: 320.0,
-            cy: 240.0,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
-        };
-        let config = MapProjectionConfig::default();
-        let tracker = MapProjectionEstimator::new(camera, config);
-        assert!(tracker.need_new_keyframe(100, Some(90), 50, 100));
+        let policy = KeyframePolicy::default();
+        assert!(policy.should_insert(100, Some(90), 50, 100));
     }
 
     #[test]
     fn test_need_new_keyframe_too_soon() {
-        let camera = PinholeCamera {
-            fx: 500.0,
-            fy: 500.0,
-            cx: 320.0,
-            cy: 240.0,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
-        };
-        let config = MapProjectionConfig::default();
-        let tracker = MapProjectionEstimator::new(camera, config);
-        assert!(!tracker.need_new_keyframe(2, Some(1), 50, 100));
+        let policy = KeyframePolicy::default();
+        assert!(!policy.should_insert(2, Some(1), 50, 100));
     }
 }
 
@@ -967,9 +790,12 @@ mod matching_tests {
         assert_eq!(result, vec![0, 1, 2]);
     }
 
-    #[test]
-    fn test_match_by_projection_simple() {
-        let camera = PinholeCamera {
+    fn make_test_estimator(camera: PinholeCamera) -> MapProjectionEstimator {
+        MapProjectionEstimator::new(camera, MapProjectionConfig::default())
+    }
+
+    fn test_camera() -> PinholeCamera {
+        PinholeCamera {
             fx: 200.0,
             fy: 200.0,
             cx: 320.0,
@@ -978,7 +804,12 @@ mod matching_tests {
             k2: 0.0,
             p1: 0.0,
             p2: 0.0,
-        };
+        }
+    }
+
+    #[test]
+    fn test_match_by_projection_simple() {
+        let estimator = make_test_estimator(test_camera());
 
         let desc_a = [0u8; 32];
         let map_points = vec![MapPoint {
@@ -996,13 +827,12 @@ mod matching_tests {
         let grid = KeypointGrid::new(&keypoints_xy, 640.0, 480.0, 64.0);
         let pose = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO);
 
-        let matches = match_by_projection(
+        let matches = estimator.match_by_projection(
             &map_points,
             &keypoints_xy,
             &descriptors,
             &grid,
             &pose,
-            &camera,
             ImageSize {
                 width: 640,
                 height: 480,
@@ -1020,16 +850,7 @@ mod matching_tests {
 
     #[test]
     fn test_behind_camera_rejected() {
-        let camera = PinholeCamera {
-            fx: 200.0,
-            fy: 200.0,
-            cx: 320.0,
-            cy: 240.0,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
-        };
+        let estimator = make_test_estimator(test_camera());
 
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, -5.0),
@@ -1044,13 +865,12 @@ mod matching_tests {
         let descriptors = vec![[0u8; 32]];
         let grid = KeypointGrid::new(&keypoints_xy, 640.0, 480.0, 64.0);
 
-        let matches = match_by_projection(
+        let matches = estimator.match_by_projection(
             &map_points,
             &keypoints_xy,
             &descriptors,
             &grid,
             &Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO),
-            &camera,
             ImageSize {
                 width: 640,
                 height: 480,
@@ -1067,16 +887,7 @@ mod matching_tests {
 
     #[test]
     fn test_high_hamming_rejected() {
-        let camera = PinholeCamera {
-            fx: 200.0,
-            fy: 200.0,
-            cx: 320.0,
-            cy: 240.0,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
-        };
+        let estimator = make_test_estimator(test_camera());
 
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, 5.0),
@@ -1091,13 +902,12 @@ mod matching_tests {
         let descriptors = vec![[0xFF; 32]];
         let grid = KeypointGrid::new(&keypoints_xy, 640.0, 480.0, 64.0);
 
-        let matches = match_by_projection(
+        let matches = estimator.match_by_projection(
             &map_points,
             &keypoints_xy,
             &descriptors,
             &grid,
             &Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO),
-            &camera,
             ImageSize {
                 width: 640,
                 height: 480,

--- a/src/estimation/map_projection/keypoint_grid.rs
+++ b/src/estimation/map_projection/keypoint_grid.rs
@@ -1,0 +1,129 @@
+//! Spatial grid for fast keypoint radius queries.
+
+/// A 2D grid that bins keypoints by their image position for O(1) spatial queries.
+pub(super) struct KeypointGrid {
+    cells: Vec<Vec<usize>>,
+    cell_w: f32,
+    cell_h: f32,
+    n_cols: usize,
+    n_rows: usize,
+    img_w: f32,
+    img_h: f32,
+}
+
+impl KeypointGrid {
+    /// Builds a grid over `keypoints_xy` (each `[x, y]`) for an image of size `img_w x img_h`.
+    ///
+    /// Each cell is `cell_size x cell_size` pixels. Points outside the image are clamped.
+    pub(super) fn new(keypoints_xy: &[[f32; 2]], img_w: f32, img_h: f32, cell_size: f32) -> Self {
+        let n_cols = (img_w / cell_size).ceil() as usize;
+        let n_rows = (img_h / cell_size).ceil() as usize;
+        let n_cells = n_cols * n_rows;
+        let mut cells = vec![Vec::new(); n_cells];
+
+        for (i, kp) in keypoints_xy.iter().enumerate() {
+            let col = ((kp[0] / cell_size) as usize).min(n_cols - 1);
+            let row = ((kp[1] / cell_size) as usize).min(n_rows - 1);
+            cells[row * n_cols + col].push(i);
+        }
+
+        Self {
+            cells,
+            cell_w: cell_size,
+            cell_h: cell_size,
+            n_cols,
+            n_rows,
+            img_w,
+            img_h,
+        }
+    }
+
+    /// Returns indices of keypoints within `radius` pixels of `(x, y)`.
+    pub(super) fn query_radius(
+        &self,
+        x: f32,
+        y: f32,
+        radius: f32,
+        keypoints_xy: &[[f32; 2]],
+    ) -> Vec<usize> {
+        let r_sq = radius * radius;
+
+        let col_min = ((x - radius).max(0.0) / self.cell_w) as usize;
+        let col_max =
+            (((x + radius).min(self.img_w - 1.0) / self.cell_w) as usize).min(self.n_cols - 1);
+        let row_min = ((y - radius).max(0.0) / self.cell_h) as usize;
+        let row_max =
+            (((y + radius).min(self.img_h - 1.0) / self.cell_h) as usize).min(self.n_rows - 1);
+
+        let mut result = Vec::new();
+        for r in row_min..=row_max {
+            for c in col_min..=col_max {
+                for &idx in &self.cells[r * self.n_cols + c] {
+                    let kp = keypoints_xy[idx];
+                    let dx = kp[0] - x;
+                    let dy = kp[1] - y;
+                    if dx * dx + dy * dy <= r_sq {
+                        result.push(idx);
+                    }
+                }
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_grid() {
+        let grid = KeypointGrid::new(&[], 640.0, 480.0, 64.0);
+        let result = grid.query_radius(320.0, 240.0, 50.0, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_single_point_found() {
+        let kps = [[100.0, 100.0]];
+        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
+
+        let result = grid.query_radius(100.0, 100.0, 10.0, &kps);
+        assert_eq!(result, vec![0]);
+
+        let result = grid.query_radius(500.0, 400.0, 10.0, &kps);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_radius_boundary() {
+        let kps = [[50.0, 50.0], [60.0, 50.0], [100.0, 50.0]];
+        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 32.0);
+
+        let mut result = grid.query_radius(55.0, 50.0, 15.0, &kps);
+        result.sort();
+        assert_eq!(result, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_corner_clamping() {
+        let kps = [[0.0, 0.0], [639.0, 479.0]];
+        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
+
+        let result = grid.query_radius(0.0, 0.0, 5.0, &kps);
+        assert_eq!(result, vec![0]);
+
+        let result = grid.query_radius(639.0, 479.0, 5.0, &kps);
+        assert_eq!(result, vec![1]);
+    }
+
+    #[test]
+    fn test_multiple_points_per_cell() {
+        let kps = [[10.0, 10.0], [12.0, 11.0], [15.0, 13.0]];
+        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
+
+        let mut result = grid.query_radius(12.0, 12.0, 20.0, &kps);
+        result.sort();
+        assert_eq!(result, vec![0, 1, 2]);
+    }
+}

--- a/src/estimation/map_projection/mod.rs
+++ b/src/estimation/map_projection/mod.rs
@@ -241,7 +241,8 @@ impl MapProjectionEstimator {
         let current_kf = current_kf_idx.and_then(|ki| map.get_keyframe(ki));
         let (local_map_points, local_to_global) =
             map.build_local_map_points(tracked_matches, current_kf);
-        if local_map_points.len() < 4 {
+        let min_corr = self.config.pnp.min_correspondences;
+        if local_map_points.len() < min_corr {
             return None;
         }
 
@@ -254,7 +255,7 @@ impl MapProjectionEstimator {
             image_size,
             self.config.local_projection,
         );
-        if local_matches.len() < 4 {
+        if local_matches.len() < min_corr {
             return None;
         }
 
@@ -267,7 +268,7 @@ impl MapProjectionEstimator {
                     .map(|global_mp_idx| (global_mp_idx, curr_idx))
             })
             .collect();
-        if global_matches.len() < 4 {
+        if global_matches.len() < min_corr {
             return None;
         }
 

--- a/src/estimation/map_projection/mod.rs
+++ b/src/estimation/map_projection/mod.rs
@@ -20,106 +20,22 @@
 //! Estimated { pose, inliers, matches }
 //! ```
 
-use std::collections::HashSet;
+mod keypoint_grid;
 
 use kornia_3d::camera::PinholeCamera;
-use kornia_3d::pnp::{LMRefineParams, refine_pose_lm};
 use kornia_3d::pose::Pose3d;
-use kornia_algebra::{Mat3AF32, Mat3F64, Vec2F32, Vec3AF32, Vec3F64};
+use kornia_algebra::Vec2F32;
 use kornia_image::ImageSize;
 use kornia_imgproc::features::hamming_distance;
+
+use super::pnp::{self, PnpConfig};
 use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
 
 use crate::frame::Frame;
 use crate::map::{Map, MapPoint};
 
 use super::Estimate;
-
-
-/// Result of matching map points against a frame.
-struct FrameMatchResult {
-    pub matches: Vec<(usize, usize)>,
-    pub keypoints_undist: Vec<[f32; 2]>,
-    pub grid: KeypointGrid,
-}
-
-/// Result of a PnP tracking attempt.
-enum TrackAttempt {
-    Success { pose: Pose3d, inliers: usize },
-    Rejected(MapProjectionRejectReason),
-}
-
-/// A 2D grid that bins keypoints by their image position for O(1) spatial queries.
-struct KeypointGrid {
-    cells: Vec<Vec<usize>>,
-    cell_w: f32,
-    cell_h: f32,
-    n_cols: usize,
-    n_rows: usize,
-    img_w: f32,
-    img_h: f32,
-}
-
-impl KeypointGrid {
-    /// Builds a grid over `keypoints_xy` (each `[x, y]`) for an image of size `img_w x img_h`.
-    ///
-    /// Each cell is `cell_size x cell_size` pixels. Points outside the image are clamped.
-    fn new(keypoints_xy: &[[f32; 2]], img_w: f32, img_h: f32, cell_size: f32) -> Self {
-        let n_cols = (img_w / cell_size).ceil() as usize;
-        let n_rows = (img_h / cell_size).ceil() as usize;
-        let n_cells = n_cols * n_rows;
-        let mut cells = vec![Vec::new(); n_cells];
-
-        for (i, kp) in keypoints_xy.iter().enumerate() {
-            let col = ((kp[0] / cell_size) as usize).min(n_cols - 1);
-            let row = ((kp[1] / cell_size) as usize).min(n_rows - 1);
-            cells[row * n_cols + col].push(i);
-        }
-
-        Self {
-            cells,
-            cell_w: cell_size,
-            cell_h: cell_size,
-            n_cols,
-            n_rows,
-            img_w,
-            img_h,
-        }
-    }
-
-    /// Returns indices of keypoints within `radius` pixels of `(x, y)`.
-    fn query_radius(
-        &self,
-        x: f32,
-        y: f32,
-        radius: f32,
-        keypoints_xy: &[[f32; 2]],
-    ) -> Vec<usize> {
-        let r_sq = radius * radius;
-
-        let col_min = ((x - radius).max(0.0) / self.cell_w) as usize;
-        let col_max =
-            (((x + radius).min(self.img_w - 1.0) / self.cell_w) as usize).min(self.n_cols - 1);
-        let row_min = ((y - radius).max(0.0) / self.cell_h) as usize;
-        let row_max =
-            (((y + radius).min(self.img_h - 1.0) / self.cell_h) as usize).min(self.n_rows - 1);
-
-        let mut result = Vec::new();
-        for r in row_min..=row_max {
-            for c in col_min..=col_max {
-                for &idx in &self.cells[r * self.n_cols + c] {
-                    let kp = keypoints_xy[idx];
-                    let dx = kp[0] - x;
-                    let dy = kp[1] - y;
-                    if dx * dx + dy * dy <= r_sq {
-                        result.push(idx);
-                    }
-                }
-            }
-        }
-        result
-    }
-}
+use keypoint_grid::KeypointGrid;
 
 /// Tunable parameters for projection-guided matching.
 #[derive(Debug, Clone, Copy)]
@@ -138,30 +54,6 @@ impl Default for ProjectionMatchConfig {
             min_depth: 0.0,
             search_radius: 15.0,
             max_hamming: 50,
-        }
-    }
-}
-
-/// PnP pose-estimation thresholds.
-#[derive(Debug, Clone)]
-pub struct PnpConfig {
-    /// Reprojection threshold (px) for filtering correspondences against the prior pose.
-    pub prior_reproj_threshold_px: f64,
-    /// Reprojection threshold (px) for counting final inliers after LM refinement.
-    pub final_reproj_threshold_px: f64,
-    /// Minimum number of 3D-2D correspondences required for PnP solving.
-    pub min_correspondences: usize,
-    /// Minimum inliers to accept a PnP solution.
-    pub min_inliers: usize,
-}
-
-impl Default for PnpConfig {
-    fn default() -> Self {
-        Self {
-            prior_reproj_threshold_px: 25.0,
-            final_reproj_threshold_px: 3.0,
-            min_correspondences: 4,
-            min_inliers: 30,
         }
     }
 }
@@ -245,49 +137,52 @@ impl MapProjectionEstimator {
         map: &Map,
         current_keyframe_idx: Option<usize>,
     ) -> Result<Estimate, MapProjectionRejectReason> {
-        const MIN_PNP_CORRESPONDENCES: usize = 4;
-        const MIN_STAGE1_INLIERS: usize = 10;
+        let pnp = &self.config.pnp;
 
-        let frame_match = self.match_map_to_frame(map.map_points(), frame, candidate_pose);
-        let curr_keypoints_undist = &frame_match.keypoints_undist;
-        let grid = &frame_match.grid;
-        let projection_matches = frame_match.matches;
+        let (projection_matches, curr_keypoints_undist, grid) =
+            self.match_map_to_frame(map.map_points(), frame, candidate_pose);
 
         // Shared logic: try_track → refine_pose → Estimate, or propagate rejection.
         let try_track_and_refine = |correspondences: Vec<(usize, usize)>,
                                     pose_init: &Pose3d|
          -> Result<Estimate, MapProjectionRejectReason> {
-            match self.try_track(
-                map.map_points(),
-                &correspondences,
-                curr_keypoints_undist,
-                pose_init,
-                MIN_STAGE1_INLIERS,
-            ) {
-                TrackAttempt::Success { pose, inliers } => {
-                    let (pose, inliers, matches) = self.refine_pose(
-                        curr_keypoints_undist,
-                        &frame.features.descriptors,
-                        grid,
-                        frame.image_size,
-                        pose,
-                        inliers,
-                        correspondences,
-                        map,
-                        current_keyframe_idx,
-                    );
-                    Ok(Estimate {
-                        pose,
-                        inliers,
-                        matches,
-                    })
-                }
-                TrackAttempt::Rejected(reason) => Err(reason),
+            let (mut pose, mut inliers) = self
+                .solve_pnp(
+                    map.map_points(),
+                    &correspondences,
+                    &curr_keypoints_undist,
+                    pose_init,
+                )
+                .ok_or(MapProjectionRejectReason::PnpFailed)?;
+            if inliers < pnp.min_inliers_early {
+                return Err(MapProjectionRejectReason::LowPnpInliers);
             }
+            let mut matches = correspondences;
+            if let Some(local) = self.refine_with_local_map(
+                map,
+                current_keyframe_idx,
+                &matches,
+                &curr_keypoints_undist,
+                &frame.features.descriptors,
+                &grid,
+                frame.image_size,
+                &pose,
+            ) {
+                matches = local.matches;
+                if local.inliers >= self.config.pnp.min_inliers {
+                    pose = local.pose;
+                    inliers = local.inliers;
+                }
+            }
+            Ok(Estimate {
+                pose,
+                inliers,
+                matches,
+            })
         };
 
         // PnP from projection matches.
-        let last_reject = if projection_matches.len() >= MIN_PNP_CORRESPONDENCES {
+        let last_reject = if projection_matches.len() >= pnp.min_correspondences {
             match try_track_and_refine(projection_matches, candidate_pose) {
                 Ok(estimate) => return Ok(estimate),
                 Err(reason) => reason,
@@ -324,91 +219,11 @@ impl MapProjectionEstimator {
             }
         }
 
-        if ref_correspondences.len() < MIN_PNP_CORRESPONDENCES {
+        if ref_correspondences.len() < pnp.min_correspondences {
             return Err(MapProjectionRejectReason::LowReferenceCorrespondences);
         }
 
         try_track_and_refine(ref_correspondences, pose_before_tracking)
-    }
-
-    /// Returns indices of map points visible in the current camera frustum.
-    pub fn visible_map_points(
-        &self,
-        map: &Map,
-        pose_world_to_cam: &Pose3d,
-        image_size: ImageSize,
-    ) -> HashSet<usize> {
-        let mut visible = HashSet::new();
-        for (mp_idx, mp) in map.map_points().iter().enumerate() {
-            if mp.culled {
-                continue;
-            }
-            let p_cam = pose_world_to_cam.transform_point(&mp.position);
-            if self
-                .camera
-                .project_to_image(&p_cam, 0.0, image_size)
-                .is_ok()
-            {
-                visible.insert(mp_idx);
-            }
-        }
-        visible
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn refine_pose(
-        &self,
-        curr_keypoints_undist: &[[f32; 2]],
-        curr_descriptors: &[[u8; 32]],
-        grid: &KeypointGrid,
-        image_size: ImageSize,
-        mut pose: Pose3d,
-        mut inliers: usize,
-        mut matches: Vec<(usize, usize)>,
-        map: &Map,
-        current_keyframe_idx: Option<usize>,
-    ) -> (Pose3d, usize, Vec<(usize, usize)>) {
-        if let Some(local) = self.refine_with_local_map(
-            map,
-            current_keyframe_idx,
-            &matches,
-            curr_keypoints_undist,
-            curr_descriptors,
-            grid,
-            image_size,
-            &pose,
-        ) {
-            matches = local.matches;
-            if local.inliers >= self.config.pnp.min_inliers {
-                pose = local.pose;
-                inliers = local.inliers;
-            }
-        }
-
-        (pose, inliers, matches)
-    }
-
-    fn try_track(
-        &self,
-        map_points: &[MapPoint],
-        correspondences: &[(usize, usize)],
-        keypoints_undist: &[[f32; 2]],
-        pose_init: &Pose3d,
-        min_inliers: usize,
-    ) -> TrackAttempt {
-        match self.solve_pnp(map_points, correspondences, keypoints_undist, pose_init) {
-            Some((new_pose, inliers)) => {
-                if inliers >= min_inliers {
-                    TrackAttempt::Success {
-                        pose: new_pose,
-                        inliers,
-                    }
-                } else {
-                    TrackAttempt::Rejected(MapProjectionRejectReason::LowPnpInliers)
-                }
-            }
-            None => TrackAttempt::Rejected(MapProjectionRejectReason::PnpFailed),
-        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -469,7 +284,7 @@ impl MapProjectionEstimator {
         })
     }
 
-    /// Solve PnP from map-point to keypoint correspondences using LM refinement.
+    /// Gather 3D-2D correspondences from map points and keypoints, then solve PnP.
     fn solve_pnp(
         &self,
         map_points: &[MapPoint],
@@ -477,108 +292,21 @@ impl MapProjectionEstimator {
         keypoints_undist: &[[f32; 2]],
         pose_init: &Pose3d,
     ) -> Option<(Pose3d, usize)> {
-        let config = &self.config.pnp;
-        let camera = &self.camera;
-
         let mut points_world = Vec::with_capacity(correspondences.len());
-        let mut points_world_f64 = Vec::with_capacity(correspondences.len());
         let mut points_image = Vec::with_capacity(correspondences.len());
         for &(mp_idx, kp_idx) in correspondences {
             if let (Some(mp), Some(&kp)) = (map_points.get(mp_idx), keypoints_undist.get(kp_idx)) {
-                points_world.push(Vec3AF32::new(
-                    mp.position.x as f32,
-                    mp.position.y as f32,
-                    mp.position.z as f32,
-                ));
-                points_world_f64.push(mp.position);
+                points_world.push(mp.position);
                 points_image.push(Vec2F32::new(kp[0], kp[1]));
             }
         }
-        if points_world.len() < config.min_correspondences {
-            return None;
-        }
-
-        let prior_th2 = config.prior_reproj_threshold_px * config.prior_reproj_threshold_px;
-        let mut prior_inliers = Vec::new();
-        for (i, pw) in points_world_f64.iter().enumerate() {
-            if camera
-                .reprojection_error_sq_world(
-                    pose_init,
-                    pw,
-                    points_image[i].x as f64,
-                    points_image[i].y as f64,
-                )
-                .is_some_and(|err_sq| err_sq <= prior_th2)
-            {
-                prior_inliers.push(i);
-            }
-        }
-        if prior_inliers.len() < config.min_correspondences {
-            return None;
-        }
-
-        let k = Mat3AF32::from_cols(
-            Vec3AF32::new(camera.fx as f32, 0.0, 0.0),
-            Vec3AF32::new(0.0, camera.fy as f32, 0.0),
-            Vec3AF32::new(camera.cx as f32, camera.cy as f32, 1.0),
-        );
-        let mut world_inliers = Vec::with_capacity(prior_inliers.len());
-        let mut image_inliers = Vec::with_capacity(prior_inliers.len());
-        for &i in &prior_inliers {
-            world_inliers.push(points_world[i]);
-            image_inliers.push(points_image[i]);
-        }
-
-        let r_init_f32 = Mat3AF32::from_cols(
-            Vec3AF32::new(
-                pose_init.rotation.col(0).x as f32,
-                pose_init.rotation.col(0).y as f32,
-                pose_init.rotation.col(0).z as f32,
-            ),
-            Vec3AF32::new(
-                pose_init.rotation.col(1).x as f32,
-                pose_init.rotation.col(1).y as f32,
-                pose_init.rotation.col(1).z as f32,
-            ),
-            Vec3AF32::new(
-                pose_init.rotation.col(2).x as f32,
-                pose_init.rotation.col(2).y as f32,
-                pose_init.rotation.col(2).z as f32,
-            ),
-        );
-        let t_init_f32 = Vec3AF32::new(
-            pose_init.translation.x as f32,
-            pose_init.translation.y as f32,
-            pose_init.translation.z as f32,
-        );
-
-        let lm = refine_pose_lm(
-            &world_inliers,
-            &image_inliers,
-            &k,
-            &r_init_f32,
-            &t_init_f32,
-            None,
-            &LMRefineParams::default(),
-        )
-        .ok()?;
-
-        let r = &lm.rotation;
-        let t = lm.translation;
-        let r_new = Mat3F64::from_cols(
-            Vec3F64::new(r.col(0).x as f64, r.col(0).y as f64, r.col(0).z as f64),
-            Vec3F64::new(r.col(1).x as f64, r.col(1).y as f64, r.col(1).z as f64),
-            Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
-        );
-        let t_new = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
-        let pose_new = Pose3d::new(r_new, t_new);
-        let final_inliers = self.count_reprojection_inliers(
-            &pose_new,
-            &points_world_f64,
+        pnp::solve_pnp(
+            &points_world,
             &points_image,
-            config.final_reproj_threshold_px,
-        );
-        Some((pose_new, final_inliers))
+            &self.camera,
+            pose_init,
+            &self.config.pnp,
+        )
     }
 
     /// Undistorts keypoints, builds a spatial grid, and runs projection matching
@@ -588,7 +316,7 @@ impl MapProjectionEstimator {
         map_points: &[MapPoint],
         frame: &Frame,
         pose: &Pose3d,
-    ) -> FrameMatchResult {
+    ) -> (Vec<(usize, usize)>, Vec<[f32; 2]>, KeypointGrid) {
         const KEYPOINT_GRID_CELL_SIZE: f32 = 64.0;
         const MIN_MATCHES_BEFORE_WIDE: usize = 20;
 
@@ -635,11 +363,7 @@ impl MapProjectionEstimator {
             );
         }
 
-        FrameMatchResult {
-            matches,
-            keypoints_undist,
-            grid,
-        }
+        (matches, keypoints_undist, grid)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -662,7 +386,9 @@ impl MapProjectionEstimator {
             }
 
             let p_cam = pose_world_to_cam.transform_point(&mp.position);
-            let Ok(pixel) = self.camera.project_to_image(&p_cam, config.min_depth, image_size)
+            let Ok(pixel) = self
+                .camera
+                .project_to_image(&p_cam, config.min_depth, image_size)
             else {
                 continue;
             };
@@ -692,28 +418,6 @@ impl MapProjectionEstimator {
 
         matches
     }
-
-    /// Count map-point reprojection inliers given a camera pose.
-    fn count_reprojection_inliers(
-        &self,
-        pose_world_to_cam: &Pose3d,
-        points_world: &[Vec3F64],
-        points_image: &[Vec2F32],
-        threshold_px: f64,
-    ) -> usize {
-        let th2 = threshold_px * threshold_px;
-        let mut inliers = 0usize;
-        for (pw, pi) in points_world.iter().zip(points_image.iter()) {
-            if self
-                .camera
-                .reprojection_error_sq_world(pose_world_to_cam, pw, pi.x as f64, pi.y as f64)
-                .is_some_and(|err_sq| err_sq <= th2)
-            {
-                inliers += 1;
-            }
-        }
-        inliers
-    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
@@ -738,57 +442,7 @@ mod estimator_tests {
 #[cfg(test)]
 mod matching_tests {
     use super::*;
-
-    #[test]
-    fn test_empty_grid() {
-        let grid = KeypointGrid::new(&[], 640.0, 480.0, 64.0);
-        let result = grid.query_radius(320.0, 240.0, 50.0, &[]);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_single_point_found() {
-        let kps = [[100.0, 100.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
-
-        let result = grid.query_radius(100.0, 100.0, 10.0, &kps);
-        assert_eq!(result, vec![0]);
-
-        let result = grid.query_radius(500.0, 400.0, 10.0, &kps);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_radius_boundary() {
-        let kps = [[50.0, 50.0], [60.0, 50.0], [100.0, 50.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 32.0);
-
-        let mut result = grid.query_radius(55.0, 50.0, 15.0, &kps);
-        result.sort();
-        assert_eq!(result, vec![0, 1]);
-    }
-
-    #[test]
-    fn test_corner_clamping() {
-        let kps = [[0.0, 0.0], [639.0, 479.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
-
-        let result = grid.query_radius(0.0, 0.0, 5.0, &kps);
-        assert_eq!(result, vec![0]);
-
-        let result = grid.query_radius(639.0, 479.0, 5.0, &kps);
-        assert_eq!(result, vec![1]);
-    }
-
-    #[test]
-    fn test_multiple_points_per_cell() {
-        let kps = [[10.0, 10.0], [12.0, 11.0], [15.0, 13.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
-
-        let mut result = grid.query_radius(12.0, 12.0, 20.0, &kps);
-        result.sort();
-        assert_eq!(result, vec![0, 1, 2]);
-    }
+    use kornia_algebra::{Mat3F64, Vec3F64};
 
     fn make_test_estimator(camera: PinholeCamera) -> MapProjectionEstimator {
         MapProjectionEstimator::new(camera, MapProjectionConfig::default())

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -3,4 +3,17 @@
 pub mod map_projection;
 pub mod two_view;
 
+use kornia_3d::pose::Pose3d;
+
 pub use map_projection::MapProjectionEstimator;
+
+/// Successful pose estimate returned by any estimator.
+#[derive(Debug, Clone)]
+pub struct Estimate {
+    /// Estimated world-to-camera pose.
+    pub pose: Pose3d,
+    /// Matched pairs `(map_point_idx, keypoint_idx)`.
+    pub matches: Vec<(usize, usize)>,
+    /// Number of inlier correspondences supporting the estimate.
+    pub inliers: usize,
+}

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -1,6 +1,7 @@
 //! Pose estimation algorithms and estimator modules.
 
 pub mod map_projection;
+pub mod pnp;
 pub mod two_view;
 
 use kornia_3d::pose::Pose3d;

--- a/src/estimation/pnp.rs
+++ b/src/estimation/pnp.rs
@@ -1,0 +1,158 @@
+//! PnP pose estimation: solve 3D-2D correspondences with LM refinement.
+
+use kornia_3d::camera::PinholeCamera;
+use kornia_3d::pnp::{LMRefineParams, refine_pose_lm};
+use kornia_3d::pose::Pose3d;
+use kornia_algebra::{Mat3AF32, Mat3F64, Vec2F32, Vec3AF32, Vec3F64};
+
+/// PnP pose-estimation thresholds.
+#[derive(Debug, Clone)]
+pub struct PnpConfig {
+    /// Reprojection threshold (px) for filtering correspondences against the prior pose.
+    pub prior_reproj_threshold_px: f64,
+    /// Reprojection threshold (px) for counting final inliers after LM refinement.
+    pub final_reproj_threshold_px: f64,
+    /// Minimum number of 3D-2D correspondences required for PnP solving.
+    pub min_correspondences: usize,
+    /// Minimum inliers for early acceptance before local map refinement.
+    pub min_inliers_early: usize,
+    /// Minimum inliers to accept a PnP solution.
+    pub min_inliers: usize,
+}
+
+impl Default for PnpConfig {
+    fn default() -> Self {
+        Self {
+            prior_reproj_threshold_px: 25.0,
+            final_reproj_threshold_px: 3.0,
+            min_correspondences: 4,
+            min_inliers_early: 10,
+            min_inliers: 30,
+        }
+    }
+}
+
+/// Solve PnP from 3D world points and 2D image points with LM refinement.
+///
+/// Filters correspondences by reprojection error against `pose_init`, runs LM,
+/// then counts final inliers. Returns the refined pose and inlier count.
+pub fn solve_pnp(
+    points_world_f64: &[Vec3F64],
+    points_image: &[Vec2F32],
+    camera: &PinholeCamera,
+    pose_init: &Pose3d,
+    config: &PnpConfig,
+) -> Option<(Pose3d, usize)> {
+    if points_world_f64.len() < config.min_correspondences {
+        return None;
+    }
+
+    // Filter by reprojection error against the prior pose.
+    let prior_th2 = config.prior_reproj_threshold_px * config.prior_reproj_threshold_px;
+    let mut prior_inlier_indices = Vec::new();
+    for (i, pw) in points_world_f64.iter().enumerate() {
+        if camera
+            .reprojection_error_sq_world(
+                pose_init,
+                pw,
+                points_image[i].x as f64,
+                points_image[i].y as f64,
+            )
+            .is_some_and(|err_sq| err_sq <= prior_th2)
+        {
+            prior_inlier_indices.push(i);
+        }
+    }
+    if prior_inlier_indices.len() < config.min_correspondences {
+        return None;
+    }
+
+    // Build f32 arrays for LM solver.
+    let k = Mat3AF32::from_cols(
+        Vec3AF32::new(camera.fx as f32, 0.0, 0.0),
+        Vec3AF32::new(0.0, camera.fy as f32, 0.0),
+        Vec3AF32::new(camera.cx as f32, camera.cy as f32, 1.0),
+    );
+    let mut world_inliers = Vec::with_capacity(prior_inlier_indices.len());
+    let mut image_inliers = Vec::with_capacity(prior_inlier_indices.len());
+    for &i in &prior_inlier_indices {
+        let pw = &points_world_f64[i];
+        world_inliers.push(Vec3AF32::new(pw.x as f32, pw.y as f32, pw.z as f32));
+        image_inliers.push(points_image[i]);
+    }
+
+    let r_init_f32 = Mat3AF32::from_cols(
+        Vec3AF32::new(
+            pose_init.rotation.col(0).x as f32,
+            pose_init.rotation.col(0).y as f32,
+            pose_init.rotation.col(0).z as f32,
+        ),
+        Vec3AF32::new(
+            pose_init.rotation.col(1).x as f32,
+            pose_init.rotation.col(1).y as f32,
+            pose_init.rotation.col(1).z as f32,
+        ),
+        Vec3AF32::new(
+            pose_init.rotation.col(2).x as f32,
+            pose_init.rotation.col(2).y as f32,
+            pose_init.rotation.col(2).z as f32,
+        ),
+    );
+    let t_init_f32 = Vec3AF32::new(
+        pose_init.translation.x as f32,
+        pose_init.translation.y as f32,
+        pose_init.translation.z as f32,
+    );
+
+    let lm = refine_pose_lm(
+        &world_inliers,
+        &image_inliers,
+        &k,
+        &r_init_f32,
+        &t_init_f32,
+        None,
+        &LMRefineParams::default(),
+    )
+    .ok()?;
+
+    let r = &lm.rotation;
+    let t = lm.translation;
+    let r_new = Mat3F64::from_cols(
+        Vec3F64::new(r.col(0).x as f64, r.col(0).y as f64, r.col(0).z as f64),
+        Vec3F64::new(r.col(1).x as f64, r.col(1).y as f64, r.col(1).z as f64),
+        Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
+    );
+    let t_new = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
+    let pose_new = Pose3d::new(r_new, t_new);
+
+    let final_inliers = count_reprojection_inliers(
+        &pose_new,
+        points_world_f64,
+        points_image,
+        camera,
+        config.final_reproj_threshold_px,
+    );
+
+    Some((pose_new, final_inliers))
+}
+
+/// Count map-point reprojection inliers given a camera pose.
+pub fn count_reprojection_inliers(
+    pose_world_to_cam: &Pose3d,
+    points_world: &[Vec3F64],
+    points_image: &[Vec2F32],
+    camera: &PinholeCamera,
+    threshold_px: f64,
+) -> usize {
+    let th2 = threshold_px * threshold_px;
+    let mut inliers = 0usize;
+    for (pw, pi) in points_world.iter().zip(points_image.iter()) {
+        if camera
+            .reprojection_error_sq_world(pose_world_to_cam, pw, pi.x as f64, pi.y as f64)
+            .is_some_and(|err_sq| err_sq <= th2)
+        {
+            inliers += 1;
+        }
+    }
+    inliers
+}

--- a/src/estimation/two_view.rs
+++ b/src/estimation/two_view.rs
@@ -16,9 +16,9 @@ use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_3d::pose::{TwoViewConfig, TwoViewModel, two_view_estimate};
 use kornia_algebra::Vec3F64;
-use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
+use kornia_imgproc::features::{OrbFeatures, OrbMatchConfig, match_orb_descriptors};
 
-use crate::OrbFeatures;
+use super::Estimate;
 
 /// Configuration for two-view initialization.
 #[derive(Debug, Clone)]
@@ -63,7 +63,7 @@ impl Default for TwoViewInitConfig {
 
 /// Two-view initialization rejection reason.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TwoViewInitRejectReason {
+pub enum TwoViewRejectReason {
     /// Not enough descriptor matches to run two-view estimation.
     LowMatches,
     /// Two-view estimation failed.
@@ -78,30 +78,17 @@ pub enum TwoViewInitRejectReason {
     LowParallax,
 }
 
-/// Result of one two-view initialization attempt.
-#[allow(clippy::large_enum_variant)]
+/// Bootstrap-specific data produced alongside the shared [`Estimate`].
 #[derive(Debug, Clone)]
-pub enum TwoViewInitOutcome {
-    /// Attempt was rejected by two-view initialization gates.
-    Rejected {
-        /// Why the two-view initialization attempt failed.
-        reason: TwoViewInitRejectReason,
-    },
-    /// Two-view initialization succeeded.
-    Initialized {
-        /// New world-to-camera pose for the current frame.
-        pose_world_to_cam: Pose3d,
-        /// Estimated constant-velocity increment (between previous pose and new pose).
-        motion_increment: Pose3d,
-        /// Descriptor match pairs `(reference_desc_idx, current_desc_idx)`.
-        matches: Vec<(usize, usize)>,
-        /// Triangulated 3D points in the reference camera frame.
-        points3d: Vec<Vec3F64>,
-        /// Indices into `matches` that were inliers in two-view estimation.
-        inlier_indices: Vec<usize>,
-        /// Median positive depth in the two-view triangulation (if available).
-        median_depth: Option<f64>,
-    },
+pub struct TwoViewEstimate {
+    /// Shared pose estimate.
+    pub estimate: Estimate,
+    /// Triangulated 3D points in the reference camera frame.
+    pub points3d: Vec<Vec3F64>,
+    /// Indices into `estimate.matches` that were inliers in two-view estimation.
+    pub inlier_indices: Vec<usize>,
+    /// Median positive depth in the two-view triangulation (if available).
+    pub median_depth: Option<f64>,
 }
 
 /// Attempt two-view initialization between a reference frame and the current frame.
@@ -109,10 +96,9 @@ pub fn try_initialize_two_view(
     ref_features: &OrbFeatures,
     ref_pose: &Pose3d,
     curr_features: &OrbFeatures,
-    curr_pose: &Pose3d,
     camera: &PinholeCamera,
     config: &TwoViewInitConfig,
-) -> TwoViewInitOutcome {
+) -> Result<TwoViewEstimate, TwoViewRejectReason> {
     let acceptance = &config.acceptance_config;
 
     let matches = match_orb_descriptors(
@@ -123,9 +109,7 @@ pub fn try_initialize_two_view(
         config.match_config,
     );
     if matches.len() < acceptance.min_matches {
-        return TwoViewInitOutcome::Rejected {
-            reason: TwoViewInitRejectReason::LowMatches,
-        };
+        return Err(TwoViewRejectReason::LowMatches);
     }
 
     let (reference_pts, current_pts) = camera.undistort_matched_pairs(
@@ -135,41 +119,30 @@ pub fn try_initialize_two_view(
     );
 
     let k = camera.intrinsic_matrix();
-    let Ok(result) = two_view_estimate(
+    let result = two_view_estimate(
         &reference_pts,
         &current_pts,
         &k,
         &k,
         &config.estimation_config,
-    ) else {
-        return TwoViewInitOutcome::Rejected {
-            reason: TwoViewInitRejectReason::EstimationFailed,
-        };
-    };
+    )
+    .map_err(|_| TwoViewRejectReason::EstimationFailed)?;
 
     if !matches!(result.model, TwoViewModel::Fundamental(_)) {
-        return TwoViewInitOutcome::Rejected {
-            reason: TwoViewInitRejectReason::WrongModel,
-        };
+        return Err(TwoViewRejectReason::WrongModel);
     }
 
     if result.points3d.len() < acceptance.min_triangulated {
-        return TwoViewInitOutcome::Rejected {
-            reason: TwoViewInitRejectReason::LowTriangulated,
-        };
+        return Err(TwoViewRejectReason::LowTriangulated);
     }
 
     if result.inlier_indices.len() < acceptance.min_inliers {
-        return TwoViewInitOutcome::Rejected {
-            reason: TwoViewInitRejectReason::LowInliers,
-        };
+        return Err(TwoViewRejectReason::LowInliers);
     }
 
     let median_parallax_deg = result.median_parallax_deg(&reference_pts, &current_pts, camera);
     if median_parallax_deg < config.estimation_config.triangulation.min_parallax_deg {
-        return TwoViewInitOutcome::Rejected {
-            reason: TwoViewInitRejectReason::LowParallax,
-        };
+        return Err(TwoViewRejectReason::LowParallax);
     }
 
     let mut t_scaled = result.translation;
@@ -184,20 +157,22 @@ pub fn try_initialize_two_view(
         t_scaled /= md;
     }
 
-    let new_pose = Pose3d::new(
+    let pose = Pose3d::new(
         result.rotation * ref_pose.rotation,
         result.rotation * ref_pose.translation + t_scaled,
     );
-    let motion_increment = Pose3d::between(curr_pose, &new_pose);
+    let inliers = result.inlier_indices.len();
 
-    TwoViewInitOutcome::Initialized {
-        pose_world_to_cam: new_pose,
-        motion_increment,
-        matches,
+    Ok(TwoViewEstimate {
+        estimate: Estimate {
+            pose,
+            matches,
+            inliers,
+        },
         points3d: result.points3d,
         inlier_indices: result.inlier_indices,
         median_depth,
-    }
+    })
 }
 
 /// Computes the median of a mutable slice in-place.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ pub mod system;
 pub use estimation::MapProjectionEstimator;
 pub use frame::Frame;
 pub use kornia_imgproc::features::OrbFeatures;
-pub use system::{SystemMode, SystemState, TrackingResult, TrackingStatus};
+pub use system::{KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus};

--- a/src/map.rs
+++ b/src/map.rs
@@ -31,6 +31,7 @@ use kornia_3d::ba::{self, BaObservation, BaParams};
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_algebra::Vec3F64;
+use kornia_image::ImageSize;
 
 use crate::frame::Frame;
 
@@ -185,6 +186,26 @@ impl Map {
     /// Returns a mutable reference to all keyframes.
     pub fn keyframes_mut(&mut self) -> &mut Vec<Keyframe> {
         &mut self.keyframes
+    }
+
+    /// Returns indices of non-culled map points that project inside the image frustum.
+    pub fn map_points_in_frustum(
+        &self,
+        camera: &PinholeCamera,
+        pose_world_to_cam: &Pose3d,
+        image_size: ImageSize,
+    ) -> HashSet<usize> {
+        let mut visible = HashSet::new();
+        for (mp_idx, mp) in self.map_points.iter().enumerate() {
+            if mp.culled {
+                continue;
+            }
+            let p_cam = pose_world_to_cam.transform_point(&mp.position);
+            if camera.project_to_image(&p_cam, 0.0, image_size).is_ok() {
+                visible.insert(mp_idx);
+            }
+        }
+        visible
     }
 
     /// Update `n_visible` and `n_found` counters for map points.

--- a/src/map.rs
+++ b/src/map.rs
@@ -187,6 +187,24 @@ impl Map {
         &mut self.keyframes
     }
 
+    /// Update `n_visible` and `n_found` counters for map points.
+    pub fn update_observation_counts(
+        &mut self,
+        visible: &HashSet<usize>,
+        matched: &[(usize, usize)],
+    ) {
+        let matched_set: HashSet<usize> = matched.iter().map(|&(mp_idx, _)| mp_idx).collect();
+
+        for &mp_idx in visible {
+            if let Some(mp) = self.map_points.get_mut(mp_idx) {
+                mp.n_visible = mp.n_visible.saturating_add(1);
+                if matched_set.contains(&mp_idx) {
+                    mp.n_found = mp.n_found.saturating_add(1);
+                }
+            }
+        }
+    }
+
     /// Builds a local map of visible points from nearby keyframes.
     pub fn build_local_map_points(
         &self,

--- a/src/system.rs
+++ b/src/system.rs
@@ -4,6 +4,57 @@ use kornia_3d::pose::Pose3d;
 
 use crate::frame::Frame;
 
+/// Keyframe insertion heuristics.
+#[derive(Debug, Clone)]
+pub struct KeyframePolicy {
+    /// Minimum frame gap before allowing keyframe insertion.
+    pub min_frames_between: usize,
+    /// Force a keyframe if this frame gap is reached.
+    pub max_frames_between: usize,
+    /// Relative inlier ratio threshold (vs reference keyframe tracked map points).
+    pub ref_ratio: f64,
+}
+
+impl Default for KeyframePolicy {
+    fn default() -> Self {
+        Self {
+            min_frames_between: 3,
+            max_frames_between: 8,
+            ref_ratio: 0.6,
+        }
+    }
+}
+
+impl KeyframePolicy {
+    /// Decide whether a new keyframe should be inserted.
+    pub fn should_insert(
+        &self,
+        curr_idx: usize,
+        last_keyframe_idx: Option<usize>,
+        tracked_inliers: usize,
+        n_ref_map_points: usize,
+    ) -> bool {
+        let Some(last_kf_idx) = last_keyframe_idx else {
+            return true;
+        };
+
+        let frames_since_last_kf = curr_idx.saturating_sub(last_kf_idx);
+        if frames_since_last_kf < self.min_frames_between {
+            return false;
+        }
+        if frames_since_last_kf >= self.max_frames_between {
+            return true;
+        }
+
+        if n_ref_map_points == 0 {
+            return true;
+        }
+
+        let weak_threshold = (n_ref_map_points as f64 * self.ref_ratio) as usize;
+        tracked_inliers >= 15 && tracked_inliers < weak_threshold
+    }
+}
+
 /// Status of processing one frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrackingStatus {
@@ -32,6 +83,8 @@ pub struct SystemState {
     pub current_keyframe_idx: Option<usize>,
     pub last_keyframe_idx: Option<usize>,
     pub consecutive_failures: usize,
+    /// Maximum consecutive tracking failures before resetting to bootstrap.
+    pub max_consecutive_failures: usize,
     pub bootstrap_frame: Option<Frame>,
     pub mode: SystemMode,
 }
@@ -53,6 +106,7 @@ impl SystemState {
             current_keyframe_idx: None,
             last_keyframe_idx: None,
             consecutive_failures: 0,
+            max_consecutive_failures: 15,
             bootstrap_frame: None,
             mode: SystemMode::Bootstrap,
         }


### PR DESCRIPTION
## Summary

- Replace custom outcome enums (`MapProjectionEstimateOutcome`, `TwoViewInitOutcome`) with idiomatic `Result<T, E>` and shared `Estimate` type
- Extract PnP solving into `estimation/pnp.rs` — reusable by any future estimator
- Move `KeypointGrid` into `map_projection/keypoint_grid.rs` submodule
- Separate estimation from orchestration: `KeyframePolicy` → `system.rs`, `enable_local_ba` → pipeline config, `max_consecutive_failures` → `SystemState`
- Move frustum visibility query from estimator to `Map::map_points_in_frustum`
- Remove unnecessary indirections: `TrackAttempt`, `FrameMatchResult`, `refine_pose`, `try_track`, `pose_increment_ok`
- Replace hardcoded consts with `PnpConfig` fields (`min_inliers_early`, `min_correspondences`)
- Make internal helpers private (`KeypointGrid`, `match_by_projection`, `count_reprojection_inliers`)
- Make estimator side-effect-free: split `update_map_point_observations` into pure `map_points_in_frustum` + `Map::update_observation_counts`

## Test plan

- [x] All 17 tests pass
- [x] Clippy clean (`--all-targets -- -D warnings`)
- [x] Run orb_slam example on EuRoC dataset to verify tracking quality