### PR TITLE
feat: fuse IMU — inertial local BA and preintegration covariance viz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6415,6 +6415,7 @@ dependencies = [
  "kornia-image",
  "kornia-imgproc",
  "kornia-io",
+ "kornia-sensors",
  "kornia-slam",
  "kornia-tensor",
  "rerun",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4954,6 +4954,7 @@ dependencies = [
  "kornia-algebra",
  "kornia-image",
  "kornia-imgproc",
+ "kornia-sensors",
  "thiserror 2.0.18",
 ]
 

--- a/crates/kornia-sensors/src/imu.rs
+++ b/crates/kornia-sensors/src/imu.rs
@@ -50,6 +50,7 @@ pub struct ImuCalib {
 /// Also propagates covariance matrices tracking how uncertainty grows:
 /// - 9×9 navigation covariance in tangent space [δrot(3), δvel(3), δpos(3)]
 /// - 6×6 bias covariance [δbias_gyro(3), δbias_accel(3)] (decoupled, grows linearly)
+#[derive(Debug, Clone)]
 pub struct PreintegratedImu {
     /// Accumulated rotation ∈ SO(3).
     pub delta_rotation: Mat3F64,
@@ -68,6 +69,17 @@ pub struct PreintegratedImu {
     /// 6×6 bias covariance [bias_gyro, bias_accel], stored column-major.
     /// Grows by σ²·dt each step (random walk).
     pub bias_covariance: [f64; 36],
+    /// Jacobian of ΔR w.r.t. gyro bias (3×3, column-major).
+    /// Used for first-order bias correction: ΔR' = ΔR · Exp(j_r_gyro · δb_g)
+    pub j_r_gyro: Mat3F64,
+    /// Jacobian of Δv w.r.t. gyro bias (3×3, column-major).
+    pub j_v_gyro: Mat3F64,
+    /// Jacobian of Δv w.r.t. accel bias (3×3, column-major).
+    pub j_v_accel: Mat3F64,
+    /// Jacobian of Δp w.r.t. gyro bias (3×3, column-major).
+    pub j_p_gyro: Mat3F64,
+    /// Jacobian of Δp w.r.t. accel bias (3×3, column-major).
+    pub j_p_accel: Mat3F64,
 }
 
 impl PreintegratedImu {
@@ -81,6 +93,11 @@ impl PreintegratedImu {
             calib,
             covariance: [0.0; 81],
             bias_covariance: [0.0; 36],
+            j_r_gyro: Mat3F64::ZERO,
+            j_v_gyro: Mat3F64::ZERO,
+            j_v_accel: Mat3F64::ZERO,
+            j_p_gyro: Mat3F64::ZERO,
+            j_p_accel: Mat3F64::ZERO,
         }
     }
 
@@ -184,6 +201,40 @@ impl PreintegratedImu {
             self.bias_covariance[i + i * 6] += ba_var;
         }
 
+        // --- Bias Jacobian update (before state update, uses old ΔR) ---
+        // Following ORB-SLAM3 ImuTypes.cc:213-231.
+        // Order matters: position depends on old velocity Jacobians, velocity on old rotation Jacobian.
+
+        // accel_hat is [a]× where a = bias-corrected accel in body frame
+        let wacc_jrg = Mat3F64(accel_hat.mul_mat3(&self.j_r_gyro));
+        let dr_wacc_jrg = Mat3F64(self.delta_rotation.mul_mat3(&wacc_jrg));
+
+        // JPa += JVa·dt - ½·ΔR·dt²
+        self.j_p_accel = Mat3F64(
+            self.j_p_accel.add_mat3(&Mat3F64(
+                mat3_scalar(&self.j_v_accel, dt)
+                    .add_mat3(&mat3_scalar(&self.delta_rotation, -0.5 * dt * dt)),
+            )),
+        );
+
+        // JPg += JVg·dt - ½·ΔR·dt²·[a]×·JRg
+        self.j_p_gyro = Mat3F64(
+            self.j_p_gyro.add_mat3(&Mat3F64(
+                mat3_scalar(&self.j_v_gyro, dt)
+                    .add_mat3(&mat3_scalar(&dr_wacc_jrg, -0.5 * dt * dt)),
+            )),
+        );
+
+        // JVa -= ΔR·dt
+        self.j_v_accel = Mat3F64(
+            self.j_v_accel.add_mat3(&mat3_scalar(&self.delta_rotation, -dt)),
+        );
+
+        // JVg -= ΔR·dt·[a]×·JRg
+        self.j_v_gyro = Mat3F64(
+            self.j_v_gyro.add_mat3(&mat3_scalar(&dr_wacc_jrg, -dt)),
+        );
+
         // --- State update ---
 
         // 1. Position (uses old Δv and ΔR)
@@ -197,7 +248,41 @@ impl PreintegratedImu {
         // prevent floating-point drift away from SO(3) over long windows.
         self.delta_rotation = normalize_rotation(&Mat3F64(self.delta_rotation.mul_mat3(&d_rot)));
 
+        // JRg = dRᵀ · JRg - Jr · dt  (must come after rotation update uses old values)
+        self.j_r_gyro = Mat3F64(
+            Mat3F64(d_rot_t.mul_mat3(&self.j_r_gyro))
+                .sub_mat3(&mat3_scalar(&jr, dt)),
+        );
+
         self.dt += dt;
+    }
+
+    /// Get the bias-corrected delta rotation for a given bias.
+    ///
+    /// ΔR' = ΔR · Exp(JRg · δb_g)
+    /// where δb_g = new_bias.gyro - self.bias.gyro
+    pub fn corrected_delta_rotation(&self, bias: &ImuBias) -> Mat3F64 {
+        let dbg = bias.gyro - self.bias.gyro;
+        let correction = mat3_mul_vec3(&self.j_r_gyro, &dbg);
+        Mat3F64(self.delta_rotation.mul_mat3(&so3::exp(&correction)))
+    }
+
+    /// Get the bias-corrected delta velocity for a given bias.
+    ///
+    /// Δv' = Δv + JVg · δb_g + JVa · δb_a
+    pub fn corrected_delta_velocity(&self, bias: &ImuBias) -> Vec3F64 {
+        let dbg = bias.gyro - self.bias.gyro;
+        let dba = bias.accel - self.bias.accel;
+        self.delta_velocity + mat3_mul_vec3(&self.j_v_gyro, &dbg) + mat3_mul_vec3(&self.j_v_accel, &dba)
+    }
+
+    /// Get the bias-corrected delta position for a given bias.
+    ///
+    /// Δp' = Δp + JPg · δb_g + JPa · δb_a
+    pub fn corrected_delta_position(&self, bias: &ImuBias) -> Vec3F64 {
+        let dbg = bias.gyro - self.bias.gyro;
+        let dba = bias.accel - self.bias.accel;
+        self.delta_position + mat3_mul_vec3(&self.j_p_gyro, &dbg) + mat3_mul_vec3(&self.j_p_accel, &dba)
     }
 
     /// Predict the state at camera frame k+1 given state at frame k.

--- a/crates/kornia-sensors/src/so3.rs
+++ b/crates/kornia-sensors/src/so3.rs
@@ -30,6 +30,72 @@ pub fn exp(omega: &Vec3F64) -> Mat3F64 {
     }
 }
 
+/// Logarithmic map SO(3) -> so(3).
+///
+/// Inverse of exp: extracts the rotation vector from a rotation matrix.
+///   log(R) = (theta / (2·sin(theta))) · vee(R - Rᵀ)
+/// where theta = arccos((tr(R) - 1) / 2).
+pub fn log(r: &Mat3F64) -> Vec3F64 {
+    let c = r.to_cols_array();
+    // Column-major: R[i,j] = c[j*3 + i]
+    let trace = c[0] + c[4] + c[8]; // R[0,0] + R[1,1] + R[2,2]
+    let cos_theta = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0);
+    let theta = cos_theta.acos();
+
+    // vee(R - Rᵀ) = [R[2,1]-R[1,2], R[0,2]-R[2,0], R[1,0]-R[0,1]]
+    let vee = Vec3F64::new(
+        c[1 * 3 + 2] - c[2 * 3 + 1], // R[2,1] - R[1,2]
+        c[2 * 3 + 0] - c[0 * 3 + 2], // R[0,2] - R[2,0]
+        c[0 * 3 + 1] - c[1 * 3 + 0], // R[1,0] - R[0,1]
+    );
+
+    if theta < 1e-10 {
+        // Small angle: log(R) ≈ vee(R - Rᵀ) / 2
+        vee * 0.5
+    } else if (std::f64::consts::PI - theta).abs() < 1e-6 {
+        // Near pi: use the column of (R + I) with largest diagonal
+        let d0 = c[0] + 1.0;
+        let d1 = c[4] + 1.0;
+        let d2 = c[8] + 1.0;
+
+        let v = if d0 >= d1 && d0 >= d2 {
+            Vec3F64::new(d0, c[1], c[2]) // column 0 of R+I
+        } else if d1 >= d2 {
+            Vec3F64::new(c[3], d1, c[5]) // column 1 of R+I
+        } else {
+            Vec3F64::new(c[6], c[7], d2) // column 2 of R+I
+        };
+        let n = (v.x * v.x + v.y * v.y + v.z * v.z).sqrt();
+        v * (theta / n)
+    } else {
+        // General case
+        vee * (theta / (2.0 * theta.sin()))
+    }
+}
+
+/// Inverse right Jacobian of SO(3).
+///
+/// J_r⁻¹(omega) = I + ½·[omega]_x + (1/theta² - (1+cos(theta))/(2·theta·sin(theta)))·[omega]_x²
+pub fn inverse_right_jacobian(omega: &Vec3F64) -> Mat3F64 {
+    let theta_sq = omega.x * omega.x + omega.y * omega.y + omega.z * omega.z;
+    let theta = theta_sq.sqrt();
+
+    let omega_hat = hat(omega);
+    let omega_hat_sq = Mat3F64(omega_hat.mul_mat3(&omega_hat));
+
+    if theta < 1e-8 {
+        // Small angle: J_r⁻¹ ≈ I + ½·[omega]_x
+        let half_hat = Mat3F64(omega_hat.mul_scalar(0.5));
+        Mat3F64(Mat3F64::IDENTITY.add_mat3(&half_hat))
+    } else {
+        // J_r⁻¹ = I + ½·hat + (1/theta² - (1+cos)/( 2·theta·sin))·hat²
+        let half_hat = Mat3F64(omega_hat.mul_scalar(0.5));
+        let coeff = 1.0 / theta_sq - (1.0 + theta.cos()) / (2.0 * theta * theta.sin());
+        let term2 = Mat3F64(omega_hat_sq.mul_scalar(coeff));
+        Mat3F64(Mat3F64::IDENTITY.add_mat3(&Mat3F64(half_hat.add_mat3(&term2))))
+    }
+}
+
 /// Hat operator: R^3 -> so(3), maps a vector to a skew-symmetric matrix.
 ///
 /// ```text
@@ -164,5 +230,61 @@ mod tests {
         let ht = Mat3F64(*h.transpose());
         let sum = Mat3F64(h.add_mat3(&ht));
         approx_eq_mat(&sum, &Mat3F64::ZERO, EPS);
+    }
+
+    #[test]
+    fn log_identity_is_zero() {
+        let omega = log(&Mat3F64::IDENTITY);
+        assert!(omega.x.abs() < EPS);
+        assert!(omega.y.abs() < EPS);
+        assert!(omega.z.abs() < EPS);
+    }
+
+    #[test]
+    fn log_exp_roundtrip() {
+        let omega = Vec3F64::new(0.3, -0.2, 0.5);
+        let r = exp(&omega);
+        let recovered = log(&r);
+        assert!((recovered.x - omega.x).abs() < 1e-9);
+        assert!((recovered.y - omega.y).abs() < 1e-9);
+        assert!((recovered.z - omega.z).abs() < 1e-9);
+    }
+
+    #[test]
+    fn log_exp_roundtrip_large_angle() {
+        // ~170 degrees, close to pi
+        let omega = Vec3F64::new(1.0, 0.5, -0.3);
+        let scale = 2.9 / (omega.x * omega.x + omega.y * omega.y + omega.z * omega.z).sqrt();
+        let omega = omega * scale;
+        let r = exp(&omega);
+        let recovered = log(&r);
+        assert!((recovered.x - omega.x).abs() < 1e-6);
+        assert!((recovered.y - omega.y).abs() < 1e-6);
+        assert!((recovered.z - omega.z).abs() < 1e-6);
+    }
+
+    #[test]
+    fn log_90_deg_around_z() {
+        let omega = Vec3F64::new(0.0, 0.0, std::f64::consts::FRAC_PI_2);
+        let r = exp(&omega);
+        let recovered = log(&r);
+        assert!((recovered.x).abs() < 1e-9);
+        assert!((recovered.y).abs() < 1e-9);
+        assert!((recovered.z - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn inverse_right_jacobian_identity_at_zero() {
+        let jr_inv = inverse_right_jacobian(&Vec3F64::ZERO);
+        approx_eq_mat(&jr_inv, &Mat3F64::IDENTITY, EPS);
+    }
+
+    #[test]
+    fn inverse_right_jacobian_inverts_right_jacobian() {
+        let omega = Vec3F64::new(0.3, -0.2, 0.5);
+        let jr = right_jacobian(&omega);
+        let jr_inv = inverse_right_jacobian(&omega);
+        let product = Mat3F64(jr.mul_mat3(&jr_inv));
+        approx_eq_mat(&product, &Mat3F64::IDENTITY, 1e-9);
     }
 }

--- a/crates/kornia-slam/Cargo.toml
+++ b/crates/kornia-slam/Cargo.toml
@@ -9,4 +9,5 @@ kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-sensors = { path = "../kornia-sensors" }
 thiserror = "2"

--- a/crates/kornia-slam/src/factors/bias_random_walk.rs
+++ b/crates/kornia-slam/src/factors/bias_random_walk.rs
@@ -1,0 +1,218 @@
+//! Bias random-walk factor.
+//!
+//! Constrains the change in IMU biases between two consecutive keyframes.
+//! The uncertainty grows linearly with integration time (random walk model).
+//!
+//! Residual (6D): bias_j − bias_i
+//! Jacobian (6×12): [−I₆ | I₆]
+
+use kornia_algebra::optim::{Factor, FactorError, FactorResult, LinearizationResult};
+use kornia_sensors::imu::PreintegratedImu;
+
+/// Bias random-walk factor between two keyframes.
+///
+/// Variables:
+///   0: bias_i (R⁶, params = [bg_x, bg_y, bg_z, ba_x, ba_y, ba_z], tangent dim = 6)
+///   1: bias_j (R⁶, params = [bg_x, bg_y, bg_z, ba_x, ba_y, ba_z], tangent dim = 6)
+pub struct BiasRandomWalkFactor {
+    /// Square-root information matrix (6×6, row-major).
+    sqrt_info: [f32; 36],
+}
+
+impl BiasRandomWalkFactor {
+    /// Construct from a `PreintegratedImu` whose `bias_covariance` encodes the
+    /// accumulated random-walk uncertainty over the integration interval.
+    pub fn new(pre: &PreintegratedImu) -> Self {
+        let sqrt_vec = super::sqrt_info_from_cov(&pre.bias_covariance, 6);
+        let mut sqrt_info = [0.0f32; 36];
+        sqrt_info.copy_from_slice(&sqrt_vec);
+        Self { sqrt_info }
+    }
+}
+
+impl Factor for BiasRandomWalkFactor {
+    fn linearize(
+        &self,
+        params: &[&[f32]],
+        compute_jacobian: bool,
+    ) -> FactorResult<LinearizationResult> {
+        if params.len() != 2 {
+            return Err(FactorError::DimensionMismatch {
+                expected: 2,
+                actual: params.len(),
+            });
+        }
+
+        let bias_i = params[0];
+        let bias_j = params[1];
+
+        let mut residual: Vec<f32> = (0..6).map(|i| bias_j[i] - bias_i[i]).collect();
+
+        let jacobian = if compute_jacobian {
+            let mut jac = vec![0.0f32; 6 * 12];
+            for i in 0..6 {
+                jac[i * 12 + i] = -1.0;     // −I block (cols 0-5)
+                jac[i * 12 + 6 + i] = 1.0;  // +I block (cols 6-11)
+            }
+            super::whiten_matrix(&mut residual, Some(jac.as_mut_slice()), &self.sqrt_info, 6);
+            Some(jac)
+        } else {
+            super::whiten_matrix(&mut residual, None, &self.sqrt_info, 6);
+            None
+        };
+
+        Ok(LinearizationResult::new(residual, jacobian, 12))
+    }
+
+    fn residual_dim(&self) -> usize {
+        6
+    }
+
+    fn num_variables(&self) -> usize {
+        2
+    }
+
+    fn variable_local_dim(&self, idx: usize) -> usize {
+        match idx {
+            0 | 1 => 6,
+            _ => panic!("BiasRandomWalkFactor has 2 variables"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kornia_algebra::Vec3F64;
+    use kornia_sensors::imu::{ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
+
+    fn make_test_pre() -> PreintegratedImu {
+        let calib = ImuCalib {
+            gyro_noise: 1.6968e-4,
+            accel_noise: 2.0e-3,
+            gyro_bias_noise: 1.9393e-5,
+            accel_bias_noise: 3.0e-3,
+        };
+        let mut pre = PreintegratedImu::new(ImuBias::default(), calib);
+        let m = ImuMeasurement {
+            timestamp: 0.0,
+            gyro: Vec3F64::ZERO,
+            accel: Vec3F64::new(0.0, 0.0, 9.81),
+        };
+        for _ in 0..10 {
+            pre.integrate(&m, 0.01);
+        }
+        pre
+    }
+
+    #[test]
+    fn zero_residual_same_bias() {
+        let pre = make_test_pre();
+        let factor = BiasRandomWalkFactor::new(&pre);
+
+        let bias = [0.1f32, -0.05, 0.02, 0.01, -0.02, 0.03];
+        let result = factor.linearize(&[&bias, &bias], false).unwrap();
+
+        for i in 0..6 {
+            assert!(
+                result.residual[i].abs() < 1e-6,
+                "residual[{i}] = {} (expected 0)",
+                result.residual[i]
+            );
+        }
+    }
+
+    #[test]
+    fn jacobian_is_neg_identity_plus_identity() {
+        let mut pre = make_test_pre();
+        // Identity bias covariance → sqrt_info = I.
+        pre.bias_covariance = [0.0; 36];
+        for i in 0..6 {
+            pre.bias_covariance[i + i * 6] = 1.0;
+        }
+
+        let factor = BiasRandomWalkFactor::new(&pre);
+
+        let bias_i = [0.1f32, -0.05, 0.02, 0.01, -0.02, 0.03];
+        let bias_j = [0.2f32, 0.0, 0.0, 0.0, 0.0, 0.0];
+
+        let result = factor.linearize(&[&bias_i, &bias_j], true).unwrap();
+        let jac = result.jacobian.unwrap();
+
+        for i in 0..6 {
+            for j in 0..12 {
+                let expected = if j == i {
+                    -1.0
+                } else if j == i + 6 {
+                    1.0
+                } else {
+                    0.0
+                };
+                assert!(
+                    (jac[i * 12 + j] - expected).abs() < 1e-5,
+                    "jac[{i},{j}] = {} expected {expected}",
+                    jac[i * 12 + j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn numerical_jacobian_check() {
+        let mut pre = make_test_pre();
+        pre.bias_covariance = [0.0; 36];
+        for i in 0..6 {
+            pre.bias_covariance[i + i * 6] = 1.0;
+        }
+
+        let factor = BiasRandomWalkFactor::new(&pre);
+
+        let bias_i = [0.01f32, -0.02, 0.03, 0.001, -0.002, 0.003];
+        let bias_j = [0.02f32, -0.01, 0.01, 0.002, -0.001, 0.001];
+        let params: Vec<&[f32]> = vec![&bias_i, &bias_j];
+
+        let result = factor.linearize(&params, true).unwrap();
+        let jac = result.jacobian.unwrap();
+
+        let eps = 1e-4f32;
+        let dims = [6, 6];
+        let mut col_offset = 0;
+
+        for (var_idx, &dim) in dims.iter().enumerate() {
+            for d in 0..dim {
+                let pp: Vec<f32> = params[var_idx]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &v)| v + if i == d { eps } else { 0.0 })
+                    .collect();
+                let pm: Vec<f32> = params[var_idx]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &v)| v - if i == d { eps } else { 0.0 })
+                    .collect();
+
+                let mut p_plus: Vec<Vec<f32>> = params.iter().map(|s| s.to_vec()).collect();
+                p_plus[var_idx] = pp;
+                let pp_refs: Vec<&[f32]> = p_plus.iter().map(|v| v.as_slice()).collect();
+
+                let mut p_minus: Vec<Vec<f32>> = params.iter().map(|s| s.to_vec()).collect();
+                p_minus[var_idx] = pm;
+                let pm_refs: Vec<&[f32]> = p_minus.iter().map(|v| v.as_slice()).collect();
+
+                let r_plus = factor.linearize(&pp_refs, false).unwrap().residual;
+                let r_minus = factor.linearize(&pm_refs, false).unwrap().residual;
+
+                for row in 0..6 {
+                    let numerical = (r_plus[row] - r_minus[row]) / (2.0 * eps);
+                    let analytical = jac[row * 12 + col_offset + d];
+                    assert!(
+                        (numerical - analytical).abs() < 1e-2,
+                        "jac[{row},{}]: numerical={numerical:.4}, analytical={analytical:.4}",
+                        col_offset + d
+                    );
+                }
+            }
+            col_offset += dim;
+        }
+    }
+}

--- a/crates/kornia-slam/src/factors/inertial.rs
+++ b/crates/kornia-slam/src/factors/inertial.rs
@@ -1,0 +1,556 @@
+//! IMU preintegration factor (Forster et al. / ORB-SLAM3 formulation).
+//!
+//! Residual (9D) = [r_R(3), r_v(3), r_p(3)]:
+//!   r_R = Log(ΔR_corr^T · R_i · R_j^T)
+//!   r_v = R_i · (v_j − v_i − g·Δt) − Δv_corr
+//!   r_p = R_i · (p_j − p_i − v_i·Δt − ½g·Δt²) − Δp_corr
+//!
+//! Pre-whitened by the Cholesky factor of the information matrix (inverse of
+//! the 9×9 navigation covariance from preintegration).
+
+use kornia_algebra::optim::{Factor, FactorError, FactorResult, LinearizationResult};
+use kornia_sensors::imu::PreintegratedImu;
+
+/// Total tangent-space dimension across all five variables.
+const TOTAL_DIM: usize = 24;
+
+/// IMU preintegration factor connecting two consecutive keyframe states.
+///
+/// Variables:
+///   0: pose_i  (SE3, params = [qw, qx, qy, qz, tx, ty, tz], tangent dim = 6)
+///   1: vel_i   (R³,  params = [vx, vy, vz], tangent dim = 3)
+///   2: pose_j  (SE3, params = [qw, qx, qy, qz, tx, ty, tz], tangent dim = 6)
+///   3: vel_j   (R³,  params = [vx, vy, vz], tangent dim = 3)
+///   4: bias    (R⁶,  params = [bg_x, bg_y, bg_z, ba_x, ba_y, ba_z], tangent dim = 6)
+pub struct InertialFactor {
+    delta_rotation: [f32; 9], // 3×3 column-major
+    delta_velocity: [f32; 3],
+    delta_position: [f32; 3],
+    dt: f32,
+    gravity: [f32; 3],
+    bias_gyro_lin: [f32; 3],
+    bias_accel_lin: [f32; 3],
+    j_r_gyro: [f32; 9],  // 3×3 column-major
+    j_v_gyro: [f32; 9],
+    j_v_accel: [f32; 9],
+    j_p_gyro: [f32; 9],
+    j_p_accel: [f32; 9],
+    /// Upper-triangular sqrt of information matrix (9×9, row-major).
+    sqrt_info: [f32; 81],
+}
+
+impl InertialFactor {
+    /// Construct from a `PreintegratedImu` and the world-frame gravity vector.
+    pub fn new(pre: &PreintegratedImu, gravity: [f32; 3]) -> Self {
+        let convert_mat3 = |m: &kornia_algebra::Mat3F64| -> [f32; 9] {
+            let c = m.to_cols_array();
+            std::array::from_fn(|i| c[i] as f32)
+        };
+        let convert_vec3 = |v: &kornia_algebra::Vec3F64| -> [f32; 3] {
+            [v.x as f32, v.y as f32, v.z as f32]
+        };
+
+        let sqrt_vec = super::sqrt_info_from_cov(&pre.covariance, 9);
+        let mut sqrt_info = [0.0f32; 81];
+        sqrt_info.copy_from_slice(&sqrt_vec);
+
+        Self {
+            delta_rotation: convert_mat3(&pre.delta_rotation),
+            delta_velocity: convert_vec3(&pre.delta_velocity),
+            delta_position: convert_vec3(&pre.delta_position),
+            dt: pre.dt as f32,
+            gravity,
+            bias_gyro_lin: convert_vec3(&pre.bias.gyro),
+            bias_accel_lin: convert_vec3(&pre.bias.accel),
+            j_r_gyro: convert_mat3(&pre.j_r_gyro),
+            j_v_gyro: convert_mat3(&pre.j_v_gyro),
+            j_v_accel: convert_mat3(&pre.j_v_accel),
+            j_p_gyro: convert_mat3(&pre.j_p_gyro),
+            j_p_accel: convert_mat3(&pre.j_p_accel),
+            sqrt_info,
+        }
+    }
+}
+
+impl Factor for InertialFactor {
+    fn linearize(
+        &self,
+        params: &[&[f32]],
+        compute_jacobian: bool,
+    ) -> FactorResult<LinearizationResult> {
+        if params.len() != 5 {
+            return Err(FactorError::DimensionMismatch {
+                expected: 5,
+                actual: params.len(),
+            });
+        }
+
+        let pose_i = params[0]; // [qw,qx,qy,qz,tx,ty,tz]
+        let vel_i = params[1];  // [vx,vy,vz]
+        let pose_j = params[2];
+        let vel_j = params[3];
+        let bias = params[4];   // [bg(3), ba(3)]
+
+        // ── Extract rotations and world positions ────────────────────────
+        let r_i = quat_to_rot(pose_i);
+        let t_i = [pose_i[4], pose_i[5], pose_i[6]];
+        let r_it = m3t(&r_i);
+        let p_i = m3v3(&r_it, &v3_neg(&t_i)); // p = -R^T·t
+
+        let r_j = quat_to_rot(pose_j);
+        let t_j = [pose_j[4], pose_j[5], pose_j[6]];
+        let r_jt = m3t(&r_j);
+        let p_j = m3v3(&r_jt, &v3_neg(&t_j));
+
+        let vi = [vel_i[0], vel_i[1], vel_i[2]];
+        let vj = [vel_j[0], vel_j[1], vel_j[2]];
+
+        // ── Bias correction ──────────────────────────────────────────────
+        let db_g = [
+            bias[0] - self.bias_gyro_lin[0],
+            bias[1] - self.bias_gyro_lin[1],
+            bias[2] - self.bias_gyro_lin[2],
+        ];
+        let db_a = [
+            bias[3] - self.bias_accel_lin[0],
+            bias[4] - self.bias_accel_lin[1],
+            bias[5] - self.bias_accel_lin[2],
+        ];
+
+        // ΔR_corr = ΔR · Exp(J_R_gyro · δb_g)
+        let dr_corr = m3m3(&self.delta_rotation, &so3_exp(&m3v3(&self.j_r_gyro, &db_g)));
+        // Δv_corr = Δv + J_v_gyro·δb_g + J_v_accel·δb_a
+        let dv_corr = v3_add(
+            &self.delta_velocity,
+            &v3_add(&m3v3(&self.j_v_gyro, &db_g), &m3v3(&self.j_v_accel, &db_a)),
+        );
+        // Δp_corr = Δp + J_p_gyro·δb_g + J_p_accel·δb_a
+        let dp_corr = v3_add(
+            &self.delta_position,
+            &v3_add(&m3v3(&self.j_p_gyro, &db_g), &m3v3(&self.j_p_accel, &db_a)),
+        );
+
+        // ── Residual ─────────────────────────────────────────────────────
+        // r_R = Log(ΔR_corr^T · R_i · R_j^T)
+        let dr_corr_t = m3t(&dr_corr);
+        let r_rot = so3_log(&m3m3(&dr_corr_t, &m3m3(&r_i, &r_jt)));
+
+        // r_v = R_i · (v_j − v_i − g·dt) − Δv_corr
+        let alpha = v3_sub(&v3_sub(&vj, &vi), &v3_scale(&self.gravity, self.dt));
+        let r_vel = v3_sub(&m3v3(&r_i, &alpha), &dv_corr);
+
+        // r_p = R_i · (p_j − p_i − v_i·dt − ½g·dt²) − Δp_corr
+        let beta = v3_sub(
+            &v3_sub(&v3_sub(&p_j, &p_i), &v3_scale(&vi, self.dt)),
+            &v3_scale(&self.gravity, 0.5 * self.dt * self.dt),
+        );
+        let r_pos = v3_sub(&m3v3(&r_i, &beta), &dp_corr);
+
+        let mut residual = vec![
+            r_rot[0], r_rot[1], r_rot[2],
+            r_vel[0], r_vel[1], r_vel[2],
+            r_pos[0], r_pos[1], r_pos[2],
+        ];
+
+        // ── Jacobian (9 × 24, row-major) ─────────────────────────────────
+        let jacobian = if compute_jacobian {
+            let mut jac = vec![0.0f32; 9 * TOTAL_DIM];
+
+            let jr_inv = inv_right_jacobian(&r_rot);
+            let jr_inv_rj = m3m3(&jr_inv, &r_j);
+
+            // --- r_R rows (0-2) ---
+            // d/d(ω_i) = J_r^{-1}·R_j  (cols 3-5)
+            set_block(&mut jac, 0, 3, &jr_inv_rj);
+            // d/d(ω_j) = −J_r^{-1}·R_j  (cols 12-14)
+            set_block(&mut jac, 0, 12, &m3_neg(&jr_inv_rj));
+            // d/d(b_g) = −J_r^{-1}·J_R_gyro  (cols 18-20)
+            set_block(&mut jac, 0, 18, &m3_neg(&m3m3(&jr_inv, &self.j_r_gyro)));
+
+            // --- r_v rows (3-5) ---
+            // d/d(ω_i) = −R_i·[α]×  (cols 3-5)
+            set_block(&mut jac, 3, 3, &m3_neg(&m3m3(&r_i, &hat(&alpha))));
+            // d/d(v_i) = −R_i  (cols 6-8)
+            set_block(&mut jac, 3, 6, &m3_neg(&r_i));
+            // d/d(v_j) = R_i  (cols 15-17)
+            set_block(&mut jac, 3, 15, &r_i);
+            // d/d(b_g) = −J_v_gyro  (cols 18-20)
+            set_block(&mut jac, 3, 18, &m3_neg(&self.j_v_gyro));
+            // d/d(b_a) = −J_v_accel  (cols 21-23)
+            set_block(&mut jac, 3, 21, &m3_neg(&self.j_v_accel));
+
+            // --- r_p rows (6-8) ---
+            // d/d(υ_i) = R_i  (cols 0-2)
+            set_block(&mut jac, 6, 0, &r_i);
+            // d/d(ω_i) = −R_i·[p_j − v_i·dt − ½g·dt²]×  (cols 3-5)
+            let gamma = v3_sub(
+                &v3_sub(&p_j, &v3_scale(&vi, self.dt)),
+                &v3_scale(&self.gravity, 0.5 * self.dt * self.dt),
+            );
+            set_block(&mut jac, 6, 3, &m3_neg(&m3m3(&r_i, &hat(&gamma))));
+            // d/d(v_i) = −R_i·dt  (cols 6-8)
+            set_block(&mut jac, 6, 6, &m3_scale(&r_i, -self.dt));
+            // d/d(υ_j) = −R_i  (cols 9-11)
+            set_block(&mut jac, 6, 9, &m3_neg(&r_i));
+            // d/d(ω_j) = R_i·[p_j]×  (cols 12-14)
+            set_block(&mut jac, 6, 12, &m3m3(&r_i, &hat(&p_j)));
+            // d/d(b_g) = −J_p_gyro  (cols 18-20)
+            set_block(&mut jac, 6, 18, &m3_neg(&self.j_p_gyro));
+            // d/d(b_a) = −J_p_accel  (cols 21-23)
+            set_block(&mut jac, 6, 21, &m3_neg(&self.j_p_accel));
+
+            super::whiten_matrix(&mut residual, Some(jac.as_mut_slice()), &self.sqrt_info, 9);
+            Some(jac)
+        } else {
+            super::whiten_matrix(&mut residual, None, &self.sqrt_info, 9);
+            None
+        };
+
+        Ok(LinearizationResult::new(residual, jacobian, TOTAL_DIM))
+    }
+
+    fn residual_dim(&self) -> usize {
+        9
+    }
+
+    fn num_variables(&self) -> usize {
+        5
+    }
+
+    fn variable_local_dim(&self, idx: usize) -> usize {
+        match idx {
+            0 => 6, // pose_i  (SE3)
+            1 => 3, // vel_i   (R³)
+            2 => 6, // pose_j  (SE3)
+            3 => 3, // vel_j   (R³)
+            4 => 6, // bias    (R⁶)
+            _ => panic!("InertialFactor has 5 variables"),
+        }
+    }
+}
+
+// ── f32 SO(3) and matrix helpers ─────────────────────────────────────────
+
+/// Column-major 3×3 index.
+#[inline]
+fn idx3(row: usize, col: usize) -> usize {
+    row + col * 3
+}
+
+/// Quaternion [qw,qx,qy,qz,...] → 3×3 rotation matrix (column-major).
+fn quat_to_rot(q: &[f32]) -> [f32; 9] {
+    let (w, x, y, z) = (q[0], q[1], q[2], q[3]);
+    [
+        1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y + w * z), 2.0 * (x * z - w * y),
+        2.0 * (x * y - w * z), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z + w * x),
+        2.0 * (x * z + w * y), 2.0 * (y * z - w * x), 1.0 - 2.0 * (x * x + y * y),
+    ]
+}
+
+/// 3×3 × 3-vec (column-major matrix).
+fn m3v3(m: &[f32; 9], v: &[f32; 3]) -> [f32; 3] {
+    [
+        m[0] * v[0] + m[3] * v[1] + m[6] * v[2],
+        m[1] * v[0] + m[4] * v[1] + m[7] * v[2],
+        m[2] * v[0] + m[5] * v[1] + m[8] * v[2],
+    ]
+}
+
+/// 3×3 × 3×3 multiply (both column-major).
+fn m3m3(a: &[f32; 9], b: &[f32; 9]) -> [f32; 9] {
+    let mut out = [0.0f32; 9];
+    for c in 0..3 {
+        for r in 0..3 {
+            out[idx3(r, c)] = a[idx3(r, 0)] * b[idx3(0, c)]
+                + a[idx3(r, 1)] * b[idx3(1, c)]
+                + a[idx3(r, 2)] * b[idx3(2, c)];
+        }
+    }
+    out
+}
+
+/// 3×3 transpose (column-major).
+fn m3t(m: &[f32; 9]) -> [f32; 9] {
+    [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
+}
+
+fn m3_scale(m: &[f32; 9], s: f32) -> [f32; 9] {
+    std::array::from_fn(|i| m[i] * s)
+}
+
+fn m3_neg(m: &[f32; 9]) -> [f32; 9] {
+    std::array::from_fn(|i| -m[i])
+}
+
+fn v3_add(a: &[f32; 3], b: &[f32; 3]) -> [f32; 3] {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+fn v3_sub(a: &[f32; 3], b: &[f32; 3]) -> [f32; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn v3_scale(v: &[f32; 3], s: f32) -> [f32; 3] {
+    [v[0] * s, v[1] * s, v[2] * s]
+}
+
+fn v3_neg(v: &[f32; 3]) -> [f32; 3] {
+    [-v[0], -v[1], -v[2]]
+}
+
+/// Skew-symmetric matrix [v]× (column-major).
+fn hat(v: &[f32; 3]) -> [f32; 9] {
+    [
+         0.0,  v[2], -v[1],
+        -v[2],  0.0,  v[0],
+         v[1], -v[0],  0.0,
+    ]
+}
+
+const ID3: [f32; 9] = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+
+/// SO(3) exponential map (Rodrigues).
+fn so3_exp(omega: &[f32; 3]) -> [f32; 9] {
+    let theta_sq = omega[0] * omega[0] + omega[1] * omega[1] + omega[2] * omega[2];
+    let theta = theta_sq.sqrt();
+    let w = hat(omega);
+    let w2 = m3m3(&w, &w);
+
+    if theta < 1e-6 {
+        std::array::from_fn(|i| ID3[i] + w[i])
+    } else {
+        let a = theta.sin() / theta;
+        let b = (1.0 - theta.cos()) / theta_sq;
+        std::array::from_fn(|i| ID3[i] + a * w[i] + b * w2[i])
+    }
+}
+
+/// SO(3) logarithmic map: rotation matrix → axis-angle vector.
+fn so3_log(r: &[f32; 9]) -> [f32; 3] {
+    let trace = r[0] + r[4] + r[8];
+    let cos_theta = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0);
+    let theta = cos_theta.acos();
+
+    let vee = [
+        r[idx3(2, 1)] - r[idx3(1, 2)],
+        r[idx3(0, 2)] - r[idx3(2, 0)],
+        r[idx3(1, 0)] - r[idx3(0, 1)],
+    ];
+
+    if theta < 1e-7 {
+        [vee[0] * 0.5, vee[1] * 0.5, vee[2] * 0.5]
+    } else if (std::f32::consts::PI - theta).abs() < 1e-5 {
+        // Near π: use column of (R + I) with largest diagonal entry
+        let d0 = r[0] + 1.0;
+        let d1 = r[4] + 1.0;
+        let d2 = r[8] + 1.0;
+        let v = if d0 >= d1 && d0 >= d2 {
+            [d0, r[idx3(1, 0)], r[idx3(2, 0)]]
+        } else if d1 >= d2 {
+            [r[idx3(0, 1)], d1, r[idx3(2, 1)]]
+        } else {
+            [r[idx3(0, 2)], r[idx3(1, 2)], d2]
+        };
+        let n = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+        let s = theta / n;
+        [v[0] * s, v[1] * s, v[2] * s]
+    } else {
+        let s = theta / (2.0 * theta.sin());
+        [vee[0] * s, vee[1] * s, vee[2] * s]
+    }
+}
+
+/// Inverse right Jacobian of SO(3).
+///
+/// J_r⁻¹(ω) = I + ½[ω]× + (1/θ² − (1+cosθ)/(2θ sinθ))·[ω]×²
+fn inv_right_jacobian(omega: &[f32; 3]) -> [f32; 9] {
+    let theta_sq = omega[0] * omega[0] + omega[1] * omega[1] + omega[2] * omega[2];
+    let theta = theta_sq.sqrt();
+    let w = hat(omega);
+    let w2 = m3m3(&w, &w);
+
+    if theta < 1e-6 {
+        std::array::from_fn(|i| ID3[i] + 0.5 * w[i])
+    } else {
+        let coeff = 1.0 / theta_sq - (1.0 + theta.cos()) / (2.0 * theta * theta.sin());
+        std::array::from_fn(|i| ID3[i] + 0.5 * w[i] + coeff * w2[i])
+    }
+}
+
+/// Write a 3×3 column-major block into a 9×24 row-major Jacobian.
+fn set_block(jac: &mut [f32], row_off: usize, col_off: usize, block: &[f32; 9]) {
+    for r in 0..3 {
+        for c in 0..3 {
+            jac[(row_off + r) * TOTAL_DIM + col_off + c] = block[idx3(r, c)];
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kornia_algebra::Vec3F64;
+    use kornia_sensors::imu::{ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
+
+    fn default_calib() -> ImuCalib {
+        ImuCalib {
+            gyro_noise: 1.6968e-4,
+            accel_noise: 2.0e-3,
+            gyro_bias_noise: 1.9393e-5,
+            accel_bias_noise: 3.0e-3,
+        }
+    }
+
+    fn make_stationary_pre() -> PreintegratedImu {
+        let mut pre = PreintegratedImu::new(ImuBias::default(), default_calib());
+        let m = ImuMeasurement {
+            timestamp: 0.0,
+            gyro: Vec3F64::ZERO,
+            accel: Vec3F64::new(0.0, 0.0, 9.81),
+        };
+        for _ in 0..10 {
+            pre.integrate(&m, 0.01);
+        }
+        pre
+    }
+
+    fn identity_pose() -> [f32; 7] {
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    }
+
+    #[test]
+    fn zero_residual_stationary() {
+        let pre = make_stationary_pre();
+        let factor = InertialFactor::new(&pre, [0.0, 0.0, -9.81]);
+
+        let pose = identity_pose();
+        let vel = [0.0f32; 3];
+        let bias = [0.0f32; 6];
+
+        let result = factor
+            .linearize(&[&pose, &vel, &pose, &vel, &bias], false)
+            .unwrap();
+
+        for i in 0..9 {
+            assert!(
+                result.residual[i].abs() < 0.01,
+                "residual[{i}] = {} (expected ~0)",
+                result.residual[i]
+            );
+        }
+    }
+
+    // ── Numerical Jacobian check ─────────────────────────────────────────
+
+    /// Rotation matrix → quaternion [qw,qx,qy,qz] (Shepperd's method).
+    fn rot_to_quat(r: &[f32; 9]) -> [f32; 4] {
+        let trace = r[0] + r[4] + r[8];
+        if trace > 0.0 {
+            let s = (1.0 + trace).sqrt() * 2.0;
+            [s / 4.0, (r[idx3(2, 1)] - r[idx3(1, 2)]) / s,
+             (r[idx3(0, 2)] - r[idx3(2, 0)]) / s, (r[idx3(1, 0)] - r[idx3(0, 1)]) / s]
+        } else if r[0] > r[4] && r[0] > r[8] {
+            let s = (1.0 + r[0] - r[4] - r[8]).sqrt() * 2.0;
+            [(r[idx3(2, 1)] - r[idx3(1, 2)]) / s, s / 4.0,
+             (r[idx3(0, 1)] + r[idx3(1, 0)]) / s, (r[idx3(0, 2)] + r[idx3(2, 0)]) / s]
+        } else if r[4] > r[8] {
+            let s = (1.0 + r[4] - r[0] - r[8]).sqrt() * 2.0;
+            [(r[idx3(0, 2)] - r[idx3(2, 0)]) / s, (r[idx3(0, 1)] + r[idx3(1, 0)]) / s,
+             s / 4.0, (r[idx3(1, 2)] + r[idx3(2, 1)]) / s]
+        } else {
+            let s = (1.0 + r[8] - r[0] - r[4]).sqrt() * 2.0;
+            [(r[idx3(1, 0)] - r[idx3(0, 1)]) / s, (r[idx3(0, 2)] + r[idx3(2, 0)]) / s,
+             (r[idx3(1, 2)] + r[idx3(2, 1)]) / s, s / 4.0]
+        }
+    }
+
+    /// Right-perturb an SE3 pose by tangent vector [δυ(3), δω(3)].
+    fn perturb_se3(pose: &[f32], delta: &[f32; 6]) -> Vec<f32> {
+        let r = quat_to_rot(pose);
+        let t = [pose[4], pose[5], pose[6]];
+        let dv = [delta[0], delta[1], delta[2]];
+        let dw = [delta[3], delta[4], delta[5]];
+
+        let r_new = m3m3(&r, &so3_exp(&dw));
+        let q = rot_to_quat(&r_new);
+        let r_dv = m3v3(&r, &dv);
+
+        vec![q[0], q[1], q[2], q[3],
+             t[0] + r_dv[0], t[1] + r_dv[1], t[2] + r_dv[2]]
+    }
+
+    #[test]
+    fn jacobian_numerical_check() {
+        let mut pre = make_stationary_pre();
+        // Identity covariance → sqrt_info = I → no whitening distortion.
+        pre.covariance = [0.0; 81];
+        for i in 0..9 {
+            pre.covariance[i + i * 9] = 1.0;
+        }
+
+        let factor = InertialFactor::new(&pre, [0.0, 0.0, -9.81]);
+
+        let pose_i = identity_pose();
+        let vel_i = [0.0f32; 3];
+        let pose_j = identity_pose();
+        let vel_j = [0.5f32, 0.0, 0.0]; // offset → non-zero residual
+        let bias = [0.0f32; 6];
+
+        let params: Vec<&[f32]> = vec![&pose_i, &vel_i, &pose_j, &vel_j, &bias];
+
+        let result = factor.linearize(&params, true).unwrap();
+        let jac = result.jacobian.unwrap();
+
+        let eps = 1e-3f32;
+        let tangent_dims = [6, 3, 6, 3, 6];
+        let mut col_offset = 0;
+
+        for (var_idx, &dim) in tangent_dims.iter().enumerate() {
+            for d in 0..dim {
+                let mut delta_pos = vec![0.0f32; dim];
+                delta_pos[d] = eps;
+                let mut delta_neg = vec![0.0f32; dim];
+                delta_neg[d] = -eps;
+
+                let (perturbed_plus, perturbed_minus) = match var_idx {
+                    0 | 2 => {
+                        let dp: [f32; 6] = std::array::from_fn(|i| delta_pos[i]);
+                        let dn: [f32; 6] = std::array::from_fn(|i| delta_neg[i]);
+                        (perturb_se3(params[var_idx], &dp), perturb_se3(params[var_idx], &dn))
+                    }
+                    _ => {
+                        let pp: Vec<f32> = params[var_idx].iter().enumerate()
+                            .map(|(i, &v)| v + if i == d { eps } else { 0.0 }).collect();
+                        let pm: Vec<f32> = params[var_idx].iter().enumerate()
+                            .map(|(i, &v)| v + if i == d { -eps } else { 0.0 }).collect();
+                        (pp, pm)
+                    }
+                };
+
+                let mut pp = params.iter().map(|s| s.to_vec()).collect::<Vec<_>>();
+                pp[var_idx] = perturbed_plus;
+                let pp_refs: Vec<&[f32]> = pp.iter().map(|v| v.as_slice()).collect();
+
+                let mut pm = params.iter().map(|s| s.to_vec()).collect::<Vec<_>>();
+                pm[var_idx] = perturbed_minus;
+                let pm_refs: Vec<&[f32]> = pm.iter().map(|v| v.as_slice()).collect();
+
+                let r_plus = factor.linearize(&pp_refs, false).unwrap().residual;
+                let r_minus = factor.linearize(&pm_refs, false).unwrap().residual;
+
+                for row in 0..9 {
+                    let numerical = (r_plus[row] - r_minus[row]) / (2.0 * eps);
+                    let analytical = jac[row * TOTAL_DIM + col_offset + d];
+                    assert!(
+                        (numerical - analytical).abs() < 5e-2,
+                        "jac[{row},{}]: numerical={numerical:.4}, analytical={analytical:.4}",
+                        col_offset + d
+                    );
+                }
+            }
+            col_offset += dim;
+        }
+    }
+}

--- a/crates/kornia-slam/src/factors/mod.rs
+++ b/crates/kornia-slam/src/factors/mod.rs
@@ -1,0 +1,109 @@
+pub mod bias_random_walk;
+pub mod inertial;
+pub mod reprojection;
+
+// === Shared whitening utilities ===
+//
+// IMU factors use matrix-valued information (inverse covariance) for whitening,
+// unlike the scalar weight used by the reprojection factor.  The helpers below
+// compute the square-root information matrix via Cholesky decomposition so that
+// whitening reduces to a matrix–vector multiply.
+
+/// Compute the square-root information matrix from a covariance matrix.
+///
+/// Given an n×n symmetric positive-definite covariance Σ (column-major, f64):
+///   1. Cholesky: Σ = L·L^T
+///   2. Invert:   L^{-1}
+///   3. Return:   L^{-T} as f32 (row-major) — the upper-triangular square root of Σ^{-1}.
+///
+/// Whitening satisfies  r_w^T · r_w = r^T · Σ^{-1} · r  when  r_w = L^{-T} · r.
+pub(crate) fn sqrt_info_from_cov(cov: &[f64], n: usize) -> Vec<f32> {
+    // Regularise for numerical stability (handles near-zero covariance entries).
+    let mut c = cov.to_vec();
+    for i in 0..n {
+        c[i + i * n] += 1e-10;
+    }
+
+    let l = cholesky_lower(&c, n);
+    let linv = invert_lower_tri(&l, n);
+
+    // L^{-T} row-major:  out[i*n + j] = linv_col_major[j + i*n]
+    let mut out = vec![0.0f32; n * n];
+    for i in 0..n {
+        for j in 0..n {
+            out[i * n + j] = linv[j + i * n] as f32;
+        }
+    }
+    out
+}
+
+/// Apply matrix whitening in-place to a residual and (optionally) its Jacobian.
+///
+/// `sqrt_info` is an n×n matrix stored **row-major**.
+/// `residual` has length n.
+/// `jacobian` (if present) has length n × total_cols, stored row-major.
+pub(crate) fn whiten_matrix(
+    residual: &mut [f32],
+    jacobian: Option<&mut [f32]>,
+    sqrt_info: &[f32],
+    n: usize,
+) {
+    // r_w = sqrt_info · r
+    let r_orig: Vec<f32> = residual[..n].to_vec();
+    for i in 0..n {
+        residual[i] = (0..n).map(|j| sqrt_info[i * n + j] * r_orig[j]).sum();
+    }
+
+    // J_w = sqrt_info · J  (row-wise)
+    if let Some(jac) = jacobian {
+        let total_cols = jac.len() / n;
+        let j_orig = jac.to_vec();
+        for i in 0..n {
+            for col in 0..total_cols {
+                jac[i * total_cols + col] = (0..n)
+                    .map(|j| sqrt_info[i * n + j] * j_orig[j * total_cols + col])
+                    .sum();
+            }
+        }
+    }
+}
+
+// ── Linear-algebra helpers (f64, column-major) ───────────────────────────
+
+/// Cholesky decomposition: mat = L·L^T.  Column-major n×n input/output.
+fn cholesky_lower(mat: &[f64], n: usize) -> Vec<f64> {
+    let mut l = vec![0.0f64; n * n];
+    for j in 0..n {
+        let mut sum = 0.0;
+        for k in 0..j {
+            let v = l[j + k * n];
+            sum += v * v;
+        }
+        l[j + j * n] = (mat[j + j * n] - sum).max(1e-20).sqrt();
+
+        for i in (j + 1)..n {
+            let mut s = 0.0;
+            for k in 0..j {
+                s += l[i + k * n] * l[j + k * n];
+            }
+            l[i + j * n] = (mat[i + j * n] - s) / l[j + j * n];
+        }
+    }
+    l
+}
+
+/// Invert a lower-triangular matrix by forward substitution.  Column-major.
+fn invert_lower_tri(l: &[f64], n: usize) -> Vec<f64> {
+    let mut inv = vec![0.0f64; n * n];
+    for j in 0..n {
+        inv[j + j * n] = 1.0 / l[j + j * n];
+        for i in (j + 1)..n {
+            let mut sum = 0.0;
+            for k in j..i {
+                sum += l[i + k * n] * inv[k + j * n];
+            }
+            inv[i + j * n] = -sum / l[i + i * n];
+        }
+    }
+    inv
+}

--- a/crates/kornia-slam/src/factors/reprojection.rs
+++ b/crates/kornia-slam/src/factors/reprojection.rs
@@ -1,0 +1,301 @@
+//! Monocular reprojection factor (EdgeMono equivalent).
+//!
+//! Residual: observed_pixel - project(pose * point_world)
+//! Pre-whitened by the scale-derived information weight.
+
+use kornia_algebra::optim::{Factor, FactorError, FactorResult, LinearizationResult};
+use kornia_algebra::optim::whitening::whiten_scalar;
+
+/// Monocular reprojection factor connecting a 3D map point and a camera pose.
+///
+/// Variables:
+///   0: map point (Euclidean 3D, params = [x, y, z])
+///   1: camera pose (SE3, params = [qw, qx, qy, qz, tx, ty, tz], tangent = [upsilon(3), omega(3)])
+///
+/// The residual is 2D: observed pixel minus projected pixel, pre-whitened
+/// by the information weight derived from the feature's pyramid scale.
+pub struct ReprojectionFactor {
+    /// Observed pixel coordinates [u, v].
+    pub observation: [f32; 2],
+    /// Camera intrinsics [fx, fy, cx, cy].
+    pub intrinsics: [f32; 4],
+    /// Information weight = 1 / scale^2 (from image pyramid octave).
+    pub information_weight: f32,
+}
+
+impl ReprojectionFactor {
+    pub fn new(observation: [f32; 2], intrinsics: [f32; 4], scale: f32) -> Self {
+        Self {
+            observation,
+            intrinsics,
+            information_weight: 1.0 / (scale * scale),
+        }
+    }
+
+    /// Transform world point by pose (world-to-camera) and project to pixel.
+    /// Returns (u, v, p_cam) where p_cam is the point in camera frame.
+    fn project(&self, point: &[f32], pose: &[f32]) -> ([f32; 2], [f32; 3]) {
+        let [fx, fy, cx, cy] = self.intrinsics;
+
+        // Parse SE3: [qw, qx, qy, qz, tx, ty, tz]
+        let (qw, qx, qy, qz) = (pose[0], pose[1], pose[2], pose[3]);
+        let (tx, ty, tz) = (pose[4], pose[5], pose[6]);
+        let (px, py, pz) = (point[0], point[1], point[2]);
+
+        // Rotate point: R * p (quaternion rotation)
+        // R(q) * v = v + 2*q_w*(q_xyz × v) + 2*(q_xyz × (q_xyz × v))
+        let cx_ = qy * pz - qz * py;
+        let cy_ = qz * px - qx * pz;
+        let cz_ = qx * py - qy * px;
+
+        let rx = px + 2.0 * (qw * cx_ + qy * cz_ - qz * cy_);
+        let ry = py + 2.0 * (qw * cy_ + qz * cx_ - qx * cz_);
+        let rz = pz + 2.0 * (qw * cz_ + qx * cy_ - qy * cx_);
+
+        // p_cam = R * p_world + t
+        let cam_x = rx + tx;
+        let cam_y = ry + ty;
+        let cam_z = rz + tz;
+
+        let inv_z = 1.0 / cam_z;
+        let u = fx * cam_x * inv_z + cx;
+        let v = fy * cam_y * inv_z + cy;
+
+        ([u, v], [cam_x, cam_y, cam_z])
+    }
+}
+
+impl Factor for ReprojectionFactor {
+    fn linearize(
+        &self,
+        params: &[&[f32]],
+        compute_jacobian: bool,
+    ) -> FactorResult<LinearizationResult> {
+        if params.len() != 2 {
+            return Err(FactorError::DimensionMismatch {
+                expected: 2,
+                actual: params.len(),
+            });
+        }
+
+        let point = params[0]; // [x, y, z]
+        let pose = params[1]; // [qw, qx, qy, qz, tx, ty, tz]
+
+        let ([u, v], [cam_x, cam_y, cam_z]) = self.project(point, pose);
+
+        let mut residual = vec![self.observation[0] - u, self.observation[1] - v];
+
+        let jacobian = if compute_jacobian {
+            let [fx, fy, _, _] = self.intrinsics;
+            let inv_z = 1.0 / cam_z;
+            let inv_z2 = inv_z * inv_z;
+
+            // d(project)/d(p_cam): 2x3 projection Jacobian
+            // u = fx * cam_x / cam_z + cx  =>  du/dcam = [fx/z, 0, -fx*x/z²]
+            // v = fy * cam_y / cam_z + cy  =>  dv/dcam = [0, fy/z, -fy*y/z²]
+            let dp_dx = fx * inv_z;
+            let dp_dz_x = -fx * cam_x * inv_z2;
+            let dp_dy = fy * inv_z;
+            let dp_dz_y = -fy * cam_y * inv_z2;
+
+            // Rotation matrix from quaternion (for Jacobian w.r.t. point)
+            let (qw, qx, qy, qz) = (pose[0], pose[1], pose[2], pose[3]);
+            let r00 = 1.0 - 2.0 * (qy * qy + qz * qz);
+            let r01 = 2.0 * (qx * qy - qw * qz);
+            let r02 = 2.0 * (qx * qz + qw * qy);
+            let r10 = 2.0 * (qx * qy + qw * qz);
+            let r11 = 1.0 - 2.0 * (qx * qx + qz * qz);
+            let r12 = 2.0 * (qy * qz - qw * qx);
+            let r20 = 2.0 * (qx * qz - qw * qy);
+            let r21 = 2.0 * (qy * qz + qw * qx);
+            let r22 = 1.0 - 2.0 * (qx * qx + qy * qy);
+
+            // Jacobian w.r.t. point (3 cols): d(residual)/d(point) = -d(proj)/d(p_cam) * R
+            // residual = obs - proj, so d(residual)/d(point) = -d(proj)/d(p_cam) * d(p_cam)/d(point)
+            // d(p_cam)/d(point) = R
+            let j_point = [
+                // row 0 (du)
+                -(dp_dx * r00 + dp_dz_x * r20),
+                -(dp_dx * r01 + dp_dz_x * r21),
+                -(dp_dx * r02 + dp_dz_x * r22),
+                // row 1 (dv)
+                -(dp_dy * r10 + dp_dz_y * r20),
+                -(dp_dy * r11 + dp_dz_y * r21),
+                -(dp_dy * r12 + dp_dz_y * r22),
+            ];
+
+            // Jacobian w.r.t. pose (6 cols): tangent = [upsilon(3), omega(3)]
+            // Right perturbation: T_new = T * exp(δξ)
+            // p_cam_new = R * exp(δω) * p_w + t + R * δυ  (first order)
+            //           ≈ p_cam + R * (δυ + [δω]× * p_w)
+            //           = p_cam + R * δυ - R * [p_w]× * δω
+            //
+            // So d(p_cam)/d(δυ) = R, d(p_cam)/d(δω) = -R * [p_w]×
+            // And d(residual)/d(δξ) = -d(proj)/d(p_cam) * [R | -R*[p_w]×]
+
+            let (px, py, pz) = (point[0], point[1], point[2]);
+
+            // -R * [p_w]× where [p_w]× is the skew-symmetric of the world point
+            // [p_w]× = [[ 0, -pz,  py],
+            //           [ pz,  0, -px],
+            //           [-py,  px,  0]]
+            // R * [p_w]× gives 3x3, we need columns
+            // Compute R * hat(p) directly
+            // (R * hat(p))[i,j] = sum_k R[i,k] * hat(p)[k,j]
+            // hat(p) = [[0, -pz, py], [pz, 0, -px], [-py, px, 0]]
+            let rhat00 = r01 * pz - r02 * py;
+            let rhat01 = -r00 * pz + r02 * px;
+            let rhat02 = r00 * py - r01 * px;
+            let rhat10 = r11 * pz - r12 * py;
+            let rhat11 = -r10 * pz + r12 * px;
+            let rhat12 = r10 * py - r11 * px;
+            let rhat20 = r21 * pz - r22 * py;
+            let rhat21 = -r20 * pz + r22 * px;
+            let rhat22 = r20 * py - r21 * px;
+
+            // d(p_cam)/d(δυ) = R (3x3)
+            // d(p_cam)/d(δω) = -R * [p_w]× (3x3)
+            // Full: d(p_cam)/d(δξ) = [R | -R*hat(p)] (3x6)
+            //
+            // d(residual)/d(δξ) = -d(proj)/d(p_cam) * [R | -R*hat(p)]
+            let j_pose = [
+                // row 0 (du), cols: upsilon(3) then omega(3)
+                -(dp_dx * r00 + dp_dz_x * r20),
+                -(dp_dx * r01 + dp_dz_x * r21),
+                -(dp_dx * r02 + dp_dz_x * r22),
+                (dp_dx * rhat00 + dp_dz_x * rhat20),
+                (dp_dx * rhat01 + dp_dz_x * rhat21),
+                (dp_dx * rhat02 + dp_dz_x * rhat22),
+                // row 1 (dv), cols: upsilon(3) then omega(3)
+                -(dp_dy * r10 + dp_dz_y * r20),
+                -(dp_dy * r11 + dp_dz_y * r21),
+                -(dp_dy * r12 + dp_dz_y * r22),
+                (dp_dy * rhat10 + dp_dz_y * rhat20),
+                (dp_dy * rhat11 + dp_dz_y * rhat21),
+                (dp_dy * rhat12 + dp_dz_y * rhat22),
+            ];
+
+            // Full Jacobian: [j_point(2x3) | j_pose(2x6)] = 2x9 row-major
+            let mut jac = vec![
+                j_point[0], j_point[1], j_point[2],
+                j_pose[0], j_pose[1], j_pose[2], j_pose[3], j_pose[4], j_pose[5],
+                j_point[3], j_point[4], j_point[5],
+                j_pose[6], j_pose[7], j_pose[8], j_pose[9], j_pose[10], j_pose[11],
+            ];
+
+            // Pre-whiten
+            whiten_scalar(&mut residual, &mut jac, self.information_weight);
+
+            Some(jac)
+        } else {
+            // Still need to whiten the residual for cost computation
+            let sqrt_w = self.information_weight.sqrt();
+            for r in residual.iter_mut() {
+                *r *= sqrt_w;
+            }
+            None
+        };
+
+        Ok(LinearizationResult::new(residual, jacobian, 9))
+    }
+
+    fn residual_dim(&self) -> usize {
+        2
+    }
+
+    fn num_variables(&self) -> usize {
+        2
+    }
+
+    fn variable_local_dim(&self, idx: usize) -> usize {
+        match idx {
+            0 => 3, // map point
+            1 => 6, // SE3 pose
+            _ => panic!("ReprojectionFactor has 2 variables"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity_pose() -> [f32; 7] {
+        // [qw, qx, qy, qz, tx, ty, tz]
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    }
+
+    #[test]
+    fn zero_residual_at_projected_point() {
+        let fx = 500.0f32;
+        let fy = 500.0;
+        let cx = 320.0;
+        let cy = 240.0;
+
+        // Point at [1, 2, 5] in world frame, identity pose
+        let point = [1.0f32, 2.0, 5.0];
+        let pose = identity_pose();
+
+        // Expected projection
+        let u = fx * 1.0 / 5.0 + cx; // 420
+        let v = fy * 2.0 / 5.0 + cy; // 440
+
+        let factor = ReprojectionFactor::new([u, v], [fx, fy, cx, cy], 1.0);
+        let result = factor
+            .linearize(&[&point, &pose], false)
+            .unwrap();
+
+        assert!(result.residual[0].abs() < 1e-5);
+        assert!(result.residual[1].abs() < 1e-5);
+    }
+
+    #[test]
+    fn jacobian_numerical_check() {
+        let fx = 500.0f32;
+        let fy = 500.0;
+        let cx = 320.0;
+        let cy = 240.0;
+        let point = [1.0f32, 2.0, 5.0];
+        let pose = identity_pose();
+
+        let u = fx * 1.0 / 5.0 + cx;
+        let v = fy * 2.0 / 5.0 + cy;
+
+        // Use scale=1 so information_weight=1 (no whitening distortion)
+        let factor = ReprojectionFactor::new([u + 0.5, v - 0.3], [fx, fy, cx, cy], 1.0);
+
+        let result = factor
+            .linearize(&[&point, &pose], true)
+            .unwrap();
+        let jac = result.jacobian.unwrap();
+        let base_r = result.residual;
+
+        // Numerical Jacobian w.r.t. point
+        let eps = 1e-4f32;
+        for col in 0..3 {
+            let mut perturbed = point;
+            perturbed[col] += eps;
+            let r_plus = factor
+                .linearize(&[&perturbed, &pose], false)
+                .unwrap()
+                .residual;
+
+            let mut perturbed = point;
+            perturbed[col] -= eps;
+            let r_minus = factor
+                .linearize(&[&perturbed, &pose], false)
+                .unwrap()
+                .residual;
+
+            for row in 0..2 {
+                let numerical = (r_plus[row] - r_minus[row]) / (2.0 * eps);
+                let analytical = jac[row * 9 + col];
+                let tol = 1e-2 * analytical.abs().max(1.0);
+                assert!(
+                    (numerical - analytical).abs() < tol,
+                    "point jac mismatch at [{row},{col}]: numerical={numerical}, analytical={analytical}"
+                );
+            }
+        }
+    }
+}

--- a/crates/kornia-slam/src/frame.rs
+++ b/crates/kornia-slam/src/frame.rs
@@ -13,6 +13,8 @@ use kornia_imgproc::features::OrbFeatures;
 pub struct Frame {
     /// Frame index.
     pub idx: usize,
+    /// Capture timestamp in seconds.
+    pub timestamp: f64,
     /// Features extracted for this frame.
     pub features: OrbFeatures,
     /// Camera pose in world-to-camera convention.

--- a/crates/kornia-slam/src/lib.rs
+++ b/crates/kornia-slam/src/lib.rs
@@ -1,6 +1,7 @@
 //! Visual odometry and SLAM building blocks for kornia-rs.
 
 pub mod estimation;
+pub mod factors;
 pub mod frame;
 pub mod map;
 pub mod system;

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -30,6 +30,7 @@ use std::collections::{HashMap, HashSet};
 use kornia_3d::ba::{self, BaObservation, BaParams};
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
+use kornia_sensors::imu::PreintegratedImu;
 use kornia_algebra::Vec3F64;
 use kornia_image::ImageSize;
 
@@ -41,6 +42,9 @@ pub struct Keyframe {
     pub frame: Frame,
     /// For each descriptor index in `frame.features`, associated map-point index.
     pub map_point_by_desc_idx: Vec<Option<usize>>,
+    /// Preintegrated IMU measurements from the previous keyframe to this one.
+    /// `None` for the first keyframe or when no IMU data is available.
+    pub preintegrated_imu: Option<PreintegratedImu>,
 }
 
 impl Keyframe {
@@ -50,6 +54,7 @@ impl Keyframe {
         Self {
             frame,
             map_point_by_desc_idx,
+            preintegrated_imu: None,
         }
     }
 
@@ -493,10 +498,12 @@ mod tests {
         let n = descriptors.len();
         Frame {
             idx,
+            timestamp: 0.0,
             features: OrbFeatures {
                 keypoints_xy: (0..n).map(|i| [i as f32, i as f32]).collect(),
                 orientations: vec![0.0; n],
                 descriptors,
+                scales: vec![1.0; n],
             },
             pose_world_to_cam: Pose3d::IDENTITY,
             image_size: ImageSize {

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -30,10 +30,14 @@ use std::collections::{HashMap, HashSet};
 use kornia_3d::ba::{self, BaObservation, BaParams};
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
-use kornia_sensors::imu::PreintegratedImu;
-use kornia_algebra::Vec3F64;
+use kornia_sensors::imu::{ImuBias, PreintegratedImu};
+use kornia_algebra::{Mat3F64, Vec3F64};
+use kornia_algebra::optim::{LevenbergMarquardt, Problem, Variable, VariableType};
 use kornia_image::ImageSize;
 
+use crate::factors::inertial::InertialFactor;
+use crate::factors::bias_random_walk::BiasRandomWalkFactor;
+use crate::factors::reprojection::ReprojectionFactor;
 use crate::frame::Frame;
 
 /// A frame promoted into the map, with descriptor-to-map-point associations.
@@ -485,6 +489,390 @@ impl Map {
             }
         }
     }
+}
+
+/// Result returned by `run_local_ba_inertial`.
+///
+/// Contains optimized velocities and biases for each active keyframe,
+/// so the caller can update its system state.
+pub struct InertialBaResult {
+    /// Optimized velocity for the most recent (active) keyframe.
+    pub latest_velocity: Vec3F64,
+    /// Optimized bias for the most recent (active) keyframe.
+    pub latest_bias: ImuBias,
+}
+
+impl Map {
+    /// Run local bundle adjustment with inertial factors.
+    ///
+    /// This extends the visual-only BA by adding:
+    ///   - Velocity (R³) and bias (R⁶) variables per keyframe
+    ///   - `InertialFactor` between consecutive keyframes
+    ///   - `BiasRandomWalkFactor` between consecutive keyframe biases
+    ///   - `ReprojectionFactor` for each map point observation
+    ///
+    /// Variables before the active window are fixed (pose, velocity, bias).
+    /// Returns `None` if there aren't enough keyframes with IMU data.
+    pub fn run_local_ba_inertial(
+        &mut self,
+        camera: &PinholeCamera,
+        gravity: &[f32; 3],
+        current_velocity: &Vec3F64,
+        current_bias: &ImuBias,
+    ) -> Option<InertialBaResult> {
+        const MAX_ACTIVE_KFS: usize = 5;
+        const MIN_OBSERVATIONS: usize = 8;
+
+        let n_kfs = self.keyframes.len();
+        if n_kfs < 2 {
+            return None;
+        }
+
+        let active_start = n_kfs.saturating_sub(MAX_ACTIVE_KFS);
+
+        // Check that active keyframes have IMU preintegration
+        let has_imu = self.keyframes[active_start..]
+            .iter()
+            .skip(1) // first KF in window won't have preintegration to its predecessor
+            .all(|kf| kf.preintegrated_imu.is_some());
+        if !has_imu {
+            return None;
+        }
+
+        // ── Build the optimization problem ──────────────────────────────
+
+        let mut problem = Problem::new();
+
+        // Collect map points observed by active keyframes
+        let mut mp_set: HashSet<usize> = HashSet::new();
+        for kf in &self.keyframes[active_start..] {
+            for mp_idx in kf.map_point_by_desc_idx.iter().flatten() {
+                if let Some(mp) = self.map_points.get(*mp_idx) {
+                    if !mp.culled {
+                        mp_set.insert(*mp_idx);
+                    }
+                }
+            }
+        }
+        if mp_set.is_empty() {
+            return None;
+        }
+
+        let mut mp_global_indices: Vec<usize> = mp_set.iter().copied().collect();
+        mp_global_indices.sort_unstable();
+        let mp_global_to_local: HashMap<usize, usize> = mp_global_indices
+            .iter()
+            .enumerate()
+            .map(|(local, &global)| (global, local))
+            .collect();
+
+        // ── Add variables ───────────────────────────────────────────────
+
+        // Pose, velocity, and bias variables for each keyframe
+        for (kf_idx, kf) in self.keyframes.iter().enumerate() {
+            let is_fixed = kf_idx < active_start;
+            let pose_name = format!("pose_{kf_idx}");
+            let vel_name = format!("vel_{kf_idx}");
+            let bias_name = format!("bias_{kf_idx}");
+
+            // Pose (SE3): [qw, qx, qy, qz, tx, ty, tz]
+            let se3_params = pose_to_se3_params(&kf.frame.pose_world_to_cam);
+            if !is_fixed {
+                problem
+                    .add_variable(
+                        Variable::new(pose_name, VariableType::SE3, vec![0.0; 7]),
+                        se3_params,
+                    )
+                    .ok()?;
+            }
+
+            // Velocity (R³)
+            let vel_init = if kf_idx == n_kfs - 1 {
+                // Most recent keyframe uses current velocity
+                vec![
+                    current_velocity.x as f32,
+                    current_velocity.y as f32,
+                    current_velocity.z as f32,
+                ]
+            } else {
+                // For intermediate keyframes, initialize to zero
+                // (the optimizer will find the right values)
+                vec![0.0; 3]
+            };
+            if !is_fixed {
+                problem
+                    .add_variable(Variable::euclidean(vel_name, 3), vel_init)
+                    .ok()?;
+            }
+
+            // Bias (R⁶): [bg_x, bg_y, bg_z, ba_x, ba_y, ba_z]
+            let bias_init = if kf_idx == n_kfs - 1 {
+                vec![
+                    current_bias.gyro.x as f32,
+                    current_bias.gyro.y as f32,
+                    current_bias.gyro.z as f32,
+                    current_bias.accel.x as f32,
+                    current_bias.accel.y as f32,
+                    current_bias.accel.z as f32,
+                ]
+            } else {
+                vec![0.0; 6]
+            };
+            if !is_fixed {
+                problem
+                    .add_variable(Variable::euclidean(bias_name, 6), bias_init)
+                    .ok()?;
+            }
+        }
+
+        // Fixed variables: add as separate variables with fixed values
+        // For fixed keyframes, we embed their values directly in the factors
+        // by using the same parameter values. However, the Problem API needs
+        // all referenced variables to exist, so add fixed ones too.
+        for kf_idx in 0..active_start {
+            let kf = &self.keyframes[kf_idx];
+            let pose_name = format!("pose_{kf_idx}");
+            let vel_name = format!("vel_{kf_idx}");
+            let bias_name = format!("bias_{kf_idx}");
+
+            let se3_params = pose_to_se3_params(&kf.frame.pose_world_to_cam);
+            problem
+                .add_variable(
+                    Variable::new(pose_name, VariableType::SE3, vec![0.0; 7]),
+                    se3_params,
+                )
+                .ok()?;
+
+            problem
+                .add_variable(Variable::euclidean(vel_name, 3), vec![0.0; 3])
+                .ok()?;
+
+            problem
+                .add_variable(Variable::euclidean(bias_name, 6), vec![0.0; 6])
+                .ok()?;
+        }
+
+        // Point variables
+        for (local_idx, &global_idx) in mp_global_indices.iter().enumerate() {
+            let pt = &self.map_points[global_idx].position;
+            let var = Variable::euclidean(format!("pt_{local_idx}"), 3);
+            let init = vec![pt.x as f32, pt.y as f32, pt.z as f32];
+            problem.add_variable(var, init).ok()?;
+        }
+
+        // ── Add factors ─────────────────────────────────────────────────
+
+        let intrinsics = [
+            camera.fx as f32,
+            camera.fy as f32,
+            camera.cx as f32,
+            camera.cy as f32,
+        ];
+
+        // Reprojection factors
+        let mut n_obs = 0usize;
+        for (kf_idx, kf) in self.keyframes.iter().enumerate() {
+            let pose_name = format!("pose_{kf_idx}");
+            for (desc_idx, mp_opt) in kf.map_point_by_desc_idx.iter().enumerate() {
+                if let Some(mp_idx) = mp_opt {
+                    let Some(&local_pt_idx) = mp_global_to_local.get(mp_idx) else {
+                        continue;
+                    };
+                    if let Some(kp) = kf.frame.features.keypoints_xy.get(desc_idx) {
+                        let scale = kf
+                            .frame
+                            .features
+                            .scales
+                            .get(desc_idx)
+                            .copied()
+                            .unwrap_or(1.0);
+                        let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                        let factor = Box::new(ReprojectionFactor::new(
+                            [p.x as f32, p.y as f32],
+                            intrinsics,
+                            scale,
+                        ));
+                        let pt_name = format!("pt_{local_pt_idx}");
+                        problem
+                            .add_factor(factor, vec![pt_name, pose_name.clone()])
+                            .ok()?;
+                        n_obs += 1;
+                    }
+                }
+            }
+        }
+
+        if n_obs < MIN_OBSERVATIONS {
+            return None;
+        }
+
+        // Inertial + bias random walk factors between consecutive keyframes
+        for kf_idx in 1..n_kfs {
+            let Some(ref pre) = self.keyframes[kf_idx].preintegrated_imu else {
+                continue;
+            };
+
+            let prev_idx = kf_idx - 1;
+            let pose_i = format!("pose_{prev_idx}");
+            let vel_i = format!("vel_{prev_idx}");
+            let pose_j = format!("pose_{kf_idx}");
+            let vel_j = format!("vel_{kf_idx}");
+            let bias_i = format!("bias_{prev_idx}");
+            let bias_j = format!("bias_{kf_idx}");
+
+            // Inertial factor: connects pose_i, vel_i, pose_j, vel_j, bias_i
+            let inertial = Box::new(InertialFactor::new(pre, *gravity));
+            problem
+                .add_factor(
+                    inertial,
+                    vec![
+                        pose_i,
+                        vel_i,
+                        pose_j,
+                        vel_j,
+                        bias_i.clone(),
+                    ],
+                )
+                .ok()?;
+
+            // Bias random walk: connects bias_i, bias_j
+            let bias_rw = Box::new(BiasRandomWalkFactor::new(pre));
+            problem
+                .add_factor(bias_rw, vec![bias_i, bias_j])
+                .ok()?;
+        }
+
+        // ── Optimize ────────────────────────────────────────────────────
+
+        let optimizer = LevenbergMarquardt {
+            lambda_init: 1.0,
+            lambda_max: 1e10,
+            lambda_factor: 10.0,
+            max_iterations: 10,
+            cost_tolerance: 1e-6,
+            gradient_tolerance: 1e-8,
+        };
+
+        if optimizer.optimize(&mut problem).is_err() {
+            return None;
+        }
+
+        // ── Read back results ───────────────────────────────────────────
+
+        let vars = problem.get_variables();
+
+        // Update active keyframe poses
+        for kf_idx in active_start..n_kfs {
+            let pose_name = format!("pose_{kf_idx}");
+            if let Some(var) = vars.get(&pose_name) {
+                self.keyframes[kf_idx].frame.pose_world_to_cam =
+                    se3_params_to_pose(&var.values);
+            }
+        }
+
+        // Update map points
+        for (local_idx, &global_idx) in mp_global_indices.iter().enumerate() {
+            let pt_name = format!("pt_{local_idx}");
+            if let Some(var) = vars.get(&pt_name) {
+                if let Some(mp) = self.map_points.get_mut(global_idx) {
+                    mp.position = Vec3F64::new(
+                        var.values[0] as f64,
+                        var.values[1] as f64,
+                        var.values[2] as f64,
+                    );
+                }
+            }
+        }
+
+        // Read latest velocity and bias
+        let last_kf_idx = n_kfs - 1;
+        let vel_name = format!("vel_{last_kf_idx}");
+        let bias_name = format!("bias_{last_kf_idx}");
+
+        let latest_velocity = vars.get(&vel_name).map(|v| {
+            Vec3F64::new(v.values[0] as f64, v.values[1] as f64, v.values[2] as f64)
+        }).unwrap_or(*current_velocity);
+
+        let latest_bias = vars.get(&bias_name).map(|v| {
+            ImuBias {
+                gyro: Vec3F64::new(v.values[0] as f64, v.values[1] as f64, v.values[2] as f64),
+                accel: Vec3F64::new(v.values[3] as f64, v.values[4] as f64, v.values[5] as f64),
+            }
+        }).unwrap_or(*current_bias);
+
+        Some(InertialBaResult {
+            latest_velocity,
+            latest_bias,
+        })
+    }
+}
+
+/// Convert a `Pose3d` (rotation matrix + translation) to SE3 parameters [qw, qx, qy, qz, tx, ty, tz].
+fn pose_to_se3_params(pose: &Pose3d) -> Vec<f32> {
+    let r = &pose.rotation;
+    // Rotation matrix to quaternion (Shepperd's method)
+    let trace = r.col(0).x + r.col(1).y + r.col(2).z;
+    let (qw, qx, qy, qz) = if trace > 0.0 {
+        let s = 0.5 / (trace + 1.0).sqrt();
+        let w = 0.25 / s;
+        let x = (r.col(1).z - r.col(2).y) * s;
+        let y = (r.col(2).x - r.col(0).z) * s;
+        let z = (r.col(0).y - r.col(1).x) * s;
+        (w, x, y, z)
+    } else if r.col(0).x > r.col(1).y && r.col(0).x > r.col(2).z {
+        let s = 2.0 * (1.0 + r.col(0).x - r.col(1).y - r.col(2).z).sqrt();
+        let w = (r.col(1).z - r.col(2).y) / s;
+        let x = 0.25 * s;
+        let y = (r.col(1).x + r.col(0).y) / s;
+        let z = (r.col(2).x + r.col(0).z) / s;
+        (w, x, y, z)
+    } else if r.col(1).y > r.col(2).z {
+        let s = 2.0 * (1.0 + r.col(1).y - r.col(0).x - r.col(2).z).sqrt();
+        let w = (r.col(2).x - r.col(0).z) / s;
+        let x = (r.col(1).x + r.col(0).y) / s;
+        let y = 0.25 * s;
+        let z = (r.col(2).y + r.col(1).z) / s;
+        (w, x, y, z)
+    } else {
+        let s = 2.0 * (1.0 + r.col(2).z - r.col(0).x - r.col(1).y).sqrt();
+        let w = (r.col(0).y - r.col(1).x) / s;
+        let x = (r.col(2).x + r.col(0).z) / s;
+        let y = (r.col(2).y + r.col(1).z) / s;
+        let z = 0.25 * s;
+        (w, x, y, z)
+    };
+    vec![
+        qw as f32, qx as f32, qy as f32, qz as f32,
+        pose.translation.x as f32,
+        pose.translation.y as f32,
+        pose.translation.z as f32,
+    ]
+}
+
+/// Convert SE3 parameters [qw, qx, qy, qz, tx, ty, tz] back to a `Pose3d`.
+fn se3_params_to_pose(params: &[f32]) -> Pose3d {
+    let (qw, qx, qy, qz) = (params[0] as f64, params[1] as f64, params[2] as f64, params[3] as f64);
+    // Normalize quaternion
+    let norm = (qw * qw + qx * qx + qy * qy + qz * qz).sqrt();
+    let (qw, qx, qy, qz) = (qw / norm, qx / norm, qy / norm, qz / norm);
+    // Quaternion to rotation matrix
+    let r00 = 1.0 - 2.0 * (qy * qy + qz * qz);
+    let r01 = 2.0 * (qx * qy - qw * qz);
+    let r02 = 2.0 * (qx * qz + qw * qy);
+    let r10 = 2.0 * (qx * qy + qw * qz);
+    let r11 = 1.0 - 2.0 * (qx * qx + qz * qz);
+    let r12 = 2.0 * (qy * qz - qw * qx);
+    let r20 = 2.0 * (qx * qz - qw * qy);
+    let r21 = 2.0 * (qy * qz + qw * qx);
+    let r22 = 1.0 - 2.0 * (qx * qx + qy * qy);
+    Pose3d::new(
+        Mat3F64::from_cols(
+            Vec3F64::new(r00, r10, r20),
+            Vec3F64::new(r01, r11, r21),
+            Vec3F64::new(r02, r12, r22),
+        ),
+        Vec3F64::new(params[4] as f64, params[5] as f64, params[6] as f64),
+    )
 }
 
 #[cfg(test)]

--- a/crates/kornia-slam/src/system.rs
+++ b/crates/kornia-slam/src/system.rs
@@ -1,6 +1,8 @@
 //! System runtime state, mode transitions, and tracking results.
 
 use kornia_3d::pose::Pose3d;
+use kornia_algebra::Vec3F64;
+use kornia_sensors::imu::{ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
 
 use crate::frame::Frame;
 
@@ -87,6 +89,16 @@ pub struct SystemState {
     pub max_consecutive_failures: usize,
     pub bootstrap_frame: Option<Frame>,
     pub mode: SystemMode,
+    /// IMU state: world-frame velocity (m/s). `None` when IMU is not active.
+    pub imu_velocity: Option<Vec3F64>,
+    /// IMU state: current bias estimates.
+    pub imu_bias: ImuBias,
+    /// Gravity vector in world frame (e.g. [0, 0, -9.81]).
+    pub gravity: Vec3F64,
+    /// Buffered IMU measurements since the last processed frame.
+    pub imu_buffer: Vec<ImuMeasurement>,
+    /// IMU calibration parameters. `None` when running visual-only.
+    pub imu_calib: Option<ImuCalib>,
 }
 
 /// Pipeline mode.
@@ -109,7 +121,41 @@ impl SystemState {
             max_consecutive_failures: 15,
             bootstrap_frame: None,
             mode: SystemMode::Bootstrap,
+            imu_velocity: None,
+            imu_bias: ImuBias::default(),
+            gravity: Vec3F64::new(0.0, 0.0, -9.81),
+            imu_buffer: Vec::new(),
+            imu_calib: None,
         }
+    }
+
+    /// Enable IMU fusion by providing calibration parameters.
+    pub fn enable_imu(&mut self, calib: ImuCalib) {
+        self.imu_calib = Some(calib);
+    }
+
+    /// Buffer an IMU measurement. Call this for each IMU sample between camera frames.
+    pub fn push_imu(&mut self, measurement: ImuMeasurement) {
+        self.imu_buffer.push(measurement);
+    }
+
+    /// Preintegrate buffered IMU measurements up to the given timestamp,
+    /// returning the preintegrated result and draining consumed samples.
+    ///
+    /// Samples with timestamp > `up_to` are kept in the buffer for the next frame.
+    pub fn preintegrate_imu(&mut self, up_to: f64) -> Option<PreintegratedImu> {
+        let calib = self.imu_calib?;
+
+        // Partition: consume samples with timestamp <= up_to
+        let split_idx = self.imu_buffer.partition_point(|m| m.timestamp <= up_to);
+        if split_idx < 2 {
+            return None;
+        }
+
+        let consumed: Vec<_> = self.imu_buffer.drain(..split_idx).collect();
+        let mut pre = PreintegratedImu::new(self.imu_bias, calib);
+        pre.integrate_batch(&consumed);
+        Some(pre)
     }
 
     pub fn reset(&mut self) {
@@ -119,6 +165,8 @@ impl SystemState {
         self.velocity = None;
         self.consecutive_failures = 0;
         self.bootstrap_frame = None;
+        self.imu_velocity = None;
+        self.imu_buffer.clear();
     }
 }
 

--- a/examples/common/datasets/euroc.rs
+++ b/examples/common/datasets/euroc.rs
@@ -1,6 +1,8 @@
 //! Dataset readers for visual odometry benchmarks.
 
 use kornia_3d::camera::PinholeCamera;
+use kornia_sensors::imu::{ImuCalib, ImuMeasurement};
+use kornia_algebra::Vec3F64;
 use serde::Deserialize;
 use std::{fs::File, io::BufRead, io::BufReader, path::Path, path::PathBuf};
 
@@ -59,6 +61,28 @@ pub struct GroundTruthPose {
     pub qz: f64,
 }
 
+/// One raw IMU measurement from `mav0/imu0/data.csv`.
+#[derive(Debug, Clone, Copy)]
+pub struct ImuSample {
+    /// Timestamp in seconds.
+    pub timestamp_sec: f64,
+    /// Gyroscope [wx, wy, wz] in rad/s.
+    pub gyro: [f64; 3],
+    /// Accelerometer [ax, ay, az] in m/s².
+    pub accel: [f64; 3],
+}
+
+impl ImuSample {
+    /// Convert to a `kornia_sensors::imu::ImuMeasurement`.
+    pub fn to_imu_measurement(self) -> ImuMeasurement {
+        ImuMeasurement {
+            timestamp: self.timestamp_sec,
+            gyro: Vec3F64::new(self.gyro[0], self.gyro[1], self.gyro[2]),
+            accel: Vec3F64::new(self.accel[0], self.accel[1], self.accel[2]),
+        }
+    }
+}
+
 /// EuRoC `cam0` calibration loaded from `sensor.yaml`.
 #[derive(Debug, Clone, Copy)]
 pub struct EurocCameraCalibration {
@@ -104,6 +128,15 @@ struct EurocSensorYaml {
     distortion_coefficients: Vec<f64>,
 }
 
+/// IMU sensor.yaml from EuRoC `mav0/imu0/sensor.yaml`.
+#[derive(Debug, Deserialize)]
+struct EurocImuSensorYaml {
+    gyroscope_noise_density: f64,
+    accelerometer_noise_density: f64,
+    gyroscope_random_walk: f64,
+    accelerometer_random_walk: f64,
+}
+
 /// Reader for the EuRoC MAV dataset (ASL format).
 ///
 /// Expects `<root>/mav0/cam0/data.csv` with nanosecond timestamps and
@@ -120,6 +153,10 @@ pub struct EurocDataset {
     /// Ground-truth poses (empty if GT file not present).
     #[allow(dead_code)]
     pub ground_truth: Vec<GroundTruthPose>,
+    /// IMU samples from `imu0/data.csv` (empty if not present).
+    pub imu0_samples: Vec<ImuSample>,
+    /// IMU calibration from `imu0/sensor.yaml` (None if not present).
+    pub imu0_calibration: Option<ImuCalib>,
 }
 
 impl EurocDataset {
@@ -167,12 +204,16 @@ impl EurocDataset {
         }
 
         let ground_truth = Self::load_ground_truth(&root);
+        let imu0_samples = Self::load_imu_data(&root);
+        let imu0_calibration = Self::load_imu_calibration(&root);
 
         Ok(Self {
             root,
             cam0_samples: samples,
             cam0_calibration,
             ground_truth,
+            imu0_samples,
+            imu0_calibration,
         })
     }
 
@@ -190,6 +231,16 @@ impl EurocDataset {
     #[allow(dead_code)]
     pub fn ground_truth(&self) -> &[GroundTruthPose] {
         &self.ground_truth
+    }
+
+    /// Returns IMU samples sorted by timestamp (possibly empty).
+    pub fn imu_samples(&self) -> &[ImuSample] {
+        &self.imu0_samples
+    }
+
+    /// Returns IMU calibration if `imu0/sensor.yaml` was found.
+    pub fn imu_calib(&self) -> Option<ImuCalib> {
+        self.imu0_calibration
     }
 
     /// Loads ground-truth poses from `mav0/state_groundtruth_estimate0/data.csv`.
@@ -242,6 +293,65 @@ impl EurocDataset {
             });
         }
         poses
+    }
+
+    /// Loads IMU measurements from `mav0/imu0/data.csv`.
+    ///
+    /// CSV format: `timestamp_ns, w_x, w_y, w_z, a_x, a_y, a_z`
+    /// Returns an empty Vec if the file does not exist.
+    fn load_imu_data(root: &Path) -> Vec<ImuSample> {
+        let csv = root.join("mav0").join("imu0").join("data.csv");
+        let file = match File::open(&csv) {
+            Ok(f) => f,
+            Err(_) => return Vec::new(),
+        };
+        let reader = BufReader::new(file);
+        let mut samples = Vec::new();
+
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            if line.starts_with('#') || line.trim().is_empty() {
+                continue;
+            }
+            let cols: Vec<&str> = line.split(',').collect();
+            if cols.len() < 7 {
+                continue;
+            }
+            let Ok(ts_ns) = cols[0].trim().parse::<u64>() else {
+                continue;
+            };
+            let f = |i: usize| cols[i].trim().parse::<f64>();
+            let (Ok(wx), Ok(wy), Ok(wz), Ok(ax), Ok(ay), Ok(az)) =
+                (f(1), f(2), f(3), f(4), f(5), f(6))
+            else {
+                continue;
+            };
+
+            samples.push(ImuSample {
+                timestamp_sec: ts_ns as f64 * 1e-9,
+                gyro: [wx, wy, wz],
+                accel: [ax, ay, az],
+            });
+        }
+        samples
+    }
+
+    /// Loads IMU calibration from `mav0/imu0/sensor.yaml`.
+    ///
+    /// Returns `None` if the file does not exist or cannot be parsed.
+    fn load_imu_calibration(root: &Path) -> Option<ImuCalib> {
+        let sensor_yaml = root.join("mav0").join("imu0").join("sensor.yaml");
+        let file = File::open(&sensor_yaml).ok()?;
+        let sensor: EurocImuSensorYaml = serde_yaml::from_reader(file).ok()?;
+        Some(ImuCalib {
+            gyro_noise: sensor.gyroscope_noise_density,
+            accel_noise: sensor.accelerometer_noise_density,
+            gyro_bias_noise: sensor.gyroscope_random_walk,
+            accel_bias_noise: sensor.accelerometer_random_walk,
+        })
     }
 
     fn load_cam0_calibration(root: &Path) -> Result<EurocCameraCalibration, DatasetError> {

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -8,6 +8,7 @@ description = "ORB-SLAM example for kornia-slam"
 [dependencies]
 argh = "0.1"
 kornia-slam = { path = "../../crates/kornia-slam" }
+kornia-sensors = { path = "../../crates/kornia-sensors" }
 kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -138,6 +138,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Run SLAM.
         let frame = Frame {
             idx,
+            timestamp: sample.timestamp_sec,
             features,
             pose_world_to_cam: Pose3d::IDENTITY,
             image_size,

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -23,8 +23,8 @@ use pipeline::Pipeline;
 use datasets::EurocDataset;
 
 use utils::{
-    log_camera_to_rerun, log_frame_to_rerun, log_map_points_to_rerun, log_trajectory_to_rerun,
-    trajectory_point_from_pose,
+    log_camera_to_rerun, log_frame_to_rerun, log_imu_covariance_to_rerun, log_imu_to_rerun,
+    log_map_points_to_rerun, log_trajectory_to_rerun, trajectory_point_from_pose,
 };
 
 /// CLI arguments.
@@ -46,6 +46,10 @@ struct Args {
     /// skip this many initial frames
     #[argh(option, default = "0")]
     start_frame: usize,
+
+    /// enable IMU fusion (requires imu0/ in dataset)
+    #[argh(switch)]
+    imu: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -78,6 +82,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── SLAM config & system ───────────────────────────────────────────────
     let mut system = Pipeline::new(camera.clone(), PipelineConfig::default());
+
+    // ── IMU ────────────────────────────────────────────────────────────
+    // Always load IMU samples for visualization; only enable fusion with --imu.
+    let imu_samples = dataset.imu_samples();
+    if args.imu {
+        if let Some(imu_calib) = dataset.imu_calib() {
+            system.enable_imu(imu_calib);
+            eprintln!("IMU enabled: {} samples", imu_samples.len());
+        } else {
+            eprintln!("Warning: --imu requested but no imu0/sensor.yaml found");
+        }
+    } else if !imu_samples.is_empty() {
+        eprintln!("IMU data available ({} samples), pass --imu to enable fusion", imu_samples.len());
+    }
+    let mut imu_cursor = 0;
 
     // ── Rerun ──────────────────────────────────────────────────────────────
     let rec = if args.rerun_stream {
@@ -135,6 +154,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             })
             .collect();
 
+        // Advance IMU cursor up to this camera frame's timestamp.
+        let imu_batch_start = imu_cursor;
+        while imu_cursor < imu_samples.len()
+            && imu_samples[imu_cursor].timestamp_sec <= sample.timestamp_sec
+        {
+            imu_cursor += 1;
+        }
+
+        // Feed IMU samples to pipeline (only when fusion is enabled)
+        if args.imu {
+            for s in &imu_samples[imu_batch_start..imu_cursor] {
+                system.push_imu(s.to_imu_measurement());
+            }
+        }
+
+        // Log IMU data to Rerun
+        if let Some(ref rec) = rec {
+            log_imu_to_rerun(rec, &imu_samples[imu_batch_start..imu_cursor]);
+        }
+
         // Run SLAM.
         let frame = Frame {
             idx,
@@ -165,6 +204,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log_trajectory_to_rerun(rec, &trajectory);
             log_camera_to_rerun(rec, &result.pose_world_to_cam, &camera, image_size);
             log_map_points_to_rerun(rec, system.map_points());
+            if args.imu {
+                if let Some(pre) = system.latest_preintegrated_imu() {
+                    log_imu_covariance_to_rerun(rec, pre);
+                }
+            }
         }
     }
 

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -289,6 +289,7 @@ impl Pipeline {
 
         let mut curr_kf = Keyframe::from_frame(Frame {
             idx: frame.idx,
+            timestamp: frame.timestamp,
             features: frame.features.clone(),
             pose_world_to_cam: self.state.pose_world_to_cam,
             image_size: frame.image_size,

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -18,6 +18,7 @@ use kornia_slam::map::{Keyframe, Map, MapPoint};
 use kornia_slam::system::{
     KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus,
 };
+use kornia_sensors::imu::{ImuCalib, ImuMeasurement, PreintegratedImu};
 
 /// Top-level ORB-SLAM pipeline: orchestrates tracking, mapping, and state transitions.
 pub struct Pipeline {
@@ -76,6 +77,25 @@ impl Pipeline {
         self.map.map_points().len()
     }
 
+    /// Enable IMU fusion by providing calibration parameters.
+    pub fn enable_imu(&mut self, calib: ImuCalib) {
+        self.state.enable_imu(calib);
+    }
+
+    /// Buffer an IMU measurement for preintegration.
+    pub fn push_imu(&mut self, measurement: ImuMeasurement) {
+        self.state.push_imu(measurement);
+    }
+
+    /// Returns the preintegrated IMU attached to the most recent keyframe, if any.
+    pub fn latest_preintegrated_imu(&self) -> Option<&PreintegratedImu> {
+        self.map
+            .keyframes()
+            .iter()
+            .rev()
+            .find_map(|kf| kf.preintegrated_imu.as_ref())
+    }
+
     fn bootstrap_step(&mut self, mut curr_frame: Frame) -> TrackingResult {
         // Stamp frames with current odometry pose so bootstrap builds
         // the new map in the existing coordinate frame.
@@ -118,7 +138,12 @@ impl Pipeline {
 
         // Promote to Keyframes
         let reference_kf = Keyframe::from_frame(prev_bootstrap_frame);
-        let current_kf = Keyframe::from_frame(curr_frame);
+        let mut current_kf = Keyframe::from_frame(curr_frame);
+
+        // Attach preintegrated IMU to the second bootstrap keyframe
+        current_kf.preintegrated_imu = self
+            .state
+            .preintegrate_imu(current_kf.frame.timestamp);
         let curr_idx = current_kf.frame.idx;
 
         self.build_initial_map(
@@ -299,6 +324,9 @@ impl Pipeline {
             curr_kf.associate_map_point(curr_idx, mp_idx);
         }
 
+        // Attach preintegrated IMU from the previous keyframe to this one
+        curr_kf.preintegrated_imu = self.state.preintegrate_imu(frame.timestamp);
+
         let enable_local_ba = self.enable_local_ba;
         let match_config = self.two_view_init_config.match_config;
         let estimation_config = self.two_view_init_config.estimation_config.clone();
@@ -314,7 +342,27 @@ impl Pipeline {
         self.state.last_keyframe_idx = Some(frame.idx);
 
         if enable_local_ba {
-            self.map.run_local_ba(&self.camera);
+            let imu_velocity = self.state.imu_velocity.unwrap_or(Vec3F64::ZERO);
+            let gravity = [
+                self.state.gravity.x as f32,
+                self.state.gravity.y as f32,
+                self.state.gravity.z as f32,
+            ];
+
+            if let Some(result) = self.map.run_local_ba_inertial(
+                &self.camera,
+                &gravity,
+                &imu_velocity,
+                &self.state.imu_bias,
+            ) {
+                // Update IMU state from optimized values
+                self.state.imu_velocity = Some(result.latest_velocity);
+                self.state.imu_bias = result.latest_bias;
+            } else {
+                // Fall back to visual-only BA
+                self.map.run_local_ba(&self.camera);
+            }
+
             if let Some(newest_kf) = self.map.keyframes().last() {
                 self.state.pose_world_to_cam = newest_kf.frame.pose_world_to_cam;
             }

--- a/examples/orb_slam/src/utils.rs
+++ b/examples/orb_slam/src/utils.rs
@@ -4,8 +4,11 @@ use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_algebra::Mat3F64;
 use kornia_image::{Image, ImageSize};
+use kornia_sensors::imu::PreintegratedImu;
 use kornia_slam::map::MapPoint;
 use kornia_tensor::CpuAllocator;
+
+use crate::datasets::euroc::ImuSample;
 
 const CAMERA_IMAGE_PLANE_DISTANCE: f32 = 0.15;
 
@@ -100,6 +103,68 @@ pub fn log_map_points_to_rerun(rec: &rerun::RecordingStream, map_points: &[MapPo
         )
         .ok();
     }
+}
+
+/// Log a batch of IMU samples as scalar time series (gyro + accel, one point per axis).
+pub fn log_imu_to_rerun(rec: &rerun::RecordingStream, samples: &[ImuSample]) {
+    for s in samples {
+        rec.set_time(
+            "imu_time",
+            rerun::TimeCell::from_duration_nanos((s.timestamp_sec * 1e9) as i64),
+        );
+        rec.log("imu/gyro/x", &rerun::Scalars::new([s.gyro[0]])).ok();
+        rec.log("imu/gyro/y", &rerun::Scalars::new([s.gyro[1]])).ok();
+        rec.log("imu/gyro/z", &rerun::Scalars::new([s.gyro[2]])).ok();
+        rec.log("imu/accel/x", &rerun::Scalars::new([s.accel[0]])).ok();
+        rec.log("imu/accel/y", &rerun::Scalars::new([s.accel[1]])).ok();
+        rec.log("imu/accel/z", &rerun::Scalars::new([s.accel[2]])).ok();
+    }
+}
+
+/// Log IMU preintegration covariances as 2D heatmap tensors.
+///
+/// Two tensors are logged:
+///   - `imu/cov_nav`: 9×9 navigation covariance (tangent-space blocks: rot, vel, pos)
+///   - `imu/cov_bias`: 6×6 bias covariance (blocks: bias_gyro, bias_accel)
+///
+/// Raw covariance entries span many orders of magnitude, so we also log a
+/// signed-log version (`..._log`) which makes off-diagonal structure visible
+/// in the Rerun viewer's default linear colormap.
+pub fn log_imu_covariance_to_rerun(rec: &rerun::RecordingStream, pre: &PreintegratedImu) {
+    // Rerun tensors are row-major; our covariances are stored column-major.
+    // Since covariance matrices are symmetric the transpose equals itself,
+    // so the flat buffer can be used directly without reordering.
+    log_matrix_heatmap(rec, "imu/cov_nav", &pre.covariance, 9);
+    log_matrix_heatmap(rec, "imu/cov_bias", &pre.bias_covariance, 6);
+}
+
+fn log_matrix_heatmap(rec: &rerun::RecordingStream, entity: &str, data: &[f64], n: usize) {
+    let shape = vec![n as u64, n as u64];
+
+    // Raw values.
+    let raw = rerun::datatypes::TensorData::new(
+        shape.clone(),
+        rerun::datatypes::TensorBuffer::F64(data.to_vec().into()),
+    );
+    rec.log(entity, &rerun::Tensor::new(raw).with_dim_names(["row", "col"]))
+        .ok();
+
+    // Signed-log version: sign(x) * log10(1 + |x|/eps) — keeps sign but
+    // compresses the dynamic range so off-diagonal structure is visible.
+    const EPS: f64 = 1e-12;
+    let slog: Vec<f64> = data
+        .iter()
+        .map(|&x| x.signum() * (1.0 + x.abs() / EPS).log10())
+        .collect();
+    let log_data = rerun::datatypes::TensorData::new(
+        shape,
+        rerun::datatypes::TensorBuffer::F64(slog.into()),
+    );
+    rec.log(
+        format!("{entity}_log"),
+        &rerun::Tensor::new(log_data).with_dim_names(["row", "col"]),
+    )
+    .ok();
 }
 
 /// Convert a world-to-camera pose into a camera-to-world trajectory point.


### PR DESCRIPTION
## Summary

Extends the visual pipeline with IMU fusion, building on the preintegration primitives from #15.

- **Inertial local BA** (`crates/kornia-slam/src/map.rs`) — `run_local_ba_inertial` combines reprojection, `InertialFactor` between consecutive keyframes, and `BiasRandomWalkFactor` on biases. Returns `InertialBaResult` with the latest velocity/bias so the pipeline can update its state.
- **EuRoC IMU loading** (`examples/common/datasets/euroc.rs`) — reads `imu0/data.csv` and `imu0/sensor.yaml` calibration.
- **Pipeline wiring** (`examples/orb_slam/src/pipeline.rs`, `main.rs`) — attaches preintegrated IMU to each accepted keyframe, runs inertial BA when available and falls back to visual-only BA otherwise. New `latest_preintegrated_imu()` accessor for diagnostics.
- **Covariance heatmap viz** (`examples/orb_slam/src/utils.rs`) — logs the 9×9 navigation covariance (rot/vel/pos) and 6×6 bias covariance as 2D tensors to Rerun, plus a signed-log version (`sign(x)·log10(1+|x|/eps)`) so off-diagonal structure is visible alongside the much larger diagonal entries.

Run with `--imu --rerun-stream` on a EuRoC sequence to see preintegration uncertainty grow between keyframes.

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo test -p kornia-sensors` passes (existing preintegration tests)
- [ ] `cargo run --manifest-path examples/orb_slam/Cargo.toml --release -- --data <EuRoC MH_01> --imu --rerun-stream` runs end-to-end and produces a trajectory
- [ ] Rerun viewer shows `imu/cov_nav`, `imu/cov_nav_log`, `imu/cov_bias`, `imu/cov_bias_log` as heatmaps
- [ ] Inertial BA path is exercised (confirm via logs / keyframe count)
- [ ] Sanity-check: visual-only path still works when `--imu` is omitted