### PR TITLE
refactor: pipeline cleanup and colored map points

### DIFF
--- a/examples/common/datasets/euroc.rs
+++ b/examples/common/datasets/euroc.rs
@@ -344,7 +344,11 @@ mod tests {
         let cam0_dir = root.join("mav0").join("cam0");
         let data_dir = cam0_dir.join("data");
         fs::create_dir_all(&data_dir).unwrap();
-        fs::write(cam0_dir.join("data.csv"), "#timestamp [ns],filename\n1403636579763555584,1403636579763555584.png\n").unwrap();
+        fs::write(
+            cam0_dir.join("data.csv"),
+            "#timestamp [ns],filename\n1403636579763555584,1403636579763555584.png\n",
+        )
+        .unwrap();
         fs::write(data_dir.join("1403636579763555584.png"), []).unwrap();
 
         if include_sensor_yaml {
@@ -383,7 +387,10 @@ mod tests {
 
         match err {
             DatasetError::FileNotFound(path) => {
-                assert_eq!(path, dir.path().join("mav0").join("cam0").join("sensor.yaml"));
+                assert_eq!(
+                    path,
+                    dir.path().join("mav0").join("cam0").join("sensor.yaml")
+                );
             }
             other => panic!("expected FileNotFound for sensor.yaml, got {other:?}"),
         }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -7,9 +7,9 @@
 //! cargo run --manifest-path examples/orb_slam/Cargo.toml -- --data /path/to/euroc/V1_01_easy
 //! ```
 
+mod config;
 #[path = "../../common/datasets/mod.rs"]
 mod datasets;
-mod config;
 mod pipeline;
 mod utils;
 
@@ -108,8 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 image_size,
                 0.0f32,
                 kornia_tensor::CpuAllocator,
-            )
-            ?;
+            )?;
             gray_u8
                 .as_slice()
                 .iter()

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -124,20 +124,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log_frame_to_rerun(rec, &gray_u8, &features.keypoints_xy);
         }
 
+        // Sample pixel colors at each keypoint location.
+        let keypoint_colors: Vec<[u8; 3]> = features
+            .keypoints_xy
+            .iter()
+            .map(|kp| {
+                let x = (kp[0] as usize).min(image_size.width.saturating_sub(1));
+                let y = (kp[1] as usize).min(image_size.height.saturating_sub(1));
+                let g = gray_u8.as_slice()[y * image_size.width + x];
+                [g, g, g]
+            })
+            .collect();
+
         // Run SLAM.
         let frame = Frame {
             idx,
             features,
             pose_world_to_cam: Pose3d::IDENTITY,
             image_size,
+            keypoint_colors,
         };
+        let t0 = std::time::Instant::now();
         let result = system.process_frame(frame);
+        let frame_ms = t0.elapsed().as_secs_f64() * 1000.0;
         let keyframe_idx = system.current_keyframe_idx().unwrap_or(idx);
         let map_point_count = system.num_map_points();
 
         // Status line.
         let status_line = format!(
-            "[{idx:>5}] {:?}  kf={:<4} pts={:<5}",
+            "[{idx:>5}] {:?}  kf={:<4} pts={:<5} {frame_ms:>6.1}ms",
             result.status, keyframe_idx, map_point_count,
         );
         eprintln!("{status_line}");

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -8,18 +8,16 @@ use std::collections::HashSet;
 use crate::config::PipelineConfig;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
-use kornia_3d::pose::{
-    TwoViewConfig, TwoViewModel, triangulate_matched_points, two_view_estimate,
-};
+use kornia_3d::pose::{TwoViewConfig, TwoViewModel, triangulate_matched_points, two_view_estimate};
 use kornia_algebra::Vec3F64;
 use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
+use kornia_slam::Frame;
 use kornia_slam::estimation::MapProjectionEstimator;
 use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
 use kornia_slam::map::{Keyframe, Map, MapPoint};
 use kornia_slam::system::{
     KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus,
 };
-use kornia_slam::Frame;
 
 /// Top-level ORB-SLAM pipeline: orchestrates tracking, mapping, and state transitions.
 pub struct Pipeline {
@@ -111,7 +109,10 @@ impl Pipeline {
         };
 
         let estimated_pose = two_view_estimate.estimate.pose;
-        self.state.velocity = Some(Pose3d::between(&curr_frame.pose_world_to_cam, &estimated_pose));
+        self.state.velocity = Some(Pose3d::between(
+            &curr_frame.pose_world_to_cam,
+            &estimated_pose,
+        ));
         self.state.pose_world_to_cam = estimated_pose;
         curr_frame.pose_world_to_cam = estimated_pose;
 
@@ -221,8 +222,7 @@ impl Pipeline {
 
         let (mut status, matches, tracked_inliers) = match result {
             Ok(estimate) => {
-                self.state.velocity =
-                    Some(Pose3d::between(&pose_before_tracking, &estimate.pose));
+                self.state.velocity = Some(Pose3d::between(&pose_before_tracking, &estimate.pose));
                 self.state.pose_world_to_cam = estimate.pose;
                 (TrackingStatus::Tracked, estimate.matches, estimate.inliers)
             }
@@ -230,9 +230,9 @@ impl Pipeline {
         };
 
         if status == TrackingStatus::Tracked {
-            let visible =
-                self.map
-                    .map_points_in_frustum(&self.camera, &candidate_pose, image_size);
+            let visible = self
+                .map
+                .map_points_in_frustum(&self.camera, &candidate_pose, image_size);
             self.map.update_observation_counts(&visible, &matches);
 
             if self.try_insert_keyframe(&frame, tracked_inliers, &matches) {
@@ -301,7 +301,12 @@ impl Pipeline {
         let enable_local_ba = self.enable_local_ba;
         let match_config = self.two_view_init_config.match_config;
         let estimation_config = self.two_view_init_config.estimation_config.clone();
-        self.grow_map_points_from_keyframe_pair(&prev_kf, &mut curr_kf, match_config, &estimation_config);
+        self.grow_map_points_from_keyframe_pair(
+            &prev_kf,
+            &mut curr_kf,
+            match_config,
+            &estimation_config,
+        );
 
         self.map.upsert_keyframe(curr_kf);
         self.state.current_keyframe_idx = Some(frame.idx);

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -3,6 +3,8 @@
 //! This example keeps the runtime flow in one file so it can be read from top
 //! to bottom in the same order frames move through the system.
 
+use std::collections::HashSet;
+
 use crate::config::PipelineConfig;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
@@ -17,10 +19,12 @@ use kornia_slam::map::{Keyframe, Map, MapPoint};
 use kornia_slam::system::{
     KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus,
 };
-use kornia_slam::{Frame, OrbFeatures};
+use kornia_slam::Frame;
 
 /// Top-level ORB-SLAM pipeline: orchestrates tracking, mapping, and state transitions.
 pub struct Pipeline {
+    // Camera model
+    camera: PinholeCamera,
     // Primary pose estimator
     estimator: MapProjectionEstimator,
     // Boostrap pose estimator
@@ -39,7 +43,8 @@ impl Pipeline {
     /// Creates a new pipeline with identity pose.
     pub fn new(camera: PinholeCamera, config: PipelineConfig) -> Self {
         Self {
-            estimator: MapProjectionEstimator::new(camera, config.map_projection),
+            camera,
+            estimator: MapProjectionEstimator::new(config.map_projection),
             two_view_init_config: config.two_view_init,
             keyframe_policy: config.keyframe_policy,
             enable_local_ba: config.enable_local_ba,
@@ -90,7 +95,7 @@ impl Pipeline {
             &prev_bootstrap_frame.features,
             &prev_bootstrap_frame.pose_world_to_cam,
             &curr_frame.features,
-            self.estimator.camera(),
+            &self.camera,
             &self.two_view_init_config,
         );
 
@@ -143,44 +148,51 @@ impl Pipeline {
         let mut current_kf = Keyframe::from_frame(current_frame);
         let depth_scale = median_depth.filter(|&d| d > 1e-6).unwrap_or(1.0);
         let reference_pose_inv = reference_kf.frame.pose_world_to_cam.inverse();
-        let mut added = 0usize;
 
+        let mut triangulated = Vec::new();
         for (p_cam, &match_idx) in points3d.iter().zip(inlier_indices.iter()) {
-            let Some(&(reference_desc_idx, current_desc_idx)) = matches.get(match_idx) else {
+            let Some(&(ref_desc_idx, curr_desc_idx)) = matches.get(match_idx) else {
                 continue;
             };
-            if reference_desc_idx >= reference_kf.map_point_by_desc_idx.len()
-                || current_desc_idx >= current_kf.map_point_by_desc_idx.len()
+            if ref_desc_idx >= reference_kf.map_point_by_desc_idx.len()
+                || curr_desc_idx >= current_kf.map_point_by_desc_idx.len()
             {
                 continue;
             }
-
             let descriptor = current_kf
                 .frame
                 .features
                 .descriptors
-                .get(current_desc_idx)
+                .get(curr_desc_idx)
                 .copied()
                 .or_else(|| {
                     reference_kf
                         .frame
                         .features
                         .descriptors
-                        .get(reference_desc_idx)
+                        .get(ref_desc_idx)
                         .copied()
                 });
             let Some(descriptor) = descriptor else {
                 continue;
             };
-
+            let color = current_kf
+                .frame
+                .keypoint_colors
+                .get(curr_desc_idx)
+                .copied()
+                .unwrap_or([128; 3]);
             let p_world = reference_pose_inv.transform_point(&(*p_cam / depth_scale));
-            let mp_idx =
-                self.map
-                    .push_map_point(MapPoint::new(p_world, descriptor, reference_kf.frame.idx));
-            reference_kf.associate_map_point(reference_desc_idx, mp_idx);
-            current_kf.associate_map_point(current_desc_idx, mp_idx);
-            added += 1;
+            triangulated.push((p_world, descriptor, color, ref_desc_idx, curr_desc_idx));
         }
+
+        let ref_idx = reference_kf.frame.idx;
+        let added = self.map.add_triangulated_points(
+            Some(&mut reference_kf),
+            &mut current_kf,
+            &triangulated,
+            ref_idx,
+        );
 
         self.map.upsert_keyframe(reference_kf);
         self.map.upsert_keyframe(current_kf);
@@ -202,6 +214,7 @@ impl Pipeline {
             &candidate_pose,
             &pose_before_tracking,
             &self.map,
+            &self.camera,
             self.state.current_keyframe_idx,
         );
 
@@ -218,7 +231,7 @@ impl Pipeline {
         if status == TrackingStatus::Tracked {
             let visible =
                 self.map
-                    .map_points_in_frustum(self.estimator.camera(), &candidate_pose, image_size);
+                    .map_points_in_frustum(&self.camera, &candidate_pose, image_size);
             self.map.update_observation_counts(&visible, &matches);
 
             if self.try_insert_keyframe(&frame, tracked_inliers, &matches) {
@@ -273,40 +286,28 @@ impl Pipeline {
             return false;
         };
 
-        let mut curr_kf_map_assoc = vec![None; frame.features.descriptors.len()];
-        for &(mp_idx, curr_idx) in matches {
-            if let Some(slot) = curr_kf_map_assoc.get_mut(curr_idx) {
-                *slot = Some(mp_idx);
-            }
-        }
-
-        let enable_local_ba = self.enable_local_ba;
-        let pose_world_to_cam = self.state.pose_world_to_cam;
-        let match_config = self.two_view_init_config.match_config;
-        let estimation_config = self.two_view_init_config.estimation_config.clone();
-        self.grow_map_points_from_keyframe_pair(
-            frame.idx,
-            &prev_kf,
-            &frame.features,
-            &mut curr_kf_map_assoc,
-            &pose_world_to_cam,
-            match_config,
-            &estimation_config,
-        );
-
-        let mut kf = Keyframe::from_frame(Frame {
+        let mut curr_kf = Keyframe::from_frame(Frame {
             idx: frame.idx,
             features: frame.features.clone(),
             pose_world_to_cam: self.state.pose_world_to_cam,
             image_size: frame.image_size,
+            keypoint_colors: frame.keypoint_colors.clone(),
         });
-        kf.map_point_by_desc_idx = curr_kf_map_assoc;
-        self.map.upsert_keyframe(kf);
+        for &(mp_idx, curr_idx) in matches {
+            curr_kf.associate_map_point(curr_idx, mp_idx);
+        }
+
+        let enable_local_ba = self.enable_local_ba;
+        let match_config = self.two_view_init_config.match_config;
+        let estimation_config = self.two_view_init_config.estimation_config.clone();
+        self.grow_map_points_from_keyframe_pair(&prev_kf, &mut curr_kf, match_config, &estimation_config);
+
+        self.map.upsert_keyframe(curr_kf);
         self.state.current_keyframe_idx = Some(frame.idx);
         self.state.last_keyframe_idx = Some(frame.idx);
 
         if enable_local_ba {
-            self.map.optimize(self.estimator.camera());
+            self.map.run_local_ba(&self.camera);
             if let Some(newest_kf) = self.map.keyframes().last() {
                 self.state.pose_world_to_cam = newest_kf.frame.pose_world_to_cam;
             }
@@ -316,27 +317,23 @@ impl Pipeline {
         true
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn grow_map_points_from_keyframe_pair(
         &mut self,
-        curr_kf_idx: usize,
         prev_kf: &Keyframe,
-        curr_features: &OrbFeatures,
-        curr_kf_map_assoc: &mut [Option<usize>],
-        pose_world_to_cam: &Pose3d,
+        curr_kf: &mut Keyframe,
         match_config: OrbMatchConfig,
         two_view_config: &TwoViewConfig,
     ) -> usize {
         const MIN_GROWTH_MATCHES: usize = 20;
         const MIN_GROWTH_INLIERS: usize = 15;
 
-        let camera = self.estimator.camera();
+        let camera = &self.camera;
         let triangulation_config = &two_view_config.triangulation;
         let matches = match_orb_descriptors(
             &prev_kf.frame.features.orientations,
             &prev_kf.frame.features.descriptors,
-            &curr_features.orientations,
-            &curr_features.descriptors,
+            &curr_kf.frame.features.orientations,
+            &curr_kf.frame.features.descriptors,
             match_config,
         );
         if matches.len() < MIN_GROWTH_MATCHES {
@@ -346,11 +343,11 @@ impl Pipeline {
         let mut pair_indices: Vec<(usize, usize)> = Vec::with_capacity(matches.len());
         for (prev_idx, curr_idx) in matches {
             if prev_idx >= prev_kf.frame.features.keypoints_xy.len()
-                || curr_idx >= curr_features.keypoints_xy.len()
+                || curr_idx >= curr_kf.frame.features.keypoints_xy.len()
             {
                 continue;
             }
-            if curr_kf_map_assoc.get(curr_idx).is_some_and(|m| m.is_some()) {
+            if curr_kf.map_point(curr_idx).is_some() {
                 continue;
             }
             if prev_kf.map_point(prev_idx).is_some() {
@@ -361,7 +358,7 @@ impl Pipeline {
 
         let (prev_pts, curr_pts) = camera.undistort_matched_pairs(
             &prev_kf.frame.features.keypoints_xy,
-            &curr_features.keypoints_xy,
+            &curr_kf.frame.features.keypoints_xy,
             &pair_indices,
         );
         if pair_indices.len() < 8 {
@@ -393,33 +390,38 @@ impl Pipeline {
             &inlier_prev,
             &inlier_curr,
             &prev_kf.frame.pose_world_to_cam,
-            pose_world_to_cam,
+            &curr_kf.frame.pose_world_to_cam,
             camera,
             triangulation_config,
         );
 
-        let mut n_added = 0usize;
+        let mut points = Vec::new();
+        let mut used_curr = HashSet::new();
         for tp in &triangulated {
             let inlier_idx = two_view.inlier_indices[tp.pair_index];
-            let Some(&(_prev_idx, curr_idx)) = pair_indices.get(inlier_idx) else {
+            let Some(&(prev_idx, curr_idx)) = pair_indices.get(inlier_idx) else {
                 continue;
             };
-            if curr_kf_map_assoc.get(curr_idx).is_some_and(|m: &Option<usize>| m.is_some()) {
+            if curr_kf.map_point(curr_idx).is_some() || !used_curr.insert(curr_idx) {
                 continue;
             }
-
-            let mp_idx = self.map.push_map_point(MapPoint::new(
+            let color = curr_kf
+                .frame
+                .keypoint_colors
+                .get(curr_idx)
+                .copied()
+                .unwrap_or([128; 3]);
+            points.push((
                 tp.position,
-                curr_features.descriptors[curr_idx],
-                curr_kf_idx,
+                curr_kf.frame.features.descriptors[curr_idx],
+                color,
+                prev_idx,
+                curr_idx,
             ));
-
-            if let Some(slot) = curr_kf_map_assoc.get_mut(curr_idx) {
-                *slot = Some(mp_idx);
-                n_added += 1;
-            }
         }
 
-        n_added
+        let kf_idx = curr_kf.frame.idx;
+        self.map
+            .add_triangulated_points(None, curr_kf, &points, kf_idx)
     }
 }

--- a/examples/orb_slam/src/utils.rs
+++ b/examples/orb_slam/src/utils.rs
@@ -77,21 +77,26 @@ pub fn log_camera_to_rerun(
 
 /// Log active map points as a 3D point cloud.
 pub fn log_map_points_to_rerun(rec: &rerun::RecordingStream, map_points: &[MapPoint]) {
-    let positions: Vec<rerun::Position3D> = map_points
+    let (positions, colors): (Vec<_>, Vec<_>) = map_points
         .iter()
         .filter(|mp| !mp.culled)
         .map(|mp| {
-            rerun::Position3D::new(
-                mp.position.x as f32,
-                mp.position.y as f32,
-                mp.position.z as f32,
+            (
+                rerun::Position3D::new(
+                    mp.position.x as f32,
+                    mp.position.y as f32,
+                    mp.position.z as f32,
+                ),
+                rerun::Color::from_rgb(mp.color[0], mp.color[1], mp.color[2]),
             )
         })
-        .collect();
+        .unzip();
     if !positions.is_empty() {
         rec.log(
             "world/map_points",
-            &rerun::Points3D::new(positions).with_radii([rerun::Radius::new_scene_units(0.01)]),
+            &rerun::Points3D::new(positions)
+                .with_colors(colors)
+                .with_radii([rerun::Radius::new_scene_units(0.01)]),
         )
         .ok();
     }

--- a/src/estimation/map_projection/mod.rs
+++ b/src/estimation/map_projection/mod.rs
@@ -393,9 +393,7 @@ impl MapProjectionEstimator {
             }
 
             let p_cam = pose_world_to_cam.transform_point(&mp.position);
-            let Ok(pixel) = camera
-                .project_to_image(&p_cam, config.min_depth, image_size)
-            else {
+            let Ok(pixel) = camera.project_to_image(&p_cam, config.min_depth, image_size) else {
                 continue;
             };
             let u = pixel.x as f32;

--- a/src/estimation/map_projection/mod.rs
+++ b/src/estimation/map_projection/mod.rs
@@ -111,17 +111,12 @@ pub enum MapProjectionRejectReason {
 /// Estimates the camera pose by projecting map points into the current frame,
 /// matching via ORB descriptors, and solving PnP.
 pub struct MapProjectionEstimator {
-    camera: PinholeCamera,
     config: MapProjectionConfig,
 }
 
 impl MapProjectionEstimator {
-    pub fn new(camera: PinholeCamera, config: MapProjectionConfig) -> Self {
-        Self { camera, config }
-    }
-
-    pub fn camera(&self) -> &PinholeCamera {
-        &self.camera
+    pub fn new(config: MapProjectionConfig) -> Self {
+        Self { config }
     }
 
     pub fn config(&self) -> &MapProjectionConfig {
@@ -135,12 +130,13 @@ impl MapProjectionEstimator {
         candidate_pose: &Pose3d,
         pose_before_tracking: &Pose3d,
         map: &Map,
+        camera: &PinholeCamera,
         current_keyframe_idx: Option<usize>,
     ) -> Result<Estimate, MapProjectionRejectReason> {
         let pnp = &self.config.pnp;
 
         let (projection_matches, curr_keypoints_undist, grid) =
-            self.match_map_to_frame(map.map_points(), frame, candidate_pose);
+            self.match_map_to_frame(map.map_points(), frame, candidate_pose, camera);
 
         // Shared logic: try_track → refine_pose → Estimate, or propagate rejection.
         let try_track_and_refine = |correspondences: Vec<(usize, usize)>,
@@ -151,6 +147,7 @@ impl MapProjectionEstimator {
                     map.map_points(),
                     &correspondences,
                     &curr_keypoints_undist,
+                    camera,
                     pose_init,
                 )
                 .ok_or(MapProjectionRejectReason::PnpFailed)?;
@@ -166,6 +163,7 @@ impl MapProjectionEstimator {
                 &frame.features.descriptors,
                 &grid,
                 frame.image_size,
+                camera,
                 &pose,
             ) {
                 matches = local.matches;
@@ -236,6 +234,7 @@ impl MapProjectionEstimator {
         curr_descriptors: &[[u8; 32]],
         grid: &KeypointGrid,
         image_size: ImageSize,
+        camera: &PinholeCamera,
         pose_init: &Pose3d,
     ) -> Option<Estimate> {
         let current_kf = current_kf_idx.and_then(|ki| map.get_keyframe(ki));
@@ -251,6 +250,7 @@ impl MapProjectionEstimator {
             curr_keypoints_undist,
             curr_descriptors,
             grid,
+            camera,
             pose_init,
             image_size,
             self.config.local_projection,
@@ -276,6 +276,7 @@ impl MapProjectionEstimator {
             map.map_points(),
             &global_matches,
             curr_keypoints_undist,
+            camera,
             pose_init,
         )?;
         Some(Estimate {
@@ -291,6 +292,7 @@ impl MapProjectionEstimator {
         map_points: &[MapPoint],
         correspondences: &[(usize, usize)],
         keypoints_undist: &[[f32; 2]],
+        camera: &PinholeCamera,
         pose_init: &Pose3d,
     ) -> Option<(Pose3d, usize)> {
         let mut points_world = Vec::with_capacity(correspondences.len());
@@ -304,7 +306,7 @@ impl MapProjectionEstimator {
         pnp::solve_pnp(
             &points_world,
             &points_image,
-            &self.camera,
+            camera,
             pose_init,
             &self.config.pnp,
         )
@@ -317,6 +319,7 @@ impl MapProjectionEstimator {
         map_points: &[MapPoint],
         frame: &Frame,
         pose: &Pose3d,
+        camera: &PinholeCamera,
     ) -> (Vec<(usize, usize)>, Vec<[f32; 2]>, KeypointGrid) {
         const KEYPOINT_GRID_CELL_SIZE: f32 = 64.0;
         const MIN_MATCHES_BEFORE_WIDE: usize = 20;
@@ -326,7 +329,7 @@ impl MapProjectionEstimator {
             .keypoints_xy
             .iter()
             .map(|kp| {
-                let p = self.camera.undistort(kp[0] as f64, kp[1] as f64);
+                let p = camera.undistort(kp[0] as f64, kp[1] as f64);
                 [p.x as f32, p.y as f32]
             })
             .collect();
@@ -344,6 +347,7 @@ impl MapProjectionEstimator {
             &keypoints_undist,
             &frame.features.descriptors,
             &grid,
+            camera,
             pose,
             frame.image_size,
             config,
@@ -355,6 +359,7 @@ impl MapProjectionEstimator {
                 &keypoints_undist,
                 &frame.features.descriptors,
                 &grid,
+                camera,
                 pose,
                 frame.image_size,
                 ProjectionMatchConfig {
@@ -374,6 +379,7 @@ impl MapProjectionEstimator {
         keypoints_xy: &[[f32; 2]],
         descriptors: &[[u8; 32]],
         grid: &KeypointGrid,
+        camera: &PinholeCamera,
         pose_world_to_cam: &Pose3d,
         image_size: ImageSize,
         config: ProjectionMatchConfig,
@@ -387,8 +393,7 @@ impl MapProjectionEstimator {
             }
 
             let p_cam = pose_world_to_cam.transform_point(&mp.position);
-            let Ok(pixel) = self
-                .camera
+            let Ok(pixel) = camera
                 .project_to_image(&p_cam, config.min_depth, image_size)
             else {
                 continue;
@@ -445,8 +450,8 @@ mod matching_tests {
     use super::*;
     use kornia_algebra::{Mat3F64, Vec3F64};
 
-    fn make_test_estimator(camera: PinholeCamera) -> MapProjectionEstimator {
-        MapProjectionEstimator::new(camera, MapProjectionConfig::default())
+    fn make_test_estimator() -> MapProjectionEstimator {
+        MapProjectionEstimator::new(MapProjectionConfig::default())
     }
 
     fn test_camera() -> PinholeCamera {
@@ -464,12 +469,14 @@ mod matching_tests {
 
     #[test]
     fn test_match_by_projection_simple() {
-        let estimator = make_test_estimator(test_camera());
+        let estimator = make_test_estimator();
+        let camera = test_camera();
 
         let desc_a = [0u8; 32];
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, 5.0),
             descriptor: desc_a,
+            color: [0; 3],
             keyframe_idx: 0,
             n_visible: 0,
             n_found: 0,
@@ -487,6 +494,7 @@ mod matching_tests {
             &keypoints_xy,
             &descriptors,
             &grid,
+            &camera,
             &pose,
             ImageSize {
                 width: 640,
@@ -505,11 +513,13 @@ mod matching_tests {
 
     #[test]
     fn test_behind_camera_rejected() {
-        let estimator = make_test_estimator(test_camera());
+        let estimator = make_test_estimator();
+        let camera = test_camera();
 
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, -5.0),
             descriptor: [0u8; 32],
+            color: [0; 3],
             keyframe_idx: 0,
             n_visible: 0,
             n_found: 0,
@@ -525,6 +535,7 @@ mod matching_tests {
             &keypoints_xy,
             &descriptors,
             &grid,
+            &camera,
             &Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO),
             ImageSize {
                 width: 640,
@@ -542,11 +553,13 @@ mod matching_tests {
 
     #[test]
     fn test_high_hamming_rejected() {
-        let estimator = make_test_estimator(test_camera());
+        let estimator = make_test_estimator();
+        let camera = test_camera();
 
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, 5.0),
             descriptor: [0u8; 32],
+            color: [0; 3],
             keyframe_idx: 0,
             n_visible: 0,
             n_found: 0,
@@ -562,6 +575,7 @@ mod matching_tests {
             &keypoints_xy,
             &descriptors,
             &grid,
+            &camera,
             &Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO),
             ImageSize {
                 width: 640,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -19,4 +19,6 @@ pub struct Frame {
     pub pose_world_to_cam: Pose3d,
     /// Image dimensions.
     pub image_size: ImageSize,
+    /// Pixel color sampled at each keypoint location (one [u8; 3] per keypoint).
+    pub keypoint_colors: Vec<[u8; 3]>,
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -22,7 +22,7 @@
 //!      * push_map_point
 //!      * build_local_map_points
 //!      * cull
-//!      * optimize
+//!      * run_local_ba
 //! ```
 
 use std::collections::{HashMap, HashSet};
@@ -88,6 +88,8 @@ pub struct MapPoint {
     pub position: Vec3F64,
     /// ORB descriptor used for projection-guided matching.
     pub descriptor: [u8; 32],
+    /// Pixel color sampled at the keypoint that created this point.
+    pub color: [u8; 3],
     /// Index of the keyframe that first observed this point.
     pub keyframe_idx: usize,
     /// Number of frames where this point was in the camera frustum.
@@ -100,10 +102,16 @@ pub struct MapPoint {
 
 impl MapPoint {
     /// Creates a fresh active map point.
-    pub fn new(position: Vec3F64, descriptor: [u8; 32], keyframe_idx: usize) -> Self {
+    pub fn new(
+        position: Vec3F64,
+        descriptor: [u8; 32],
+        color: [u8; 3],
+        keyframe_idx: usize,
+    ) -> Self {
         Self {
             position,
             descriptor,
+            color,
             keyframe_idx,
             n_visible: 1,
             n_found: 1,
@@ -169,6 +177,34 @@ impl Map {
         } else {
             self.keyframes.push(keyframe);
         }
+    }
+
+    /// Inserts triangulated 3D points as map points and associates them to keyframes.
+    ///
+    /// For each entry, creates a `MapPoint` and associates it with `curr_kf`.
+    /// If `prev_kf` is provided, associates it there too.
+    /// Inserts triangulated 3D points as map points and associates them to keyframes.
+    ///
+    /// For each entry, creates a `MapPoint` and associates it with `curr_kf`.
+    /// If `prev_kf` is provided, associates it there too.
+    pub fn add_triangulated_points(
+        &mut self,
+        prev_kf: Option<&mut Keyframe>,
+        curr_kf: &mut Keyframe,
+        points: &[(Vec3F64, [u8; 32], [u8; 3], usize, usize)], // (position, descriptor, color, prev_desc_idx, curr_desc_idx)
+        keyframe_idx: usize,
+    ) -> usize {
+        let first_mp_idx = self.map_points.len();
+        for (i, &(position, descriptor, color, _, curr_desc_idx)) in points.iter().enumerate() {
+            self.push_map_point(MapPoint::new(position, descriptor, color, keyframe_idx));
+            curr_kf.associate_map_point(curr_desc_idx, first_mp_idx + i);
+        }
+        if let Some(prev) = prev_kf {
+            for (i, &(_, _, _, prev_desc_idx, _)) in points.iter().enumerate() {
+                prev.associate_map_point(prev_desc_idx, first_mp_idx + i);
+            }
+        }
+        points.len()
     }
 
     /// Appends a map point and returns its index.
@@ -353,7 +389,7 @@ impl Map {
     /// Collects the last N active keyframes, gathers observations (undistorting keypoints
     /// via camera), calls `kornia_3d::ba::bundle_adjust`, and writes back optimized poses
     /// and point positions.
-    pub fn optimize(&mut self, camera: &PinholeCamera) {
+    pub fn run_local_ba(&mut self, camera: &PinholeCamera) {
         const MAX_ACTIVE_KFS: usize = 3;
         const MIN_OBSERVATIONS: usize = 8;
 
@@ -451,15 +487,12 @@ mod tests {
     use kornia_imgproc::features::OrbFeatures;
 
     fn test_frame(idx: usize, descriptors: Vec<[u8; 32]>) -> Frame {
+        let n = descriptors.len();
         Frame {
             idx,
             features: OrbFeatures {
-                keypoints_xy: descriptors
-                    .iter()
-                    .enumerate()
-                    .map(|(i, _)| [i as f32, i as f32])
-                    .collect(),
-                orientations: vec![0.0; descriptors.len()],
+                keypoints_xy: (0..n).map(|i| [i as f32, i as f32]).collect(),
+                orientations: vec![0.0; n],
                 descriptors,
             },
             pose_world_to_cam: Pose3d::IDENTITY,
@@ -467,6 +500,7 @@ mod tests {
                 width: 640,
                 height: 480,
             },
+            keypoint_colors: vec![[0; 3]; n],
         }
     }
 
@@ -499,7 +533,7 @@ mod tests {
 
     #[test]
     fn map_point_new_sets_active_defaults() {
-        let mp = MapPoint::new(Vec3F64::new(1.0, 2.0, 3.0), [9u8; 32], 5);
+        let mp = MapPoint::new(Vec3F64::new(1.0, 2.0, 3.0), [9u8; 32], [0; 3], 5);
 
         assert_eq!(mp.position, Vec3F64::new(1.0, 2.0, 3.0));
         assert_eq!(mp.descriptor, [9u8; 32]);
@@ -511,7 +545,7 @@ mod tests {
 
     #[test]
     fn map_point_tracking_helpers_work() {
-        let mut mp = MapPoint::new(Vec3F64::new(0.0, 0.0, 1.0), [0u8; 32], 0);
+        let mut mp = MapPoint::new(Vec3F64::new(0.0, 0.0, 1.0), [0u8; 32], [0; 3], 0);
         mp.n_visible = 10;
         mp.n_found = 4;
 
@@ -549,9 +583,9 @@ mod tests {
         let mut map = Map::new();
 
         let first_idx =
-            map.push_map_point(MapPoint::new(Vec3F64::new(0.0, 0.0, 1.0), [0u8; 32], 0));
+            map.push_map_point(MapPoint::new(Vec3F64::new(0.0, 0.0, 1.0), [0u8; 32], [0; 3], 0));
         let second_idx =
-            map.push_map_point(MapPoint::new(Vec3F64::new(1.0, 0.0, 1.0), [1u8; 32], 0));
+            map.push_map_point(MapPoint::new(Vec3F64::new(1.0, 0.0, 1.0), [1u8; 32], [0; 3], 0));
 
         assert_eq!(first_idx, 0);
         assert_eq!(second_idx, 1);
@@ -563,9 +597,9 @@ mod tests {
         let mut map = Map::new();
 
         let first_idx =
-            map.push_map_point(MapPoint::new(Vec3F64::new(0.0, 0.0, 5.0), [0u8; 32], 0));
+            map.push_map_point(MapPoint::new(Vec3F64::new(0.0, 0.0, 5.0), [0u8; 32], [0; 3], 0));
         let second_idx =
-            map.push_map_point(MapPoint::new(Vec3F64::new(1.0, 0.0, 5.0), [1u8; 32], 0));
+            map.push_map_point(MapPoint::new(Vec3F64::new(1.0, 0.0, 5.0), [1u8; 32], [0; 3], 0));
         map.map_points_mut()[first_idx].n_visible = 10;
         map.map_points_mut()[first_idx].n_found = 1;
         map.map_points_mut()[second_idx].n_visible = 10;


### PR DESCRIPTION
## Summary
- Move `PinholeCamera` ownership from `MapProjectionEstimator` to `Pipeline`, eliminating indirect `self.estimator.camera()` access
- Build `Keyframe` before `grow_map_points_from_keyframe_pair`, removing the separate `curr_kf_map_assoc` vector and reducing the function from 8 args to 4
- Extract `Map::add_triangulated_points` to deduplicate the map point insertion loop shared by `build_initial_map` and `grow_map_points_from_keyframe_pair`
- Rename `Map::optimize` → `Map::run_local_ba` for clarity
- Add `color: [u8; 3]` to `MapPoint` and `keypoint_colors` to `Frame`, sampled from the grayscale image at keypoint locations, for colored Rerun point cloud visualization

## Test plan
- [x] All 17 unit tests pass
- [x] Run on EuRoC MH_01_easy with `--rerun-stream` and verify colored point cloud renders correctly