### PR TITLE
chore: update kornia-rs deps to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6414,7 +6414,6 @@ dependencies = [
  "kornia-image",
  "kornia-imgproc",
  "kornia-io",
- "kornia-sensors",
  "kornia-slam",
  "kornia-tensor",
  "rerun",

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ Beyond serving spatial state to external agents, kornia-slam is exploring the id
 
 The current runnable package is the standalone ORB-SLAM example in [examples/orb_slam/README.md](examples/orb_slam/README.md).
 
-Temporary dependency note: until [kornia-rs PR #803](https://github.com/kornia/kornia-rs/pull/803) is merged and released, this repository depends on unpublished `kornia-rs` crates from the `feat/slam-utils` branch. Cargo fetches them automatically on first build.
-
 ### Local checks
 
 The current baseline checks for this repository are:

--- a/crates/kornia-slam/Cargo.toml
+++ b/crates/kornia-slam/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 description = "Spatial runtime for real-time pose estimation, mapping, and agent interaction."
 
 [dependencies]
-kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
+kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 thiserror = "2"

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -8,12 +8,12 @@ description = "ORB-SLAM example for kornia-slam"
 [dependencies]
 argh = "0.1"
 kornia-slam = { path = "../../crates/kornia-slam" }
-kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-io = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
-kornia-tensor = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
+kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-io = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-tensor = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 rerun = "0.29.2"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/examples/orb_slam/README.md
+++ b/examples/orb_slam/README.md
@@ -2,8 +2,6 @@
 
 This package is the current runnable slice of `kornia-slam`: a monocular ORB-based SLAM pipeline over EuRoC MAV image sequences with optional Rerun visualization.
 
-Temporary dependency note: until [kornia-rs PR #803](https://github.com/kornia/kornia-rs/pull/803) is merged and released, this package depends on unpublished `kornia-rs` crates from the `feat/slam-utils` branch. Cargo fetches them automatically on first build.
-
 ## Dataset setup
 
 Download the EuRoC MAV dataset from the OpenVINS dataset guide:


### PR DESCRIPTION
## Summary
- Switch all `kornia-rs` git dependencies from `feat/slam-utils` branch to `main` now that PR #803 is merged
- Remove temporary dependency notes from READMEs

## Test plan
- [ ] `cargo build` succeeds with deps from `main`
- [ ] `cargo test` passes