### PR TITLE
feat: move mapping to a dedicated thread

### DIFF
--- a/examples/orb_slam/src/config.rs
+++ b/examples/orb_slam/src/config.rs
@@ -8,6 +8,7 @@ pub struct PipelineConfig {
     pub map_projection: MapProjectionConfig,
     pub keyframe_policy: KeyframePolicy,
     pub enable_local_ba: bool,
+    pub mapping_queue_capacity: usize,
 }
 
 impl Default for PipelineConfig {
@@ -27,6 +28,7 @@ impl Default for PipelineConfig {
             map_projection: MapProjectionConfig::default(),
             keyframe_policy: KeyframePolicy::default(),
             enable_local_ba: true,
+            mapping_queue_capacity: 4,
         }
     }
 }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -149,7 +149,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(ref rec) = rec {
             log_trajectory_to_rerun(rec, &trajectory);
             log_camera_to_rerun(rec, &result.pose_world_to_cam, &camera, image_size);
-            log_map_points_to_rerun(rec, system.map_points());
+            let map_points = system.map_points();
+            log_map_points_to_rerun(rec, &map_points);
         }
     }
 

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -3,6 +3,11 @@
 //! This example keeps the runtime flow in one file so it can be read from top
 //! to bottom in the same order frames move through the system.
 
+use std::collections::VecDeque;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
+use std::thread::{self, JoinHandle};
+
 use crate::config::PipelineConfig;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
@@ -29,25 +34,38 @@ pub struct Pipeline {
     two_view_init_config: TwoViewInitConfig,
     // Keyframe insertion policy
     keyframe_policy: KeyframePolicy,
-    // Enable local bundle adjustment after keyframe insertion
-    enable_local_ba: bool,
-    // Map object
-    map: Map,
+    // Shared map object
+    map: Arc<RwLock<Map>>,
     // System state
     state: SystemState,
+    // Dedicated mapping worker
+    mapping_worker: MappingWorker,
+    // Mapping updates consumed by tracking
+    mapping_updates: Receiver<MappingUpdate>,
 }
 
 impl Pipeline {
     /// Creates a new pipeline with identity pose.
     pub fn new(camera: PinholeCamera, config: PipelineConfig) -> Self {
+        let map = Arc::new(RwLock::new(Map::new()));
+        let (mapping_updates, mapping_worker) = MappingWorker::spawn(
+            Arc::clone(&map),
+            camera.clone(),
+            config.two_view_init.match_config,
+            config.two_view_init.estimation_config.clone(),
+            config.enable_local_ba,
+            config.mapping_queue_capacity,
+        );
+
         Self {
             estimator: MapProjectionEstimator::new(camera.clone(), config.map_projection),
             camera,
             two_view_init_config: config.two_view_init,
             keyframe_policy: config.keyframe_policy,
-            enable_local_ba: config.enable_local_ba,
-            map: Map::new(),
+            map,
             state: SystemState::new(),
+            mapping_worker,
+            mapping_updates,
         }
     }
 
@@ -60,20 +78,34 @@ impl Pipeline {
     }
 
     /// Returns all persistent map points.
-    pub fn map_points(&self) -> &[MapPoint] {
-        self.map.map_points()
+    pub fn map_points(&self) -> Vec<MapPoint> {
+        self.map
+            .read()
+            .expect("map read lock poisoned")
+            .map_points()
+            .to_vec()
     }
 
     /// Returns the index of the current reference keyframe, if tracking has one.
     pub fn current_keyframe_idx(&self) -> Option<usize> {
         self.state
             .current_keyframe_idx
-            .and_then(|ki| self.map.get_keyframe(ki).map(|kf| kf.frame.idx))
+            .and_then(|ki| {
+                self.map
+                    .read()
+                    .expect("map read lock poisoned")
+                    .get_keyframe(ki)
+                    .map(|kf| kf.frame.idx)
+            })
     }
 
     /// Returns the total number of persistent map points.
     pub fn num_map_points(&self) -> usize {
-        self.map.map_points().len()
+        self.map
+            .read()
+            .expect("map read lock poisoned")
+            .map_points()
+            .len()
     }
 
     fn bootstrap_step(&mut self, mut curr_frame: Frame) -> TrackingResult {
@@ -118,6 +150,7 @@ impl Pipeline {
         let current_kf = Keyframe::from_frame(curr_frame);
         let curr_idx = current_kf.frame.idx;
 
+        self.mapping_worker.clear_pending();
         self.build_initial_map(
             reference_kf,
             current_kf,
@@ -180,18 +213,22 @@ impl Pipeline {
             let p_world = cam_to_world_transform.transform_point(&(*p_cam / depth_scale));
             let mp_idx =
                 self.map
+                    .write()
+                    .expect("map write lock poisoned")
                     .push_map_point(MapPoint::new(p_world, descriptor, reference_kf.frame.idx));
             reference_kf.associate_map_point(reference_desc_idx, mp_idx);
             current_kf.associate_map_point(current_desc_idx, mp_idx);
             added += 1;
         }
 
-        self.map.upsert_keyframe(reference_kf);
-        self.map.upsert_keyframe(current_kf);
+        let mut map = self.map.write().expect("map write lock poisoned");
+        map.upsert_keyframe(reference_kf);
+        map.upsert_keyframe(current_kf);
         added
     }
 
     fn tracking_step(&mut self, frame: Frame) -> TrackingResult {
+        self.apply_mapping_updates();
         let pose_before_tracking = self.state.pose_world_to_cam;
         let image_size = frame.image_size;
 
@@ -201,13 +238,16 @@ impl Pipeline {
             self.state.pose_world_to_cam
         };
 
-        let result = self.estimator.estimate_pose(
-            &frame,
-            &candidate_pose,
-            &pose_before_tracking,
-            &self.map,
-            self.state.current_keyframe_idx,
-        );
+        let result = {
+            let map = self.map.read().expect("map read lock poisoned");
+            self.estimator.estimate_pose(
+                &frame,
+                &candidate_pose,
+                &pose_before_tracking,
+                &map,
+                self.state.current_keyframe_idx,
+            )
+        };
 
         let (mut status, matches, tracked_inliers) = match result {
             Ok(estimate) => {
@@ -222,8 +262,13 @@ impl Pipeline {
         if status == TrackingStatus::Tracked {
             let visible =
                 self.map
+                    .read()
+                    .expect("map read lock poisoned")
                     .map_points_in_frustum(&self.camera, &candidate_pose, image_size);
-            self.map.update_observation_counts(&visible, &matches);
+            self.map
+                .write()
+                .expect("map write lock poisoned")
+                .update_observation_counts(&visible, &matches);
 
             if self.try_insert_keyframe(&frame, tracked_inliers, &matches) {
                 status = TrackingStatus::KeyframeAccepted;
@@ -252,12 +297,14 @@ impl Pipeline {
         tracked_inliers: usize,
         matches: &[(usize, usize)],
     ) -> bool {
-        let n_ref_map_points = self
-            .state
-            .current_keyframe_idx
-            .and_then(|ki| self.map.get_keyframe(ki))
-            .map(|kf| kf.num_associated_points())
-            .unwrap_or(0);
+        let n_ref_map_points = {
+            let map = self.map.read().expect("map read lock poisoned");
+            self.state
+                .current_keyframe_idx
+                .and_then(|ki| map.get_keyframe(ki))
+                .map(|kf| kf.num_associated_points())
+                .unwrap_or(0)
+        };
 
         if !self.keyframe_policy.should_insert(
             frame.idx,
@@ -268,12 +315,7 @@ impl Pipeline {
             return false;
         }
 
-        let Some(prev_kf) = self
-            .state
-            .current_keyframe_idx
-            .and_then(|ki| self.map.get_keyframe(ki))
-            .cloned()
-        else {
+        let Some(prev_kf_idx) = self.state.current_keyframe_idx else {
             return false;
         };
 
@@ -284,20 +326,6 @@ impl Pipeline {
             }
         }
 
-        let enable_local_ba = self.enable_local_ba;
-        let pose_world_to_cam = self.state.pose_world_to_cam;
-        let match_config = self.two_view_init_config.match_config;
-        let estimation_config = self.two_view_init_config.estimation_config.clone();
-        self.grow_map_points_from_keyframe_pair(
-            frame.idx,
-            &prev_kf,
-            &frame.features,
-            &mut curr_kf_map_assoc,
-            &pose_world_to_cam,
-            match_config,
-            &estimation_config,
-        );
-
         let mut kf = Keyframe::from_frame(Frame {
             idx: frame.idx,
             features: frame.features.clone(),
@@ -305,24 +333,33 @@ impl Pipeline {
             image_size: frame.image_size,
         });
         kf.map_point_by_desc_idx = curr_kf_map_assoc;
-        self.map.upsert_keyframe(kf);
+        self.map
+            .write()
+            .expect("map write lock poisoned")
+            .upsert_keyframe(kf);
         self.state.current_keyframe_idx = Some(frame.idx);
         self.state.last_keyframe_idx = Some(frame.idx);
 
-        if enable_local_ba {
-            self.map.optimize(&self.camera);
-            if let Some(newest_kf) = self.map.keyframes().last() {
-                self.state.pose_world_to_cam = newest_kf.frame.pose_world_to_cam;
+        self.mapping_worker.enqueue(MappingTask {
+            previous_keyframe_idx: prev_kf_idx,
+            current_keyframe_idx: frame.idx,
+        });
+        true
+    }
+
+    fn apply_mapping_updates(&mut self) {
+        while let Ok(update) = self.mapping_updates.try_recv() {
+            if self.state.current_keyframe_idx == Some(update.current_keyframe_idx) {
+                self.state.pose_world_to_cam = update.pose_world_to_cam;
+                self.state.velocity = None;
             }
         }
-
-        self.map.cull();
-        true
     }
 
     #[allow(clippy::too_many_arguments)]
     fn grow_map_points_from_keyframe_pair(
-        &mut self,
+        map: &mut Map,
+        camera: &PinholeCamera,
         curr_kf_idx: usize,
         prev_kf: &Keyframe,
         curr_features: &OrbFeatures,
@@ -334,7 +371,6 @@ impl Pipeline {
         const MIN_GROWTH_MATCHES: usize = 20;
         const MIN_GROWTH_INLIERS: usize = 15;
 
-        let camera = &self.camera;
         let triangulation_config = &two_view_config.triangulation;
         let matches = match_orb_descriptors(
             &prev_kf.frame.features.orientations,
@@ -412,7 +448,7 @@ impl Pipeline {
                 continue;
             }
 
-            let mp_idx = self.map.push_map_point(MapPoint::new(
+            let mp_idx = map.push_map_point(MapPoint::new(
                 tp.position,
                 curr_features.descriptors[curr_idx],
                 curr_kf_idx,
@@ -425,5 +461,230 @@ impl Pipeline {
         }
 
         n_added
+    }
+}
+
+impl Drop for Pipeline {
+    fn drop(&mut self) {
+        self.mapping_worker.shutdown();
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MappingTask {
+    previous_keyframe_idx: usize,
+    current_keyframe_idx: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MappingUpdate {
+    current_keyframe_idx: usize,
+    pose_world_to_cam: Pose3d,
+}
+
+#[derive(Default)]
+struct MappingQueueState {
+    pending: VecDeque<MappingTask>,
+    shutdown: bool,
+}
+
+struct MappingQueue {
+    capacity: usize,
+    state: Mutex<MappingQueueState>,
+    ready: Condvar,
+}
+
+impl MappingQueue {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            state: Mutex::new(MappingQueueState::default()),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn push(&self, task: MappingTask) {
+        let mut state = self.state.lock().expect("mapping queue lock poisoned");
+        if state.pending.len() == self.capacity {
+            state.pending.pop_front();
+        }
+        state.pending.push_back(task);
+        self.ready.notify_one();
+    }
+
+    fn pop(&self) -> Option<MappingTask> {
+        let mut state = self.state.lock().expect("mapping queue lock poisoned");
+        loop {
+            if let Some(task) = state.pending.pop_front() {
+                return Some(task);
+            }
+            if state.shutdown {
+                return None;
+            }
+            state = self
+                .ready
+                .wait(state)
+                .expect("mapping queue wait poisoned");
+        }
+    }
+
+    fn clear(&self) {
+        self.state
+            .lock()
+            .expect("mapping queue lock poisoned")
+            .pending
+            .clear();
+    }
+
+    fn shutdown(&self) {
+        let mut state = self.state.lock().expect("mapping queue lock poisoned");
+        state.shutdown = true;
+        self.ready.notify_all();
+    }
+}
+
+struct MappingWorker {
+    queue: Arc<MappingQueue>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl MappingWorker {
+    fn spawn(
+        map: Arc<RwLock<Map>>,
+        camera: PinholeCamera,
+        match_config: OrbMatchConfig,
+        two_view_config: TwoViewConfig,
+        enable_local_ba: bool,
+        queue_capacity: usize,
+    ) -> (Receiver<MappingUpdate>, Self) {
+        let queue = Arc::new(MappingQueue::new(queue_capacity));
+        let queue_for_thread = Arc::clone(&queue);
+        let (updates_tx, updates_rx) = mpsc::channel();
+
+        let thread = thread::Builder::new()
+            .name("mapping".to_owned())
+            .spawn(move || {
+                while let Some(task) = queue_for_thread.pop() {
+                    run_mapping_task(
+                        &map,
+                        &camera,
+                        match_config,
+                        &two_view_config,
+                        enable_local_ba,
+                        task,
+                        &updates_tx,
+                    );
+                }
+            })
+            .expect("failed to spawn mapping thread");
+
+        (
+            updates_rx,
+            Self {
+                queue,
+                thread: Some(thread),
+            },
+        )
+    }
+
+    fn enqueue(&self, task: MappingTask) {
+        self.queue.push(task);
+    }
+
+    fn clear_pending(&self) {
+        self.queue.clear();
+    }
+
+    fn shutdown(&mut self) {
+        self.queue.shutdown();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_mapping_task(
+    map: &Arc<RwLock<Map>>,
+    camera: &PinholeCamera,
+    match_config: OrbMatchConfig,
+    two_view_config: &TwoViewConfig,
+    enable_local_ba: bool,
+    task: MappingTask,
+    updates_tx: &Sender<MappingUpdate>,
+) {
+    let mut working_map = map.read().expect("map read lock poisoned").clone();
+    let base_map_point_count = working_map.map_points().len();
+
+    let Some(prev_kf) = working_map.get_keyframe(task.previous_keyframe_idx).cloned() else {
+        return;
+    };
+    let Some(curr_kf) = working_map.get_keyframe(task.current_keyframe_idx).cloned() else {
+        return;
+    };
+
+    let mut curr_kf_map_assoc = curr_kf.map_point_by_desc_idx.clone();
+    Pipeline::grow_map_points_from_keyframe_pair(
+        &mut working_map,
+        camera,
+        task.current_keyframe_idx,
+        &prev_kf,
+        &curr_kf.frame.features,
+        &mut curr_kf_map_assoc,
+        &curr_kf.frame.pose_world_to_cam,
+        match_config,
+        two_view_config,
+    );
+
+    let mut updated_kf = curr_kf;
+    updated_kf.map_point_by_desc_idx = curr_kf_map_assoc;
+    working_map.upsert_keyframe(updated_kf);
+
+    if enable_local_ba {
+        working_map.optimize(camera);
+    }
+    working_map.cull();
+
+    let optimized_pose = working_map
+        .get_keyframe(task.current_keyframe_idx)
+        .map(|kf| kf.frame.pose_world_to_cam);
+
+    let mut shared_map = map.write().expect("map write lock poisoned");
+    merge_mapping_result(&mut shared_map, &working_map, base_map_point_count);
+
+    if let Some(pose_world_to_cam) = optimized_pose {
+        let _ = updates_tx.send(MappingUpdate {
+            current_keyframe_idx: task.current_keyframe_idx,
+            pose_world_to_cam,
+        });
+    }
+}
+
+fn merge_mapping_result(shared_map: &mut Map, working_map: &Map, base_map_point_count: usize) {
+    for (mp_idx, updated_mp) in working_map.map_points().iter().enumerate() {
+        if mp_idx < base_map_point_count {
+            if let Some(shared_mp) = shared_map.map_points_mut().get_mut(mp_idx) {
+                shared_mp.position = updated_mp.position;
+                shared_mp.culled = updated_mp.culled;
+            }
+            continue;
+        }
+
+        if mp_idx >= shared_map.map_points().len() {
+            shared_map.push_map_point(updated_mp.clone());
+        } else if let Some(shared_mp) = shared_map.map_points_mut().get_mut(mp_idx) {
+            *shared_mp = updated_mp.clone();
+        }
+    }
+
+    for working_kf in working_map.keyframes() {
+        let Some(shared_kf) = shared_map
+            .keyframes_mut()
+            .iter_mut()
+            .find(|kf| kf.frame.idx == working_kf.frame.idx)
+        else {
+            continue;
+        };
+        shared_kf.frame.pose_world_to_cam = working_kf.frame.pose_world_to_cam;
+        shared_kf.map_point_by_desc_idx = working_kf.map_point_by_desc_idx.clone();
     }
 }


### PR DESCRIPTION
  Refs #9

  ## Summary
  This PR moves mapping off the main tracking path so `process_frame` does not sit and wait for local bundle adjustment.

  ## What changed
  - tracking keeps doing pose estimation and keyframe decisions
  - once a keyframe is accepted, the heavier mapping work is pushed to a dedicated mapping thread
  - the mapping thread handles map growth, local BA, and culling
  - added a bounded queue for pending keyframes so the system does not pile up work if mapping falls behind
  - BA updates are fed back into tracking state
  - the map is now shared safely between tracking and mapping
  - expensive mapping work runs on a snapshot, then merges back into the live map with a short lock

  ## Verification
  - `cargo test --lib`
  - `cargo check --manifest-path examples/orb_slam/Cargo.toml`