### PR TITLE
feat: ORB-SLAM3 monocular parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4900,6 +4900,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kornia-bow"
+version = "0.1.11"
+dependencies = [
+ "bincode 2.0.1",
+ "rand 0.9.2",
+ "rayon",
+ "serde",
+ "serde-big-array",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kornia-image"
 version = "0.1.11"
 dependencies = [
@@ -4952,9 +4964,26 @@ version = "0.1.0"
 dependencies = [
  "kornia-3d",
  "kornia-algebra",
+ "kornia-bow",
  "kornia-image",
  "kornia-imgproc",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kornia-slam-parity"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "kornia-3d",
+ "kornia-algebra",
+ "kornia-image",
+ "kornia-imgproc",
+ "kornia-io",
+ "kornia-slam",
+ "kornia-tensor",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -6411,6 +6440,7 @@ dependencies = [
  "argh",
  "kornia-3d",
  "kornia-algebra",
+ "kornia-bow",
  "kornia-image",
  "kornia-imgproc",
  "kornia-io",
@@ -9911,6 +9941,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
 [workspace]
-members = ["crates/*", "examples/orb_slam"]
+members = ["crates/*", "examples/orb_slam", "parity/rust"]
 resolver = "3"
+
+[patch."https://github.com/kornia/kornia-rs"]
+kornia-3d = { path = "/home/christie/projects/kornia-rs/crates/kornia-3d" }
+kornia-algebra = { path = "/home/christie/projects/kornia-rs/crates/kornia-algebra" }
+kornia-bow = { path = "/home/christie/projects/kornia-rs/crates/kornia-bow" }
+kornia-image = { path = "/home/christie/projects/kornia-rs/crates/kornia-image" }
+kornia-imgproc = { path = "/home/christie/projects/kornia-rs/crates/kornia-imgproc" }
+kornia-io = { path = "/home/christie/projects/kornia-rs/crates/kornia-io" }
+kornia-tensor = { path = "/home/christie/projects/kornia-rs/crates/kornia-tensor" }

--- a/crates/kornia-slam/Cargo.toml
+++ b/crates/kornia-slam/Cargo.toml
@@ -7,6 +7,7 @@ description = "Spatial runtime for real-time pose estimation, mapping, and agent
 [dependencies]
 kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-bow = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 thiserror = "2"

--- a/crates/kornia-slam/src/estimation/map_projection/keypoint_grid.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/keypoint_grid.rs
@@ -1,129 +1,212 @@
-//! Spatial grid for fast keypoint radius queries.
+//! Spatial grid that mirrors ORB-SLAM3 `Frame::GetFeaturesInArea`.
 
-/// A 2D grid that bins keypoints by their image position for O(1) spatial queries.
+const FRAME_GRID_COLS: usize = 64;
+const FRAME_GRID_ROWS: usize = 48;
+
+/// A 2D grid over undistorted image bounds for ORB-SLAM3-style keypoint lookups.
 pub(super) struct KeypointGrid {
     cells: Vec<Vec<usize>>,
-    cell_w: f32,
-    cell_h: f32,
-    n_cols: usize,
-    n_rows: usize,
-    img_w: f32,
-    img_h: f32,
+    min_x: f32,
+    max_x: f32,
+    min_y: f32,
+    max_y: f32,
+    grid_w_inv: f32,
+    grid_h_inv: f32,
 }
 
 impl KeypointGrid {
-    /// Builds a grid over `keypoints_xy` (each `[x, y]`) for an image of size `img_w x img_h`.
-    ///
-    /// Each cell is `cell_size x cell_size` pixels. Points outside the image are clamped.
-    pub(super) fn new(keypoints_xy: &[[f32; 2]], img_w: f32, img_h: f32, cell_size: f32) -> Self {
-        let n_cols = (img_w / cell_size).ceil() as usize;
-        let n_rows = (img_h / cell_size).ceil() as usize;
-        let n_cells = n_cols * n_rows;
-        let mut cells = vec![Vec::new(); n_cells];
+    /// Builds the grid using ORB-SLAM3's fixed 64x48 layout over undistorted
+    /// image bounds. Keypoints outside the bounds are skipped.
+    pub(super) fn new(
+        keypoints_xy: &[[f32; 2]],
+        image_bounds: (f32, f32, f32, f32),
+    ) -> Self {
+        let (min_x, max_x, min_y, max_y) = image_bounds;
+        let width = (max_x - min_x).max(1.0);
+        let height = (max_y - min_y).max(1.0);
+        let grid_w_inv = FRAME_GRID_COLS as f32 / width;
+        let grid_h_inv = FRAME_GRID_ROWS as f32 / height;
+        let mut cells = vec![Vec::new(); FRAME_GRID_COLS * FRAME_GRID_ROWS];
 
         for (i, kp) in keypoints_xy.iter().enumerate() {
-            let col = ((kp[0] / cell_size) as usize).min(n_cols - 1);
-            let row = ((kp[1] / cell_size) as usize).min(n_rows - 1);
-            cells[row * n_cols + col].push(i);
+            if let Some((col, row)) = pos_in_grid(kp[0], kp[1], min_x, min_y, grid_w_inv, grid_h_inv)
+            {
+                cells[row * FRAME_GRID_COLS + col].push(i);
+            }
         }
 
         Self {
             cells,
-            cell_w: cell_size,
-            cell_h: cell_size,
-            n_cols,
-            n_rows,
-            img_w,
-            img_h,
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+            grid_w_inv,
+            grid_h_inv,
         }
     }
 
-    /// Returns indices of keypoints within `radius` pixels of `(x, y)`.
-    pub(super) fn query_radius(
+    /// Returns indices matching ORB-SLAM3 `GetFeaturesInArea`: square search
+    /// window, optional octave range, and undistorted-bounds grid traversal.
+    pub(super) fn query_features_in_area(
         &self,
         x: f32,
         y: f32,
         radius: f32,
+        min_level: isize,
+        max_level: isize,
         keypoints_xy: &[[f32; 2]],
+        scales: &[f32],
+        keypoint_octave: impl Fn(f32) -> usize,
     ) -> Vec<usize> {
-        let r_sq = radius * radius;
-
-        let col_min = ((x - radius).max(0.0) / self.cell_w) as usize;
-        let col_max =
-            (((x + radius).min(self.img_w - 1.0) / self.cell_w) as usize).min(self.n_cols - 1);
-        let row_min = ((y - radius).max(0.0) / self.cell_h) as usize;
-        let row_max =
-            (((y + radius).min(self.img_h - 1.0) / self.cell_h) as usize).min(self.n_rows - 1);
-
         let mut result = Vec::new();
-        for r in row_min..=row_max {
-            for c in col_min..=col_max {
-                for &idx in &self.cells[r * self.n_cols + c] {
+
+        let n_min_cell_x = (((x - self.min_x - radius) * self.grid_w_inv).floor() as isize)
+            .max(0);
+        if n_min_cell_x >= FRAME_GRID_COLS as isize {
+            return result;
+        }
+        let n_max_cell_x = (((x - self.min_x + radius) * self.grid_w_inv).ceil() as isize)
+            .min(FRAME_GRID_COLS as isize - 1);
+        if n_max_cell_x < 0 {
+            return result;
+        }
+
+        let n_min_cell_y = (((y - self.min_y - radius) * self.grid_h_inv).floor() as isize)
+            .max(0);
+        if n_min_cell_y >= FRAME_GRID_ROWS as isize {
+            return result;
+        }
+        let n_max_cell_y = (((y - self.min_y + radius) * self.grid_h_inv).ceil() as isize)
+            .min(FRAME_GRID_ROWS as isize - 1);
+        if n_max_cell_y < 0 {
+            return result;
+        }
+
+        let check_levels = min_level > 0 || max_level >= 0;
+        for ix in n_min_cell_x..=n_max_cell_x {
+            for iy in n_min_cell_y..=n_max_cell_y {
+                for &idx in &self.cells[iy as usize * FRAME_GRID_COLS + ix as usize] {
+                    if check_levels {
+                        let octave = keypoint_octave(scales.get(idx).copied().unwrap_or(1.0)) as isize;
+                        if octave < min_level {
+                            continue;
+                        }
+                        if max_level >= 0 && octave > max_level {
+                            continue;
+                        }
+                    }
+
                     let kp = keypoints_xy[idx];
                     let dx = kp[0] - x;
                     let dy = kp[1] - y;
-                    if dx * dx + dy * dy <= r_sq {
+                    if dx.abs() < radius && dy.abs() < radius {
                         result.push(idx);
                     }
                 }
             }
         }
+
         result
     }
+
+    #[allow(dead_code)]
+    pub(super) fn bounds(&self) -> (f32, f32, f32, f32) {
+        (self.min_x, self.max_x, self.min_y, self.max_y)
+    }
+}
+
+fn pos_in_grid(
+    x: f32,
+    y: f32,
+    min_x: f32,
+    min_y: f32,
+    grid_w_inv: f32,
+    grid_h_inv: f32,
+) -> Option<(usize, usize)> {
+    let col = ((x - min_x) * grid_w_inv).round() as isize;
+    let row = ((y - min_y) * grid_h_inv).round() as isize;
+    if !(0..FRAME_GRID_COLS as isize).contains(&col) || !(0..FRAME_GRID_ROWS as isize).contains(&row)
+    {
+        return None;
+    }
+    Some((col as usize, row as usize))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn octave_from_scale(scale: f32) -> usize {
+        match scale.round() as i32 {
+            1 => 0,
+            2 => 1,
+            _ => 0,
+        }
+    }
+
     #[test]
     fn test_empty_grid() {
-        let grid = KeypointGrid::new(&[], 640.0, 480.0, 64.0);
-        let result = grid.query_radius(320.0, 240.0, 50.0, &[]);
+        let grid = KeypointGrid::new(&[], (0.0, 640.0, 0.0, 480.0));
+        let result =
+            grid.query_features_in_area(320.0, 240.0, 50.0, -1, -1, &[], &[], octave_from_scale);
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_single_point_found() {
         let kps = [[100.0, 100.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
+        let scales = [1.0];
+        let grid = KeypointGrid::new(&kps, (0.0, 640.0, 0.0, 480.0));
 
-        let result = grid.query_radius(100.0, 100.0, 10.0, &kps);
+        let result = grid.query_features_in_area(
+            100.0,
+            100.0,
+            10.0,
+            -1,
+            -1,
+            &kps,
+            &scales,
+            octave_from_scale,
+        );
         assert_eq!(result, vec![0]);
-
-        let result = grid.query_radius(500.0, 400.0, 10.0, &kps);
-        assert!(result.is_empty());
     }
 
     #[test]
-    fn test_radius_boundary() {
-        let kps = [[50.0, 50.0], [60.0, 50.0], [100.0, 50.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 32.0);
-
-        let mut result = grid.query_radius(55.0, 50.0, 15.0, &kps);
+    fn test_square_window_matches_orb_slam3() {
+        let kps = [[65.0, 65.0], [75.0, 75.0], [85.0, 85.0]];
+        let scales = [1.0, 1.0, 1.0];
+        let grid = KeypointGrid::new(&kps, (0.0, 640.0, 0.0, 480.0));
+        let mut result = grid.query_features_in_area(
+            70.0,
+            70.0,
+            10.0,
+            -1,
+            -1,
+            &kps,
+            &scales,
+            octave_from_scale,
+        );
         result.sort();
         assert_eq!(result, vec![0, 1]);
     }
 
     #[test]
-    fn test_corner_clamping() {
-        let kps = [[0.0, 0.0], [639.0, 479.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
+    fn test_level_filter_matches_orb_slam3_bounds() {
+        let kps = [[100.0, 100.0], [102.0, 100.0]];
+        let scales = [1.0, 2.0];
+        let grid = KeypointGrid::new(&kps, (0.0, 640.0, 0.0, 480.0));
 
-        let result = grid.query_radius(0.0, 0.0, 5.0, &kps);
+        let result = grid.query_features_in_area(
+            101.0,
+            100.0,
+            5.0,
+            0,
+            0,
+            &kps,
+            &scales,
+            octave_from_scale,
+        );
         assert_eq!(result, vec![0]);
-
-        let result = grid.query_radius(639.0, 479.0, 5.0, &kps);
-        assert_eq!(result, vec![1]);
-    }
-
-    #[test]
-    fn test_multiple_points_per_cell() {
-        let kps = [[10.0, 10.0], [12.0, 11.0], [15.0, 13.0]];
-        let grid = KeypointGrid::new(&kps, 640.0, 480.0, 64.0);
-
-        let mut result = grid.query_radius(12.0, 12.0, 20.0, &kps);
-        result.sort();
-        assert_eq!(result, vec![0, 1, 2]);
     }
 }

--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -37,12 +37,16 @@ use crate::map::{Map, MapPoint};
 use super::Estimate;
 use keypoint_grid::KeypointGrid;
 
+const ORB_SCALE_FACTOR: f64 = 1.2;
+const ORB_N_LEVELS: usize = 8;
+const VIEWING_COS_LIMIT: f64 = 0.5;
+
 /// Tunable parameters for projection-guided matching.
 #[derive(Debug, Clone, Copy)]
 pub struct ProjectionMatchConfig {
     /// Reject projected points with depth `<= min_depth`.
     pub min_depth: f64,
-    /// Keypoint search radius around each projected pixel.
+    /// Multiplier applied to the ORB-SLAM3-style search radius.
     pub search_radius: f32,
     /// Maximum Hamming distance to accept a descriptor match.
     pub max_hamming: u32,
@@ -52,8 +56,8 @@ impl Default for ProjectionMatchConfig {
     fn default() -> Self {
         Self {
             min_depth: 0.0,
-            search_radius: 15.0,
-            max_hamming: 50,
+            search_radius: 1.0,
+            max_hamming: 100,
         }
     }
 }
@@ -83,8 +87,8 @@ impl Default for MapProjectionConfig {
             pnp: PnpConfig::default(),
             projection: ProjectionMatchConfig::default(),
             local_projection: ProjectionMatchConfig {
-                search_radius: 30.0,
-                max_hamming: 60,
+                search_radius: 1.0,
+                max_hamming: 100,
                 ..ProjectionMatchConfig::default()
             },
         }
@@ -106,6 +110,103 @@ pub enum MapProjectionRejectReason {
     LowReferenceCorrespondences,
 }
 
+/// Non-behavioral counters from one map-projection tracking attempt.
+#[derive(Debug, Clone, Default)]
+pub struct MapProjectionReport {
+    /// Matches from the first projection-guided pass.
+    pub projection_matches: usize,
+    /// PnP inliers from the first projection-guided pass.
+    pub projection_pnp_inliers: usize,
+    /// Descriptor matches against the current reference keyframe.
+    pub reference_matches: usize,
+    /// Usable 3D-2D correspondences built from reference matches.
+    pub reference_correspondences: usize,
+    /// Matches from local-map projection refinement.
+    pub local_projection_matches: usize,
+    /// PnP inliers from local-map refinement.
+    pub local_pnp_inliers: usize,
+    /// Rejection reason if tracking failed.
+    pub reject_reason: Option<MapProjectionRejectReason>,
+}
+
+/// Per-map-point projection/matching decisions for parity debugging.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectionDebugFeatureCandidate {
+    /// Keypoint index in the current debug frame.
+    pub keypoint_idx: usize,
+    /// Pyramid octave for this candidate keypoint.
+    pub octave: usize,
+    /// Whether the feature was already occupied before matching.
+    pub occupied_before: bool,
+    /// Hamming distance to the map-point descriptor.
+    pub descriptor_dist: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProjectionDebugMatcherTrace {
+    /// Search radius used for `GetFeaturesInArea` / grid query.
+    pub search_radius: f32,
+    /// Minimum accepted octave.
+    pub min_level: isize,
+    /// Maximum accepted octave.
+    pub max_level: isize,
+    /// Best candidate feature index.
+    pub best_keypoint_idx: Option<usize>,
+    /// Best descriptor distance.
+    pub best_dist: Option<u32>,
+    /// Best octave.
+    pub best_level: Option<usize>,
+    /// Second-best candidate feature index.
+    pub second_best_keypoint_idx: Option<usize>,
+    /// Second-best descriptor distance.
+    pub second_best_dist: Option<u32>,
+    /// Second-best octave.
+    pub second_best_level: Option<usize>,
+    /// Whether the ratio test rejected the best match.
+    pub ratio_rejected: bool,
+    /// Candidate features returned by the spatial query.
+    pub feature_candidates: Vec<ProjectionDebugFeatureCandidate>,
+}
+
+/// Per-map-point projection/matching decisions for parity debugging.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectionDebugPoint {
+    /// Local map-point index in the slice passed to the matcher.
+    pub map_point_idx: usize,
+    /// Whether this map point projected into the current image under the
+    /// configured visibility gate.
+    pub visible: bool,
+    /// Projected undistorted pixel if visible.
+    pub projected_pixel: Option<[f32; 2]>,
+    /// Predicted octave if the matcher computes one.
+    pub predicted_octave: Option<usize>,
+    /// Final matched keypoint index for this map point in the current frame.
+    pub matched_keypoint_idx: Option<usize>,
+    /// Matcher-side candidate list and best/second-best bookkeeping.
+    pub matcher_trace: ProjectionDebugMatcherTrace,
+}
+
+/// Structured debug output for one projection-matching pass.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProjectionDebugFrame {
+    /// Per-map-point projection and final match results.
+    pub points: Vec<ProjectionDebugPoint>,
+}
+
+/// Debug-only override for the per-map-point projection state entering
+/// `SearchByProjection`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ProjectionOverridePoint {
+    /// Whether the map point should be considered visible.
+    pub visible: bool,
+    /// Projected undistorted pixel when visible.
+    pub projected_pixel: Option<[f32; 2]>,
+    /// Predicted octave when visible.
+    pub predicted_octave: Option<usize>,
+    /// Viewing cosine used to scale the search radius.
+    pub view_cos: Option<f32>,
+}
+
 /// Map-projection-based pose estimator.
 ///
 /// Estimates the camera pose by projecting map points into the current frame,
@@ -123,6 +224,46 @@ impl MapProjectionEstimator {
         &self.config
     }
 
+    /// Run the same projection-matching path used by tracking, but return
+    /// per-point visibility and match decisions for parity tooling.
+    pub fn debug_match_map_to_frame(
+        &self,
+        map_points: &[MapPoint],
+        frame: &Frame,
+        pose: &Pose3d,
+        camera: &PinholeCamera,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
+    ) -> ProjectionDebugFrame {
+        self.match_map_to_frame_internal(map_points, frame, pose, camera, mp_filter, true)
+            .3
+            .expect("debug_match_map_to_frame must collect debug output")
+    }
+
+    /// Run projection matching with externally supplied projection/octave
+    /// states. This is for parity tooling only and does not alter production
+    /// tracking behavior.
+    pub fn debug_match_map_to_frame_with_overrides(
+        &self,
+        map_points: &[MapPoint],
+        frame: &Frame,
+        pose: &Pose3d,
+        camera: &PinholeCamera,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
+        overrides: &[ProjectionOverridePoint],
+    ) -> ProjectionDebugFrame {
+        self.match_map_to_frame_internal_with_overrides(
+            map_points,
+            frame,
+            pose,
+            camera,
+            mp_filter,
+            true,
+            Some(overrides),
+        )
+        .3
+        .expect("debug_match_map_to_frame_with_overrides must collect debug output")
+    }
+
     /// Estimate the pose of `frame` against the map.
     pub fn estimate_pose(
         &self,
@@ -133,24 +274,55 @@ impl MapProjectionEstimator {
         camera: &PinholeCamera,
         current_keyframe_idx: Option<usize>,
     ) -> Result<Estimate, MapProjectionRejectReason> {
+        self.estimate_pose_with_report(
+            frame,
+            candidate_pose,
+            pose_before_tracking,
+            map,
+            camera,
+            current_keyframe_idx,
+        )
+        .0
+    }
+
+    pub fn estimate_pose_with_report(
+        &self,
+        frame: &Frame,
+        candidate_pose: &Pose3d,
+        pose_before_tracking: &Pose3d,
+        map: &Map,
+        camera: &PinholeCamera,
+        current_keyframe_idx: Option<usize>,
+    ) -> (
+        Result<Estimate, MapProjectionRejectReason>,
+        MapProjectionReport,
+    ) {
         let pnp = &self.config.pnp;
+        let mut report = MapProjectionReport::default();
 
         let (projection_matches, curr_keypoints_undist, grid) =
-            self.match_map_to_frame(map.map_points(), frame, candidate_pose, camera);
+            self.match_map_to_frame(map.map_points(), frame, candidate_pose, camera, None);
+        report.projection_matches = projection_matches.len();
 
         // Shared logic: try_track → refine_pose → Estimate, or propagate rejection.
         let try_track_and_refine = |correspondences: Vec<(usize, usize)>,
-                                    pose_init: &Pose3d|
+                                    pose_init: &Pose3d,
+                                    report: &mut MapProjectionReport,
+                                    is_projection_stage: bool|
          -> Result<Estimate, MapProjectionRejectReason> {
             let (mut pose, mut inliers) = self
                 .solve_pnp(
                     map.map_points(),
                     &correspondences,
                     &curr_keypoints_undist,
+                    &frame.features.scales,
                     camera,
                     pose_init,
                 )
                 .ok_or(MapProjectionRejectReason::PnpFailed)?;
+            if is_projection_stage {
+                report.projection_pnp_inliers = inliers;
+            }
             if inliers < pnp.min_inliers_early {
                 return Err(MapProjectionRejectReason::LowPnpInliers);
             }
@@ -160,12 +332,15 @@ impl MapProjectionEstimator {
                 current_keyframe_idx,
                 &matches,
                 &curr_keypoints_undist,
+                &frame.features.scales,
                 &frame.features.descriptors,
                 &grid,
                 frame.image_size,
                 camera,
                 &pose,
             ) {
+                report.local_projection_matches = local.matches.len();
+                report.local_pnp_inliers = local.inliers;
                 matches = local.matches;
                 if local.inliers >= self.config.pnp.min_inliers {
                     pose = local.pose;
@@ -181,8 +356,8 @@ impl MapProjectionEstimator {
 
         // PnP from projection matches.
         let last_reject = if projection_matches.len() >= pnp.min_correspondences {
-            match try_track_and_refine(projection_matches, candidate_pose) {
-                Ok(estimate) => return Ok(estimate),
+            match try_track_and_refine(projection_matches, candidate_pose, &mut report, true) {
+                Ok(estimate) => return (Ok(estimate), report),
                 Err(reason) => reason,
             }
         } else {
@@ -192,7 +367,8 @@ impl MapProjectionEstimator {
         // Fallback: match against reference keyframe descriptors.
         let current_kf = current_keyframe_idx.and_then(|ki| map.get_keyframe(ki));
         let Some(current_kf) = current_kf else {
-            return Err(last_reject);
+            report.reject_reason = Some(last_reject);
+            return (Err(last_reject), report);
         };
 
         let ref_matches = match_orb_descriptors(
@@ -202,10 +378,12 @@ impl MapProjectionEstimator {
             &frame.features.descriptors,
             self.config.match_config,
         );
+        report.reference_matches = ref_matches.len();
 
         const MIN_REF_MATCHES: usize = 15;
         if ref_matches.len() < MIN_REF_MATCHES {
-            return Err(MapProjectionRejectReason::LowReferenceMatches);
+            report.reject_reason = Some(MapProjectionRejectReason::LowReferenceMatches);
+            return (Err(MapProjectionRejectReason::LowReferenceMatches), report);
         }
 
         let mut ref_correspondences = Vec::with_capacity(ref_matches.len());
@@ -216,12 +394,28 @@ impl MapProjectionEstimator {
                 ref_correspondences.push((*mp_idx, curr_idx));
             }
         }
+        report.reference_correspondences = ref_correspondences.len();
 
         if ref_correspondences.len() < pnp.min_correspondences {
-            return Err(MapProjectionRejectReason::LowReferenceCorrespondences);
+            report.reject_reason = Some(MapProjectionRejectReason::LowReferenceCorrespondences);
+            return (
+                Err(MapProjectionRejectReason::LowReferenceCorrespondences),
+                report,
+            );
         }
 
-        try_track_and_refine(ref_correspondences, pose_before_tracking)
+        match try_track_and_refine(
+            ref_correspondences,
+            pose_before_tracking,
+            &mut report,
+            false,
+        ) {
+            Ok(estimate) => (Ok(estimate), report),
+            Err(reason) => {
+                report.reject_reason = Some(reason);
+                (Err(reason), report)
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -231,6 +425,7 @@ impl MapProjectionEstimator {
         current_kf_idx: Option<usize>,
         tracked_matches: &[(usize, usize)],
         curr_keypoints_undist: &[[f32; 2]],
+        curr_scales: &[f32],
         curr_descriptors: &[[u8; 32]],
         grid: &KeypointGrid,
         image_size: ImageSize,
@@ -248,12 +443,14 @@ impl MapProjectionEstimator {
         let local_matches = self.match_by_projection(
             &local_map_points,
             curr_keypoints_undist,
+            curr_scales,
             curr_descriptors,
             grid,
             camera,
             pose_init,
             image_size,
             self.config.local_projection,
+            None,
         );
         if local_matches.len() < min_corr {
             return None;
@@ -276,6 +473,7 @@ impl MapProjectionEstimator {
             map.map_points(),
             &global_matches,
             curr_keypoints_undist,
+            curr_scales,
             camera,
             pose_init,
         )?;
@@ -292,20 +490,26 @@ impl MapProjectionEstimator {
         map_points: &[MapPoint],
         correspondences: &[(usize, usize)],
         keypoints_undist: &[[f32; 2]],
+        keypoint_scales: &[f32],
         camera: &PinholeCamera,
         pose_init: &Pose3d,
     ) -> Option<(Pose3d, usize)> {
         let mut points_world = Vec::with_capacity(correspondences.len());
         let mut points_image = Vec::with_capacity(correspondences.len());
+        let mut keypoint_octaves = Vec::with_capacity(correspondences.len());
         for &(mp_idx, kp_idx) in correspondences {
             if let (Some(mp), Some(&kp)) = (map_points.get(mp_idx), keypoints_undist.get(kp_idx)) {
                 points_world.push(mp.position);
                 points_image.push(Vec2F32::new(kp[0], kp[1]));
+                keypoint_octaves.push(keypoint_octave(
+                    keypoint_scales.get(kp_idx).copied().unwrap_or(1.0),
+                ));
             }
         }
-        pnp::solve_pnp(
+        pnp::solve_pnp_with_octaves(
             &points_world,
             &points_image,
+            Some(&keypoint_octaves),
             camera,
             pose_init,
             &self.config.pnp,
@@ -320,8 +524,54 @@ impl MapProjectionEstimator {
         frame: &Frame,
         pose: &Pose3d,
         camera: &PinholeCamera,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
     ) -> (Vec<(usize, usize)>, Vec<[f32; 2]>, KeypointGrid) {
-        const KEYPOINT_GRID_CELL_SIZE: f32 = 64.0;
+        let (matches, keypoints_undist, grid, _) = self.match_map_to_frame_internal(
+            map_points, frame, pose, camera, mp_filter, false,
+        );
+        (matches, keypoints_undist, grid)
+    }
+
+    fn match_map_to_frame_internal(
+        &self,
+        map_points: &[MapPoint],
+        frame: &Frame,
+        pose: &Pose3d,
+        camera: &PinholeCamera,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
+        collect_debug: bool,
+    ) -> (
+        Vec<(usize, usize)>,
+        Vec<[f32; 2]>,
+        KeypointGrid,
+        Option<ProjectionDebugFrame>,
+    ) {
+        self.match_map_to_frame_internal_with_overrides(
+            map_points,
+            frame,
+            pose,
+            camera,
+            mp_filter,
+            collect_debug,
+            None,
+        )
+    }
+
+    fn match_map_to_frame_internal_with_overrides(
+        &self,
+        map_points: &[MapPoint],
+        frame: &Frame,
+        pose: &Pose3d,
+        camera: &PinholeCamera,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
+        collect_debug: bool,
+        projection_overrides: Option<&[ProjectionOverridePoint]>,
+    ) -> (
+        Vec<(usize, usize)>,
+        Vec<[f32; 2]>,
+        KeypointGrid,
+        Option<ProjectionDebugFrame>,
+    ) {
         const MIN_MATCHES_BEFORE_WIDE: usize = 20;
 
         let keypoints_undist: Vec<[f32; 2]> = frame
@@ -334,29 +584,46 @@ impl MapProjectionEstimator {
             })
             .collect();
 
+        let image_bounds = undistorted_image_bounds(camera, frame.image_size);
         let grid = KeypointGrid::new(
             &keypoints_undist,
-            frame.image_size.width as f32,
-            frame.image_size.height as f32,
-            KEYPOINT_GRID_CELL_SIZE,
+            (
+                image_bounds.0 as f32,
+                image_bounds.1 as f32,
+                image_bounds.2 as f32,
+                image_bounds.3 as f32,
+            ),
         );
 
+        if let Some(overrides) = projection_overrides {
+            assert_eq!(
+                overrides.len(),
+                map_points.len(),
+                "projection override count must match map_points length"
+            );
+        }
+
         let config = self.config.projection;
-        let mut matches = self.match_by_projection(
+        let (mut matches, mut debug) = self.match_by_projection_internal(
             map_points,
             &keypoints_undist,
+            &frame.features.scales,
             &frame.features.descriptors,
             &grid,
             camera,
             pose,
             frame.image_size,
             config,
+            mp_filter,
+            collect_debug,
+            projection_overrides,
         );
 
         if matches.len() < MIN_MATCHES_BEFORE_WIDE {
-            matches = self.match_by_projection(
+            (matches, debug) = self.match_by_projection_internal(
                 map_points,
                 &keypoints_undist,
+                &frame.features.scales,
                 &frame.features.descriptors,
                 &grid,
                 camera,
@@ -366,10 +633,13 @@ impl MapProjectionEstimator {
                     search_radius: config.search_radius * 2.0,
                     ..config
                 },
+                mp_filter,
+                collect_debug,
+                projection_overrides,
             );
         }
 
-        (matches, keypoints_undist, grid)
+        (matches, keypoints_undist, grid, debug)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -377,50 +647,284 @@ impl MapProjectionEstimator {
         &self,
         map_points: &[MapPoint],
         keypoints_xy: &[[f32; 2]],
+        scales: &[f32],
         descriptors: &[[u8; 32]],
         grid: &KeypointGrid,
         camera: &PinholeCamera,
         pose_world_to_cam: &Pose3d,
         image_size: ImageSize,
         config: ProjectionMatchConfig,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
     ) -> Vec<(usize, usize)> {
+        self.match_by_projection_internal(
+            map_points,
+            keypoints_xy,
+            scales,
+            descriptors,
+            grid,
+            camera,
+            pose_world_to_cam,
+            image_size,
+            config,
+            mp_filter,
+            false,
+            None,
+        )
+        .0
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn match_by_projection_internal(
+        &self,
+        map_points: &[MapPoint],
+        keypoints_xy: &[[f32; 2]],
+        scales: &[f32],
+        descriptors: &[[u8; 32]],
+        grid: &KeypointGrid,
+        camera: &PinholeCamera,
+        pose_world_to_cam: &Pose3d,
+        image_size: ImageSize,
+        config: ProjectionMatchConfig,
+        mp_filter: Option<&std::collections::HashSet<usize>>,
+        collect_debug: bool,
+        projection_overrides: Option<&[ProjectionOverridePoint]>,
+    ) -> (Vec<(usize, usize)>, Option<ProjectionDebugFrame>) {
         let mut matched_kp = vec![false; keypoints_xy.len()];
         let mut matches = Vec::new();
+        let mut debug_points = collect_debug.then(Vec::new);
+        let camera_center = pose_world_to_cam.inverse().translation;
+        let image_bounds = undistorted_image_bounds(camera, image_size);
 
         for (mp_idx, mp) in map_points.iter().enumerate() {
             if mp.culled {
                 continue;
             }
+            if let Some(filter) = mp_filter
+                && !filter.contains(&mp_idx)
+            {
+                continue;
+            }
 
-            let p_cam = pose_world_to_cam.transform_point(&mp.position);
-            let Ok(pixel) = camera.project_to_image(&p_cam, config.min_depth, image_size) else {
+            let override_state = projection_overrides.and_then(|overrides| overrides.get(mp_idx));
+            let projected = if let Some(override_state) = override_state {
+                if override_state.visible {
+                    match (
+                        override_state.projected_pixel,
+                        override_state.predicted_octave,
+                        override_state.view_cos,
+                    ) {
+                        (Some([u, v]), Some(predicted_octave), Some(view_cos)) => Some((
+                            kornia_algebra::Vec2F64::new(u as f64, v as f64),
+                            predicted_octave,
+                            view_cos as f64,
+                        )),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            } else {
+                project_visible_map_point(
+                    mp,
+                    pose_world_to_cam,
+                    camera,
+                    config.min_depth,
+                    &camera_center,
+                    image_bounds,
+                )
+            };
+
+            let Some((pixel, predicted_octave, view_cos)) = projected else {
+                if let Some(points) = debug_points.as_mut() {
+                    points.push(ProjectionDebugPoint {
+                        map_point_idx: mp_idx,
+                        visible: false,
+                        projected_pixel: None,
+                        predicted_octave: None,
+                        matched_keypoint_idx: None,
+                        matcher_trace: ProjectionDebugMatcherTrace::default(),
+                    });
+                }
                 continue;
             };
             let u = pixel.x as f32;
             let v = pixel.y as f32;
+            let mut debug_point = ProjectionDebugPoint {
+                map_point_idx: mp_idx,
+                visible: true,
+                projected_pixel: Some([u, v]),
+                predicted_octave: Some(predicted_octave),
+                matched_keypoint_idx: None,
+                matcher_trace: ProjectionDebugMatcherTrace::default(),
+            };
 
-            let candidates = grid.query_radius(u, v, config.search_radius, keypoints_xy);
+            let search_radius = config.search_radius
+                * radius_by_viewing_cos(view_cos) as f32
+                * ORB_SCALE_FACTOR.powi(predicted_octave as i32) as f32;
+            debug_point.matcher_trace.search_radius = search_radius;
+            debug_point.matcher_trace.min_level = predicted_octave.saturating_sub(1) as isize;
+            debug_point.matcher_trace.max_level = predicted_octave as isize;
+            let candidates = grid.query_features_in_area(
+                u,
+                v,
+                search_radius,
+                predicted_octave.saturating_sub(1) as isize,
+                predicted_octave as isize,
+                keypoints_xy,
+                scales,
+                keypoint_octave,
+            );
             let mut best_dist = u32::MAX;
+            let mut best_octave = usize::MAX;
+            let mut second_dist = u32::MAX;
+            let mut second_octave = usize::MAX;
             let mut best_kp = usize::MAX;
 
             for kp_idx in candidates {
+                let kp_octave = keypoint_octave(scales.get(kp_idx).copied().unwrap_or(1.0));
+                let dist = hamming_distance(&mp.descriptor, &descriptors[kp_idx]);
+                debug_point
+                    .matcher_trace
+                    .feature_candidates
+                    .push(ProjectionDebugFeatureCandidate {
+                        keypoint_idx: kp_idx,
+                        octave: kp_octave,
+                        occupied_before: false,
+                        descriptor_dist: dist,
+                    });
                 if matched_kp[kp_idx] {
                     continue;
                 }
-                let dist = hamming_distance(&mp.descriptor, &descriptors[kp_idx]);
                 if dist < best_dist {
+                    second_dist = best_dist;
+                    second_octave = best_octave;
+                    debug_point.matcher_trace.second_best_keypoint_idx =
+                        debug_point.matcher_trace.best_keypoint_idx;
+                    debug_point.matcher_trace.second_best_dist = debug_point.matcher_trace.best_dist;
+                    debug_point.matcher_trace.second_best_level =
+                        debug_point.matcher_trace.best_level;
                     best_dist = dist;
+                    best_octave = kp_octave;
                     best_kp = kp_idx;
+                    debug_point.matcher_trace.best_keypoint_idx = Some(kp_idx);
+                    debug_point.matcher_trace.best_dist = Some(dist);
+                    debug_point.matcher_trace.best_level = Some(kp_octave);
+                } else if dist < second_dist {
+                    second_dist = dist;
+                    second_octave = kp_octave;
+                    debug_point.matcher_trace.second_best_keypoint_idx = Some(kp_idx);
+                    debug_point.matcher_trace.second_best_dist = Some(dist);
+                    debug_point.matcher_trace.second_best_level = Some(kp_octave);
                 }
             }
 
-            if best_dist <= config.max_hamming && best_kp != usize::MAX {
+            let passes_ratio = best_octave != second_octave
+                || second_dist == u32::MAX
+                || (best_dist as f32) <= 0.8 * (second_dist as f32);
+            if best_dist <= config.max_hamming && best_kp != usize::MAX && !passes_ratio {
+                debug_point.matcher_trace.ratio_rejected = true;
+            }
+            if best_dist <= config.max_hamming && best_kp != usize::MAX && passes_ratio {
                 matched_kp[best_kp] = true;
                 matches.push((mp_idx, best_kp));
+                debug_point.matched_keypoint_idx = Some(best_kp);
+            }
+
+            if let Some(points) = debug_points.as_mut() {
+                points.push(debug_point);
             }
         }
 
-        matches
+        (
+            matches,
+            debug_points.map(|points| ProjectionDebugFrame { points }),
+        )
+    }
+}
+
+fn project_visible_map_point(
+    map_point: &MapPoint,
+    pose_world_to_cam: &Pose3d,
+    camera: &PinholeCamera,
+    min_depth: f64,
+    camera_center_world: &kornia_algebra::Vec3F64,
+    image_bounds: (f64, f64, f64, f64),
+) -> Option<(kornia_algebra::Vec2F64, usize, f64)> {
+    let p_cam = pose_world_to_cam.transform_point(&map_point.position);
+    let pixel = camera.project_to_pixel(&p_cam, min_depth)?;
+    let (min_x, max_x, min_y, max_y) = image_bounds;
+    if pixel.x < min_x || pixel.x > max_x || pixel.y < min_y || pixel.y > max_y {
+        return None;
+    }
+
+    let po = map_point.position - *camera_center_world;
+    let dist = po.length();
+    if dist <= 0.0 {
+        return None;
+    }
+    if dist < map_point.min_distance_invariance() || dist > map_point.max_distance_invariance() {
+        return None;
+    }
+
+    let view_cos = po.dot(map_point.viewing_normal()) / dist;
+    if view_cos < VIEWING_COS_LIMIT {
+        return None;
+    }
+
+    Some((
+        pixel,
+        map_point.predict_scale(dist, ORB_SCALE_FACTOR, ORB_N_LEVELS),
+        view_cos,
+    ))
+}
+
+fn undistorted_image_bounds(
+    camera: &PinholeCamera,
+    image_size: ImageSize,
+) -> (f64, f64, f64, f64) {
+    if camera.k1 == 0.0 && camera.k2 == 0.0 && camera.p1 == 0.0 && camera.p2 == 0.0 {
+        return (
+            0.0,
+            image_size.width as f64,
+            0.0,
+            image_size.height as f64,
+        );
+    }
+
+    let top_left = camera.undistort(0.0, 0.0);
+    let top_right = camera.undistort(image_size.width as f64, 0.0);
+    let bottom_left = camera.undistort(0.0, image_size.height as f64);
+    let bottom_right = camera.undistort(image_size.width as f64, image_size.height as f64);
+
+    (
+        top_left.x.min(bottom_left.x),
+        top_right.x.max(bottom_right.x),
+        top_left.y.min(top_right.y),
+        bottom_left.y.max(bottom_right.y),
+    )
+}
+
+fn radius_by_viewing_cos(view_cos: f64) -> f64 {
+    if view_cos > 0.998 {
+        2.5
+    } else {
+        4.0
+    }
+}
+
+fn keypoint_octave(scale: f32) -> usize {
+    let octave = ((scale as f64).ln() / ORB_SCALE_FACTOR.ln()).round() as isize;
+    octave.clamp(0, ORB_N_LEVELS.saturating_sub(1) as isize) as usize
+}
+
+/// Human-readable name for a map-projection rejection reason.
+pub fn map_projection_reject_reason_name(reason: MapProjectionRejectReason) -> &'static str {
+    match reason {
+        MapProjectionRejectReason::LowProjectionMatches => "low_projection_matches",
+        MapProjectionRejectReason::PnpFailed => "pnp_failed",
+        MapProjectionRejectReason::LowPnpInliers => "low_pnp_inliers",
+        MapProjectionRejectReason::LowReferenceMatches => "low_reference_matches",
+        MapProjectionRejectReason::LowReferenceCorrespondences => "low_reference_correspondences",
     }
 }
 
@@ -437,6 +941,12 @@ mod estimator_tests {
     }
 
     #[test]
+    fn test_need_new_keyframe_max_gap_overrides_strong_tracking() {
+        let policy = KeyframePolicy::default();
+        assert!(policy.should_insert(100, Some(90), 100, 100));
+    }
+
+    #[test]
     fn test_need_new_keyframe_too_soon() {
         let policy = KeyframePolicy::default();
         assert!(!policy.should_insert(2, Some(1), 50, 100));
@@ -446,6 +956,8 @@ mod estimator_tests {
 #[cfg(test)]
 mod matching_tests {
     use super::*;
+    use std::collections::HashSet;
+
     use kornia_algebra::{Mat3F64, Vec3F64};
 
     fn make_test_estimator() -> MapProjectionEstimator {
@@ -479,17 +991,23 @@ mod matching_tests {
             n_visible: 0,
             n_found: 0,
             culled: false,
+            normal: Vec3F64::new(0.0, 0.0, 1.0),
+            min_distance: 0.0,
+            max_distance: f64::INFINITY,
+            observation_count_override: None,
+            observed_keyframes_override: None,
         }];
 
         let keypoints_xy = vec![[320.0f32, 240.0], [100.0, 100.0]];
         let descriptors = vec![desc_a, [0xFF; 32]];
 
-        let grid = KeypointGrid::new(&keypoints_xy, 640.0, 480.0, 64.0);
+        let grid = KeypointGrid::new(&keypoints_xy, (0.0, 640.0, 0.0, 480.0));
         let pose = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO);
 
         let matches = estimator.match_by_projection(
             &map_points,
             &keypoints_xy,
+            &[1.0, 1.0],
             &descriptors,
             &grid,
             &camera,
@@ -503,6 +1021,7 @@ mod matching_tests {
                 search_radius: 15.0,
                 max_hamming: 50,
             },
+            None,
         );
 
         assert_eq!(matches.len(), 1);
@@ -522,15 +1041,21 @@ mod matching_tests {
             n_visible: 0,
             n_found: 0,
             culled: false,
+            normal: Vec3F64::new(0.0, 0.0, 1.0),
+            min_distance: 0.0,
+            max_distance: f64::INFINITY,
+            observation_count_override: None,
+            observed_keyframes_override: None,
         }];
 
         let keypoints_xy = vec![[320.0f32, 240.0]];
         let descriptors = vec![[0u8; 32]];
-        let grid = KeypointGrid::new(&keypoints_xy, 640.0, 480.0, 64.0);
+        let grid = KeypointGrid::new(&keypoints_xy, (0.0, 640.0, 0.0, 480.0));
 
         let matches = estimator.match_by_projection(
             &map_points,
             &keypoints_xy,
+            &[1.0],
             &descriptors,
             &grid,
             &camera,
@@ -544,6 +1069,7 @@ mod matching_tests {
                 search_radius: 15.0,
                 max_hamming: 50,
             },
+            None,
         );
 
         assert!(matches.is_empty());
@@ -562,15 +1088,21 @@ mod matching_tests {
             n_visible: 0,
             n_found: 0,
             culled: false,
+            normal: Vec3F64::new(0.0, 0.0, 1.0),
+            min_distance: 0.0,
+            max_distance: f64::INFINITY,
+            observation_count_override: None,
+            observed_keyframes_override: None,
         }];
 
         let keypoints_xy = vec![[320.0f32, 240.0]];
         let descriptors = vec![[0xFF; 32]];
-        let grid = KeypointGrid::new(&keypoints_xy, 640.0, 480.0, 64.0);
+        let grid = KeypointGrid::new(&keypoints_xy, (0.0, 640.0, 0.0, 480.0));
 
         let matches = estimator.match_by_projection(
             &map_points,
             &keypoints_xy,
+            &[1.0],
             &descriptors,
             &grid,
             &camera,
@@ -584,8 +1116,194 @@ mod matching_tests {
                 search_radius: 15.0,
                 max_hamming: 50,
             },
+            None,
         );
 
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_debug_match_map_to_frame_returns_structured_output() {
+        use kornia_imgproc::features::OrbFeatures;
+
+        let estimator = make_test_estimator();
+        let camera = test_camera();
+        let descriptor = [0u8; 32];
+        let frame = Frame {
+            idx: 0,
+            features: OrbFeatures {
+                keypoints_xy: vec![[320.0, 240.0], [100.0, 100.0]],
+                scales: vec![1.0, 1.0],
+                orientations: vec![0.0, 0.0],
+                descriptors: vec![descriptor, [0xFF; 32]],
+            },
+            pose_world_to_cam: Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO),
+            image_size: ImageSize {
+                width: 640,
+                height: 480,
+            },
+            keypoint_colors: vec![[0; 3]; 2],
+        };
+        let map_points = vec![MapPoint {
+            position: Vec3F64::new(0.0, 0.0, 5.0),
+            descriptor,
+            color: [0; 3],
+            keyframe_idx: 0,
+            n_visible: 0,
+            n_found: 0,
+            culled: false,
+            normal: Vec3F64::new(0.0, 0.0, 1.0),
+            min_distance: 0.0,
+            max_distance: f64::INFINITY,
+            observation_count_override: None,
+            observed_keyframes_override: None,
+        }];
+
+        let debug = estimator.debug_match_map_to_frame(
+            &map_points,
+            &frame,
+            &Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO),
+            &camera,
+            None,
+        );
+
+        assert_eq!(debug.points.len(), 1);
+        let point = &debug.points[0];
+        assert_eq!(point.map_point_idx, 0);
+        assert!(point.visible);
+        assert_eq!(point.projected_pixel, Some([320.0, 240.0]));
+        assert_eq!(point.predicted_octave, Some(0));
+        assert_eq!(point.matched_keypoint_idx, Some(0));
+    }
+
+    #[test]
+    fn test_debug_match_map_to_frame_matches_normal_path_with_wide_fallback() {
+        use kornia_imgproc::features::OrbFeatures;
+
+        let estimator = make_test_estimator();
+        let camera = test_camera();
+        let descriptor = [0u8; 32];
+        let pose = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO);
+        let frame = Frame {
+            idx: 0,
+            features: OrbFeatures {
+                keypoints_xy: vec![[324.0, 240.0]],
+                scales: vec![1.0],
+                orientations: vec![0.0],
+                descriptors: vec![descriptor],
+            },
+            pose_world_to_cam: pose.clone(),
+            image_size: ImageSize {
+                width: 640,
+                height: 480,
+            },
+            keypoint_colors: vec![[0; 3]],
+        };
+        let map_points = vec![MapPoint {
+            position: Vec3F64::new(0.0, 0.0, 5.0),
+            descriptor,
+            color: [0; 3],
+            keyframe_idx: 0,
+            n_visible: 0,
+            n_found: 0,
+            culled: false,
+            normal: Vec3F64::new(0.0, 0.0, 1.0),
+            min_distance: 0.0,
+            max_distance: f64::INFINITY,
+            observation_count_override: None,
+            observed_keyframes_override: None,
+        }];
+
+        let (matches, _, _) = estimator.match_map_to_frame(&map_points, &frame, &pose, &camera, None);
+        let debug = estimator.debug_match_map_to_frame(&map_points, &frame, &pose, &camera, None);
+
+        let debug_matches: Vec<(usize, usize)> = debug
+            .points
+            .iter()
+            .filter_map(|point| {
+                point
+                    .matched_keypoint_idx
+                    .map(|kp_idx| (point.map_point_idx, kp_idx))
+            })
+            .collect();
+
+        assert_eq!(matches, vec![(0, 0)]);
+        assert_eq!(debug_matches, matches);
+    }
+
+    #[test]
+    fn test_debug_match_map_to_frame_respects_mp_filter() {
+        use kornia_imgproc::features::OrbFeatures;
+
+        let estimator = make_test_estimator();
+        let camera = test_camera();
+        let pose = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::ZERO);
+        let descriptors = vec![[0u8; 32], [1u8; 32]];
+        let frame = Frame {
+            idx: 0,
+            features: OrbFeatures {
+                keypoints_xy: vec![[320.0, 240.0], [360.0, 240.0]],
+                scales: vec![1.0, 1.0],
+                orientations: vec![0.0, 0.0],
+                descriptors: descriptors.clone(),
+            },
+            pose_world_to_cam: pose.clone(),
+            image_size: ImageSize {
+                width: 640,
+                height: 480,
+            },
+            keypoint_colors: vec![[0; 3]; 2],
+        };
+        let map_points = vec![
+            MapPoint {
+                position: Vec3F64::new(0.0, 0.0, 5.0),
+                descriptor: descriptors[0],
+                color: [0; 3],
+                keyframe_idx: 0,
+                n_visible: 0,
+                n_found: 0,
+                culled: false,
+                normal: Vec3F64::new(0.0, 0.0, 1.0),
+                min_distance: 0.0,
+                max_distance: f64::INFINITY,
+                observation_count_override: None,
+                observed_keyframes_override: None,
+            },
+            MapPoint {
+                position: Vec3F64::new(1.0, 0.0, 5.0),
+                descriptor: descriptors[1],
+                color: [0; 3],
+                keyframe_idx: 0,
+                n_visible: 0,
+                n_found: 0,
+                culled: false,
+                normal: Vec3F64::new(0.0, 0.0, 1.0),
+                min_distance: 0.0,
+                max_distance: f64::INFINITY,
+                observation_count_override: None,
+                observed_keyframes_override: None,
+            },
+        ];
+        let filter = HashSet::from([1usize]);
+
+        let (matches, _, _) =
+            estimator.match_map_to_frame(&map_points, &frame, &pose, &camera, Some(&filter));
+        let debug =
+            estimator.debug_match_map_to_frame(&map_points, &frame, &pose, &camera, Some(&filter));
+
+        let debug_matches: Vec<(usize, usize)> = debug
+            .points
+            .iter()
+            .filter_map(|point| {
+                point
+                    .matched_keypoint_idx
+                    .map(|kp_idx| (point.map_point_idx, kp_idx))
+            })
+            .collect();
+
+        assert_eq!(debug.points.len(), 1);
+        assert_eq!(debug.points[0].map_point_idx, 1);
+        assert_eq!(matches, vec![(1, 1)]);
+        assert_eq!(debug_matches, matches);
     }
 }

--- a/crates/kornia-slam/src/estimation/mod.rs
+++ b/crates/kornia-slam/src/estimation/mod.rs
@@ -2,11 +2,14 @@
 
 pub mod map_projection;
 pub mod pnp;
+pub mod triangulation_search;
 pub mod two_view;
 
 use kornia_3d::pose::Pose3d;
 
-pub use map_projection::MapProjectionEstimator;
+pub use map_projection::{
+    MapProjectionEstimator, ProjectionDebugFrame, ProjectionDebugPoint, ProjectionOverridePoint,
+};
 
 /// Successful pose estimate returned by any estimator.
 #[derive(Debug, Clone)]

--- a/crates/kornia-slam/src/estimation/pnp.rs
+++ b/crates/kornia-slam/src/estimation/pnp.rs
@@ -5,6 +5,11 @@ use kornia_3d::pnp::{LMRefineParams, refine_pose_lm};
 use kornia_3d::pose::Pose3d;
 use kornia_algebra::{Mat3AF32, Mat3F64, Vec2F32, Vec3AF32, Vec3F64};
 
+const ORB_SCALE_FACTOR: f64 = 1.2;
+const ORB_MONO_CHI2: f64 = 5.991;
+const ORB_POSE_OPT_PASSES: usize = 4;
+const ORB_POSE_OPT_ITERATIONS: usize = 10;
+
 /// PnP pose-estimation thresholds.
 #[derive(Debug, Clone)]
 pub struct PnpConfig {
@@ -24,7 +29,7 @@ impl Default for PnpConfig {
     fn default() -> Self {
         Self {
             prior_reproj_threshold_px: 25.0,
-            final_reproj_threshold_px: 3.0,
+            final_reproj_threshold_px: 5.0,
             min_correspondences: 4,
             min_inliers_early: 10,
             min_inliers: 30,
@@ -43,7 +48,31 @@ pub fn solve_pnp(
     pose_init: &Pose3d,
     config: &PnpConfig,
 ) -> Option<(Pose3d, usize)> {
+    solve_pnp_with_octaves(
+        points_world_f64,
+        points_image,
+        None,
+        camera,
+        pose_init,
+        config,
+    )
+}
+
+/// Solve PnP with ORB-SLAM3-style octave-weighted inlier classification.
+pub fn solve_pnp_with_octaves(
+    points_world_f64: &[Vec3F64],
+    points_image: &[Vec2F32],
+    keypoint_octaves: Option<&[usize]>,
+    camera: &PinholeCamera,
+    pose_init: &Pose3d,
+    config: &PnpConfig,
+) -> Option<(Pose3d, usize)> {
     if points_world_f64.len() < config.min_correspondences {
+        return None;
+    }
+    if let Some(octaves) = keypoint_octaves
+        && octaves.len() != points_world_f64.len()
+    {
         return None;
     }
 
@@ -67,15 +96,80 @@ pub fn solve_pnp(
         return None;
     }
 
-    // Build f32 arrays for LM solver.
+    let initial_inliers = count_reprojection_inliers_for_indices(
+        pose_init,
+        points_world_f64,
+        points_image,
+        keypoint_octaves,
+        camera,
+        config.final_reproj_threshold_px,
+        &prior_inlier_indices,
+    );
+
+    let mut active_indices = prior_inlier_indices.clone();
+    let mut current_pose = *pose_init;
+    let mut best_pose = *pose_init;
+    let mut best_inliers = initial_inliers;
+
+    // ORB-SLAM3 PoseOptimization runs four optimize/classify passes. Outliers
+    // are excluded from the next pass, but can be reclassified as inliers after
+    // each pose update.
+    for _ in 0..ORB_POSE_OPT_PASSES {
+        if active_indices.len() < config.min_correspondences {
+            break;
+        }
+
+        let pose_new = refine_pose_for_indices(
+            points_world_f64,
+            points_image,
+            camera,
+            &current_pose,
+            &active_indices,
+            ORB_POSE_OPT_ITERATIONS,
+        )?;
+
+        let pass_inlier_indices = reprojection_inlier_indices(
+            &pose_new,
+            points_world_f64,
+            points_image,
+            keypoint_octaves,
+            camera,
+            config.final_reproj_threshold_px,
+            &prior_inlier_indices,
+        );
+
+        if pass_inlier_indices.len() >= best_inliers {
+            best_inliers = pass_inlier_indices.len();
+            best_pose = pose_new;
+        }
+
+        active_indices = pass_inlier_indices;
+        current_pose = pose_new;
+    }
+
+    Some((best_pose, best_inliers))
+}
+
+fn refine_pose_for_indices(
+    points_world_f64: &[Vec3F64],
+    points_image: &[Vec2F32],
+    camera: &PinholeCamera,
+    pose_init: &Pose3d,
+    indices: &[usize],
+    max_iterations: usize,
+) -> Option<Pose3d> {
+    if indices.len() < 3 {
+        return None;
+    }
+
     let k = Mat3AF32::from_cols(
         Vec3AF32::new(camera.fx as f32, 0.0, 0.0),
         Vec3AF32::new(0.0, camera.fy as f32, 0.0),
         Vec3AF32::new(camera.cx as f32, camera.cy as f32, 1.0),
     );
-    let mut world_inliers = Vec::with_capacity(prior_inlier_indices.len());
-    let mut image_inliers = Vec::with_capacity(prior_inlier_indices.len());
-    for &i in &prior_inlier_indices {
+    let mut world_inliers = Vec::with_capacity(indices.len());
+    let mut image_inliers = Vec::with_capacity(indices.len());
+    for &i in indices {
         let pw = &points_world_f64[i];
         world_inliers.push(Vec3AF32::new(pw.x as f32, pw.y as f32, pw.z as f32));
         image_inliers.push(points_image[i]);
@@ -111,7 +205,7 @@ pub fn solve_pnp(
         &r_init_f32,
         &t_init_f32,
         None,
-        &LMRefineParams::default(),
+        &LMRefineParams::default().with_max_iterations(max_iterations),
     )
     .ok()?;
 
@@ -123,17 +217,7 @@ pub fn solve_pnp(
         Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
     );
     let t_new = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
-    let pose_new = Pose3d::new(r_new, t_new);
-
-    let final_inliers = count_reprojection_inliers(
-        &pose_new,
-        points_world_f64,
-        points_image,
-        camera,
-        config.final_reproj_threshold_px,
-    );
-
-    Some((pose_new, final_inliers))
+    Some(Pose3d::new(r_new, t_new))
 }
 
 /// Count map-point reprojection inliers given a camera pose.
@@ -141,18 +225,151 @@ pub fn count_reprojection_inliers(
     pose_world_to_cam: &Pose3d,
     points_world: &[Vec3F64],
     points_image: &[Vec2F32],
+    keypoint_octaves: Option<&[usize]>,
     camera: &PinholeCamera,
     threshold_px: f64,
 ) -> usize {
-    let th2 = threshold_px * threshold_px;
-    let mut inliers = 0usize;
-    for (pw, pi) in points_world.iter().zip(points_image.iter()) {
+    let all_indices: Vec<_> = (0..points_world.len()).collect();
+    count_reprojection_inliers_for_indices(
+        pose_world_to_cam,
+        points_world,
+        points_image,
+        keypoint_octaves,
+        camera,
+        threshold_px,
+        &all_indices,
+    )
+}
+
+fn count_reprojection_inliers_for_indices(
+    pose_world_to_cam: &Pose3d,
+    points_world: &[Vec3F64],
+    points_image: &[Vec2F32],
+    keypoint_octaves: Option<&[usize]>,
+    camera: &PinholeCamera,
+    threshold_px: f64,
+    indices: &[usize],
+) -> usize {
+    reprojection_inlier_indices(
+        pose_world_to_cam,
+        points_world,
+        points_image,
+        keypoint_octaves,
+        camera,
+        threshold_px,
+        indices,
+    )
+    .len()
+}
+
+fn reprojection_inlier_indices(
+    pose_world_to_cam: &Pose3d,
+    points_world: &[Vec3F64],
+    points_image: &[Vec2F32],
+    keypoint_octaves: Option<&[usize]>,
+    camera: &PinholeCamera,
+    threshold_px: f64,
+    indices: &[usize],
+) -> Vec<usize> {
+    let mut inliers = Vec::new();
+    for &idx in indices {
+        let Some(pw) = points_world.get(idx) else {
+            continue;
+        };
+        let Some(pi) = points_image.get(idx) else {
+            continue;
+        };
+        let th2 = reprojection_threshold_sq(keypoint_octaves, idx, threshold_px);
         if camera
             .reprojection_error_sq_world(pose_world_to_cam, pw, pi.x as f64, pi.y as f64)
             .is_some_and(|err_sq| err_sq <= th2)
         {
-            inliers += 1;
+            inliers.push(idx);
         }
     }
     inliers
+}
+
+fn reprojection_threshold_sq(
+    keypoint_octaves: Option<&[usize]>,
+    point_idx: usize,
+    fallback_threshold_px: f64,
+) -> f64 {
+    keypoint_octaves
+        .and_then(|octaves| octaves.get(point_idx))
+        .map(|&octave| ORB_MONO_CHI2 * ORB_SCALE_FACTOR.powi((2 * octave) as i32))
+        .unwrap_or(fallback_threshold_px * fallback_threshold_px)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn camera() -> PinholeCamera {
+        PinholeCamera {
+            fx: 200.0,
+            fy: 200.0,
+            cx: 320.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        }
+    }
+
+    #[test]
+    fn octave_threshold_scales_like_orb_slam3() {
+        let th0 = reprojection_threshold_sq(Some(&[0]), 0, 5.0);
+        let th2 = reprojection_threshold_sq(Some(&[2]), 0, 5.0);
+
+        assert!((th0 - ORB_MONO_CHI2).abs() < 1e-12);
+        assert!((th2 - ORB_MONO_CHI2 * ORB_SCALE_FACTOR.powi(4)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn solve_pnp_with_octaves_rejects_consistent_pixel_outliers() {
+        let camera = camera();
+        let pose = Pose3d::IDENTITY;
+        let mut points_world = Vec::new();
+        let mut points_image = Vec::new();
+        let mut octaves = Vec::new();
+
+        for y in -2..=2 {
+            for x in -2..=2 {
+                let point = Vec3F64::new(x as f64 * 0.1, y as f64 * 0.1, 5.0);
+                let pixel = camera.project_to_pixel(&point, 1e-8).unwrap();
+                points_world.push(point);
+                points_image.push(Vec2F32::new(pixel.x as f32, pixel.y as f32));
+                octaves.push(0);
+            }
+        }
+
+        // These pass the loose prior gate but fail the ORB mono chi-square gate.
+        for i in 0..8 {
+            let point = Vec3F64::new((i as f64 - 4.0) * 0.1, 0.35, 5.0);
+            let pixel = camera.project_to_pixel(&point, 1e-8).unwrap();
+            points_world.push(point);
+            points_image.push(Vec2F32::new((pixel.x + 12.0) as f32, pixel.y as f32));
+            octaves.push(0);
+        }
+
+        let config = PnpConfig {
+            prior_reproj_threshold_px: 25.0,
+            min_correspondences: 4,
+            ..PnpConfig::default()
+        };
+
+        let (_pose, inliers) = solve_pnp_with_octaves(
+            &points_world,
+            &points_image,
+            Some(&octaves),
+            &camera,
+            &pose,
+            &config,
+        )
+        .expect("synthetic PnP should solve");
+
+        assert_eq!(inliers, 25);
+    }
 }

--- a/crates/kornia-slam/src/estimation/triangulation_search.rs
+++ b/crates/kornia-slam/src/estimation/triangulation_search.rs
@@ -1,0 +1,373 @@
+//! BoW-accelerated stereo search for new-map-point triangulation.
+//!
+//! Port of ORB-SLAM3's `ORBmatcher::SearchForTriangulation` (ORBmatcher.cc:907).
+//! Given two keyframes with BoW direct indices, walks matching tree nodes and
+//! returns (idx1, idx2) pairs of *unmatched* features that satisfy a hamming
+//! threshold, an epipolar-line distance check, and an orientation-histogram
+//! consistency test.
+//!
+//! The matches returned here are the input to `triangulate_matched_points`
+//! during continuous map growth (`LocalMapping::CreateNewMapPoints` equivalent).
+
+use kornia_3d::camera::PinholeCamera;
+use kornia_algebra::{Mat3F64, Vec3F64};
+
+use crate::map::Keyframe;
+
+/// Tunables for [`search_for_triangulation`].
+#[derive(Debug, Clone, Copy)]
+pub struct TriangulationSearchConfig {
+    /// Max accepted ORB descriptor hamming distance (ORB-SLAM3 `TH_LOW`).
+    pub max_hamming_distance: u32,
+    /// Enable orientation-histogram filtering.
+    pub check_orientation: bool,
+    /// Number of bins in the orientation histogram (ORB-SLAM3 `HISTO_LENGTH`).
+    pub histogram_bins: usize,
+    /// Skip matches whose epipole-to-kp2 distance² is below `margin_factor *
+    /// scale_factor[octave]` (ORB-SLAM3: 100).
+    pub epipole_margin_factor: f32,
+    /// Chi² scaling for the epipolar-line distance check (ORB-SLAM3: 3.84).
+    pub epipolar_chi2: f32,
+}
+
+impl Default for TriangulationSearchConfig {
+    fn default() -> Self {
+        Self {
+            max_hamming_distance: 50,
+            check_orientation: true,
+            histogram_bins: 30,
+            epipole_margin_factor: 100.0,
+            epipolar_chi2: 3.84,
+        }
+    }
+}
+
+/// Computes hamming distance between two packed 32-byte ORB descriptors.
+#[inline]
+fn hamming_u8(a: &[u8; 32], b: &[u8; 32]) -> u32 {
+    let mut d = 0u32;
+    for i in 0..32 {
+        d += (a[i] ^ b[i]).count_ones();
+    }
+    d
+}
+
+/// Computes the fundamental matrix F21 such that `x2^T F21 x1 = 0`.
+///
+/// Matches the form used by ORB-SLAM3's `Pinhole::epipolarConstrain`, where
+/// the epipolar line in image 2 is `l2 = F12^T x1` and residual is the
+/// point-to-line distance of `x2` to `l2`. We compute `F12` under the
+/// convention `F12 = K1^{-T} [t12]_x R12 K2^{-1}` with `T12 = T1w * Tw2`.
+fn fundamental_12(
+    t1w: &kornia_3d::pose::Pose3d,
+    t2w: &kornia_3d::pose::Pose3d,
+    k: &PinholeCamera,
+) -> (Mat3F64, Vec3F64) {
+    // T12 = T1w * T2w.inverse() → R12 = R1w * R2w^T, t12 = t1w - R12 * t2w
+    let r12 = t1w.rotation * t2w.rotation.transpose();
+    let t12 = t1w.translation - r12 * t2w.translation;
+    let tx = Mat3F64::from_cols(
+        Vec3F64::new(0.0, t12.z, -t12.y),
+        Vec3F64::new(-t12.z, 0.0, t12.x),
+        Vec3F64::new(t12.y, -t12.x, 0.0),
+    );
+    let k_mat = k.intrinsic_matrix();
+    let k_inv = Mat3F64::from_cols(
+        Vec3F64::new(1.0 / k.fx, 0.0, 0.0),
+        Vec3F64::new(0.0, 1.0 / k.fy, 0.0),
+        Vec3F64::new(-k.cx / k.fx, -k.cy / k.fy, 1.0),
+    );
+    let k_inv_t = k_mat.transpose();
+    // K^{-T} computed as (K^{-1})^T
+    let k_inv_t_ = Mat3F64::from_cols(
+        Vec3F64::new(1.0 / k.fx, 0.0, -k.cx / k.fx),
+        Vec3F64::new(0.0, 1.0 / k.fy, -k.cy / k.fy),
+        Vec3F64::new(0.0, 0.0, 1.0),
+    );
+    let _ = (k_inv, k_inv_t);
+    let f12 = k_inv_t_ * tx * r12 * {
+        // K^{-1}
+        Mat3F64::from_cols(
+            Vec3F64::new(1.0 / k.fx, 0.0, 0.0),
+            Vec3F64::new(0.0, 1.0 / k.fy, 0.0),
+            Vec3F64::new(-k.cx / k.fx, -k.cy / k.fy, 1.0),
+        )
+    };
+    // Projected epipole in image 2: e2 = K * (T2w * C1_world) where C1_world = -R1w^T t1w.
+    let c1_world = -(t1w.rotation.transpose() * t1w.translation);
+    let c1_in_cam2 = t2w.rotation * c1_world + t2w.translation;
+    let _ = c1_in_cam2;
+    (f12, t12)
+}
+
+/// Returns point-to-epipolar-line squared distance in image 2.
+///
+/// `l2 = [a, b, c] = x1^T F12` where `x1 = (u1, v1, 1)`. The squared pixel
+/// distance of `x2 = (u2, v2)` to line `l2` is `(a u2 + b v2 + c)^2 / (a^2 + b^2)`.
+#[inline]
+fn epipolar_line_distance_sq(f12: &Mat3F64, u1: f32, v1: f32, u2: f32, v2: f32) -> Option<f32> {
+    let u1 = u1 as f64;
+    let v1 = v1 as f64;
+    // row = x1^T F12 (treating F12 as column-major; use explicit indexing)
+    let a = u1 * f12.x_axis.x + v1 * f12.x_axis.y + f12.x_axis.z;
+    let b = u1 * f12.y_axis.x + v1 * f12.y_axis.y + f12.y_axis.z;
+    let c = u1 * f12.z_axis.x + v1 * f12.z_axis.y + f12.z_axis.z;
+    let num = a * u2 as f64 + b * v2 as f64 + c;
+    let den = a * a + b * b;
+    if den < 1e-12 {
+        return None;
+    }
+    Some(((num * num) / den) as f32)
+}
+
+/// Projects keyframe-1's camera center into keyframe-2's image.
+fn project_epipole_into_kf2(
+    t1w: &kornia_3d::pose::Pose3d,
+    t2w: &kornia_3d::pose::Pose3d,
+    k: &PinholeCamera,
+) -> Option<[f32; 2]> {
+    let c1_world = -(t1w.rotation.transpose() * t1w.translation);
+    let c1_in_cam2 = t2w.rotation * c1_world + t2w.translation;
+    if c1_in_cam2.z <= 1e-6 {
+        return None;
+    }
+    let u = k.fx * c1_in_cam2.x / c1_in_cam2.z + k.cx;
+    let v = k.fy * c1_in_cam2.y / c1_in_cam2.z + k.cy;
+    Some([u as f32, v as f32])
+}
+
+/// Returns candidate `(idx1, idx2)` pairs suitable for triangulation.
+///
+/// Walks the BoW direct indices of both keyframes (same-node intersection),
+/// skips features already owning a map point, enforces a hamming threshold,
+/// checks epipole margin + epipolar-line distance, and applies orientation
+/// histogram filtering.
+/// Diagnostic counters returned alongside the matched pairs.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TriangulationSearchStats {
+    pub node_intersections: usize,
+    pub candidate_feats_kf1: usize,
+    pub candidate_feats_kf2: usize,
+    pub rejected_already_matched: usize,
+    pub rejected_hamming: usize,
+    pub rejected_epipole_margin: usize,
+    pub rejected_epipolar_line: usize,
+    pub rejected_degenerate_line: usize,
+    pub accepted_before_orientation: usize,
+    pub dropped_by_orientation: usize,
+}
+
+pub fn search_for_triangulation(
+    kf1: &Keyframe,
+    kf2: &Keyframe,
+    camera: &PinholeCamera,
+    config: &TriangulationSearchConfig,
+) -> Vec<(usize, usize)> {
+    search_for_triangulation_with_stats(kf1, kf2, camera, config).0
+}
+
+pub fn search_for_triangulation_with_stats(
+    kf1: &Keyframe,
+    kf2: &Keyframe,
+    camera: &PinholeCamera,
+    config: &TriangulationSearchConfig,
+) -> (Vec<(usize, usize)>, TriangulationSearchStats) {
+    let mut stats = TriangulationSearchStats::default();
+    let Some(di1) = kf1.direct_index.as_ref() else {
+        return (Vec::new(), stats);
+    };
+    let Some(di2) = kf2.direct_index.as_ref() else {
+        return (Vec::new(), stats);
+    };
+
+    let t1w = &kf1.frame.pose_world_to_cam;
+    let t2w = &kf2.frame.pose_world_to_cam;
+
+    let (f12, _t12) = fundamental_12(t1w, t2w, camera);
+
+    let Some(epipole2) = project_epipole_into_kf2(t1w, t2w, camera) else {
+        return (Vec::new(), stats);
+    };
+
+    let n1 = kf1.frame.features.descriptors.len();
+    let n2 = kf2.frame.features.descriptors.len();
+    let mut matched2 = vec![false; n2];
+    let mut matches_12: Vec<i32> = vec![-1; n1];
+    let mut match_rot_bin: Vec<i16> = vec![-1; n1];
+
+    let factor = 1.0f32 / (config.histogram_bins as f32);
+
+    // Walk both sorted direct indices keeping node IDs aligned.
+    let a = &di1.0;
+    let b = &di2.0;
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        let (node_a, feats_a) = &a[i];
+        let (node_b, feats_b) = &b[j];
+        use std::cmp::Ordering;
+        match node_a.cmp(node_b) {
+            Ordering::Less => {
+                // advance i to the first node >= node_b
+                match a[i..].binary_search_by_key(node_b, |(n, _)| *n) {
+                    Ok(off) => i += off,
+                    Err(off) => i += off,
+                }
+            }
+            Ordering::Greater => match b[j..].binary_search_by_key(node_a, |(n, _)| *n) {
+                Ok(off) => j += off,
+                Err(off) => j += off,
+            },
+            Ordering::Equal => {
+                stats.node_intersections += 1;
+                stats.candidate_feats_kf1 += feats_a.len();
+                stats.candidate_feats_kf2 += feats_b.len();
+                for &fa in feats_a.iter() {
+                    let idx1 = fa as usize;
+                    if kf1.map_point(idx1).is_some() {
+                        stats.rejected_already_matched += 1;
+                        continue;
+                    }
+                    let d1 = &kf1.frame.features.descriptors[idx1];
+                    let kp1 = kf1.frame.features.keypoints_xy[idx1];
+                    let ang1 = kf1.frame.features.orientations[idx1];
+
+                    let mut best_dist = config.max_hamming_distance + 1;
+                    let mut best_idx2: i32 = -1;
+
+                    for &fb in feats_b.iter() {
+                        let idx2 = fb as usize;
+                        if matched2[idx2] || kf2.map_point(idx2).is_some() {
+                            stats.rejected_already_matched += 1;
+                            continue;
+                        }
+                        let d2 = &kf2.frame.features.descriptors[idx2];
+                        let dist = hamming_u8(d1, d2);
+                        if dist > config.max_hamming_distance || dist >= best_dist {
+                            stats.rejected_hamming += 1;
+                            continue;
+                        }
+
+                        let kp2 = kf2.frame.features.keypoints_xy[idx2];
+                        let scale2 = kf2.frame.features.scales[idx2];
+
+                        // Epipole margin: drop matches whose kp2 is too close to the epipole.
+                        let dex = epipole2[0] - kp2[0];
+                        let dey = epipole2[1] - kp2[1];
+                        if dex * dex + dey * dey < config.epipole_margin_factor * scale2 {
+                            stats.rejected_epipole_margin += 1;
+                            continue;
+                        }
+
+                        // Epipolar line distance in image 2 (units: px²).
+                        let Some(dsq) =
+                            epipolar_line_distance_sq(&f12, kp1[0], kp1[1], kp2[0], kp2[1])
+                        else {
+                            stats.rejected_degenerate_line += 1;
+                            continue;
+                        };
+                        // ORB-SLAM3 threshold: dsq < 3.84 * sigmaLevel2(kp2.octave)
+                        // sigmaLevel2 = scaleFactor^2.
+                        if dsq >= config.epipolar_chi2 * scale2 * scale2 {
+                            stats.rejected_epipolar_line += 1;
+                            continue;
+                        }
+
+                        best_dist = dist;
+                        best_idx2 = idx2 as i32;
+                    }
+
+                    if best_idx2 >= 0 {
+                        let idx2 = best_idx2 as usize;
+                        matches_12[idx1] = best_idx2;
+                        matched2[idx2] = true;
+
+                        if config.check_orientation {
+                            let ang2 = kf2.frame.features.orientations[idx2];
+                            // ORB-SLAM3 uses degrees and keypoint angle in [0, 360).
+                            let mut rot = (ang1 - ang2).to_degrees();
+                            if rot < 0.0 {
+                                rot += 360.0;
+                            }
+                            let mut bin = (rot * factor).round() as i32;
+                            if bin == config.histogram_bins as i32 {
+                                bin = 0;
+                            }
+                            if bin >= 0 && (bin as usize) < config.histogram_bins {
+                                match_rot_bin[idx1] = bin as i16;
+                            }
+                        }
+                    }
+                }
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+
+    // Orientation-histogram filter: keep only the three most populated bins,
+    // and drop any secondary bin whose mass is < 10% of the max.
+    if config.check_orientation {
+        let mut counts = vec![0i32; config.histogram_bins];
+        for &b in &match_rot_bin {
+            if b >= 0 {
+                counts[b as usize] += 1;
+            }
+        }
+        let (ind1, ind2, ind3) = three_maxima(&counts);
+
+        for (idx1, &b) in match_rot_bin.iter().enumerate() {
+            if b < 0 {
+                continue;
+            }
+            let bi = b as i32;
+            if bi != ind1 && bi != ind2 && bi != ind3 {
+                matches_12[idx1] = -1;
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for (idx1, &m) in matches_12.iter().enumerate() {
+        if m >= 0 {
+            out.push((idx1, m as usize));
+        }
+    }
+    (out, stats)
+}
+
+/// Returns the three histogram bins with the largest counts. Bins 2 and 3 are
+/// suppressed (returned as -1) when their mass falls below 10% of bin 1's mass.
+fn three_maxima(counts: &[i32]) -> (i32, i32, i32) {
+    let mut max1 = 0i32;
+    let mut max2 = 0i32;
+    let mut max3 = 0i32;
+    let mut ind1: i32 = -1;
+    let mut ind2: i32 = -1;
+    let mut ind3: i32 = -1;
+    for (i, &s) in counts.iter().enumerate() {
+        let i = i as i32;
+        if s > max1 {
+            max3 = max2;
+            max2 = max1;
+            max1 = s;
+            ind3 = ind2;
+            ind2 = ind1;
+            ind1 = i;
+        } else if s > max2 {
+            max3 = max2;
+            max2 = s;
+            ind3 = ind2;
+            ind2 = i;
+        } else if s > max3 {
+            max3 = s;
+            ind3 = i;
+        }
+    }
+    if (max2 as f32) < 0.1 * (max1 as f32) {
+        ind2 = -1;
+        ind3 = -1;
+    } else if (max3 as f32) < 0.1 * (max1 as f32) {
+        ind3 = -1;
+    }
+    (ind1, ind2, ind3)
+}

--- a/crates/kornia-slam/src/estimation/two_view.rs
+++ b/crates/kornia-slam/src/estimation/two_view.rs
@@ -14,9 +14,13 @@
 
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
-use kornia_3d::pose::{TwoViewConfig, TwoViewModel, two_view_estimate};
-use kornia_algebra::Vec3F64;
-use kornia_imgproc::features::{OrbFeatures, OrbMatchConfig, match_orb_descriptors};
+use kornia_3d::pose::{
+    TwoViewConfig, TwoViewDiagnostics, TwoViewModel, two_view_estimate_with_diagnostics,
+};
+use kornia_algebra::{Mat3F64, Vec2F64, Vec3F64};
+use kornia_imgproc::features::{
+    OrbFeatures, OrbMatchConfig, hamming_distance, match_orb_descriptors,
+};
 
 use super::Estimate;
 
@@ -29,6 +33,8 @@ pub struct TwoViewAcceptanceConfig {
     pub min_inliers: usize,
     /// Minimum triangulated points required to accept initialization.
     pub min_triangulated: usize,
+    /// Minimum median parallax required to accept initialization.
+    pub min_parallax_deg: f64,
 }
 
 /// Configuration for two-view initialization.
@@ -36,6 +42,8 @@ pub struct TwoViewAcceptanceConfig {
 pub struct TwoViewInitConfig {
     /// ORB descriptor matcher settings.
     pub match_config: OrbMatchConfig,
+    /// ORB-SLAM3 initialization matcher search window in pixels.
+    pub initialization_window_px: Option<f32>,
     /// Two-view model estimation settings.
     pub estimation_config: TwoViewConfig,
     /// Acceptance thresholds applied on top of the estimator result.
@@ -46,16 +54,29 @@ impl Default for TwoViewInitConfig {
     fn default() -> Self {
         Self {
             match_config: OrbMatchConfig {
-                nn_ratio: 0.6,
+                nn_ratio: 0.9,
                 th_low: 50,
                 check_orientation: true,
                 histo_length: 30,
             },
-            estimation_config: TwoViewConfig::default(),
+            initialization_window_px: Some(100.0),
+            estimation_config: {
+                let mut cfg = TwoViewConfig::default();
+                cfg.triangulation.use_orb_slam3_check_rt = true;
+                cfg.triangulation.check_rt_reproj_th_sq = 4.0;
+                cfg.triangulation.min_cheirality_count = 1;
+                // ORB-SLAM3 chi-square thresholds (sigma=1 px): sqrt(3.841) ≈ 1.96 for F,
+                // sqrt(5.991) ≈ 2.45 for H. Our RANSAC threshold is compared against the
+                // squared residual internally, so pass the linear threshold here.
+                cfg.ransac_f.threshold = 3.841_f64.sqrt();
+                cfg.ransac_h.threshold = 5.991_f64.sqrt();
+                cfg
+            },
             acceptance_config: TwoViewAcceptanceConfig {
                 min_matches: 100,
                 min_inliers: 30,
                 min_triangulated: 50,
+                min_parallax_deg: 1.0,
             },
         }
     }
@@ -91,6 +112,70 @@ pub struct TwoViewEstimate {
     pub median_depth: Option<f64>,
 }
 
+/// Non-behavioral counters from a two-view initialization attempt.
+#[derive(Debug, Clone)]
+pub struct TwoViewInitReport {
+    /// Descriptor matches before geometric estimation.
+    pub matches: usize,
+    /// Selected model name, or `none` if no model was estimated.
+    pub model: &'static str,
+    /// Geometric inliers from the selected model.
+    pub inliers: usize,
+    /// Accepted triangulated point count.
+    pub triangulated: usize,
+    /// Median positive triangulated depth.
+    pub median_depth: Option<f64>,
+    /// Rejection reason, if initialization failed.
+    pub reject_reason: Option<TwoViewRejectReason>,
+
+    /// Was two-view estimation attempted at all (matches >= min_matches).
+    pub two_view_ran: bool,
+    /// Did the pipeline accept the geometry (returns Ok).
+    pub two_view_accepted: bool,
+    /// Fundamental RANSAC inliers.
+    pub inliers_f: usize,
+    /// Homography RANSAC inliers.
+    pub inliers_h: usize,
+    /// ORB-SLAM3-style homography score (chi-square capped) in pixel units, sigma=1.
+    pub orb_slam3_sh: f64,
+    /// ORB-SLAM3-style fundamental score in pixel units, sigma=1.
+    pub orb_slam3_sf: f64,
+    /// ORB-SLAM3-style RH = SH / (SH + SF).
+    pub orb_slam3_rh: f64,
+    /// Per-candidate triangulation counts for the selected model.
+    pub candidate_ngood: Vec<usize>,
+    /// Best candidate index inside `candidate_ngood`, if any.
+    pub best_candidate_idx: Option<usize>,
+    /// Second-best candidate count.
+    pub second_best_good: usize,
+    /// Median parallax of the selected pose (degrees).
+    pub median_parallax_deg: f64,
+}
+
+impl Default for TwoViewInitReport {
+    fn default() -> Self {
+        Self {
+            matches: 0,
+            model: "none",
+            inliers: 0,
+            triangulated: 0,
+            median_depth: None,
+            reject_reason: None,
+            two_view_ran: false,
+            two_view_accepted: false,
+            inliers_f: 0,
+            inliers_h: 0,
+            orb_slam3_sh: 0.0,
+            orb_slam3_sf: 0.0,
+            orb_slam3_rh: 0.0,
+            candidate_ngood: Vec::new(),
+            best_candidate_idx: None,
+            second_best_good: 0,
+            median_parallax_deg: 0.0,
+        }
+    }
+}
+
 /// Attempt two-view initialization between a reference frame and the current frame.
 pub fn try_initialize_two_view(
     ref_features: &OrbFeatures,
@@ -99,17 +184,43 @@ pub fn try_initialize_two_view(
     camera: &PinholeCamera,
     config: &TwoViewInitConfig,
 ) -> Result<TwoViewEstimate, TwoViewRejectReason> {
-    let acceptance = &config.acceptance_config;
+    try_initialize_two_view_with_report(ref_features, ref_pose, curr_features, camera, config).0
+}
 
-    let matches = match_orb_descriptors(
-        &ref_features.orientations,
-        &ref_features.descriptors,
-        &curr_features.orientations,
-        &curr_features.descriptors,
-        config.match_config,
-    );
+/// Attempt two-view initialization and return trace counters alongside the result.
+pub fn try_initialize_two_view_with_report(
+    ref_features: &OrbFeatures,
+    ref_pose: &Pose3d,
+    curr_features: &OrbFeatures,
+    camera: &PinholeCamera,
+    config: &TwoViewInitConfig,
+) -> (
+    Result<TwoViewEstimate, TwoViewRejectReason>,
+    TwoViewInitReport,
+) {
+    let acceptance = &config.acceptance_config;
+    let mut report = TwoViewInitReport::default();
+
+    let matches = if let Some(window_px) = config.initialization_window_px {
+        match_orb_descriptors_for_initialization(
+            ref_features,
+            curr_features,
+            config.match_config,
+            window_px,
+        )
+    } else {
+        match_orb_descriptors(
+            &ref_features.orientations,
+            &ref_features.descriptors,
+            &curr_features.orientations,
+            &curr_features.descriptors,
+            config.match_config,
+        )
+    };
+    report.matches = matches.len();
     if matches.len() < acceptance.min_matches {
-        return Err(TwoViewRejectReason::LowMatches);
+        report.reject_reason = Some(TwoViewRejectReason::LowMatches);
+        return (Err(TwoViewRejectReason::LowMatches), report);
     }
 
     let (reference_pts, current_pts) = camera.undistort_matched_pairs(
@@ -119,30 +230,57 @@ pub fn try_initialize_two_view(
     );
 
     let k = camera.intrinsic_matrix();
-    let result = two_view_estimate(
+    report.two_view_ran = true;
+    let estimation = two_view_estimate_with_diagnostics(
         &reference_pts,
         &current_pts,
         &k,
         &k,
         &config.estimation_config,
     )
-    .map_err(|_| TwoViewRejectReason::EstimationFailed)?;
+    .map_err(|_| TwoViewRejectReason::EstimationFailed);
+    let (result, diagnostics) = match estimation {
+        Ok(pair) => pair,
+        Err(reason) => {
+            report.reject_reason = Some(reason);
+            fill_diagnostics_empty(&mut report, &reference_pts, &current_pts);
+            return (Err(reason), report);
+        }
+    };
+
+    fill_diagnostics(&mut report, &diagnostics, &reference_pts, &current_pts);
+
+    report.model = two_view_model_name(result.model);
+    report.inliers = result.inlier_indices.len();
+    report.triangulated = result.points3d.len();
+    // Use ORB-SLAM3's sorted-cos-parallax-at-index-min(50,N-1) from CheckRT,
+    // not a per-inlier bearing-angle median. Falls back to the bearing median
+    // if CheckRT wasn't used (flag off in some configs).
+    report.median_parallax_deg = if diagnostics.best_candidate_parallax_deg > 0.0 {
+        diagnostics.best_candidate_parallax_deg
+    } else {
+        result.median_parallax_deg(&reference_pts, &current_pts, camera)
+    };
 
     if !matches!(result.model, TwoViewModel::Fundamental(_)) {
-        return Err(TwoViewRejectReason::WrongModel);
+        report.reject_reason = Some(TwoViewRejectReason::WrongModel);
+        return (Err(TwoViewRejectReason::WrongModel), report);
     }
 
     if result.points3d.len() < acceptance.min_triangulated {
-        return Err(TwoViewRejectReason::LowTriangulated);
+        report.reject_reason = Some(TwoViewRejectReason::LowTriangulated);
+        return (Err(TwoViewRejectReason::LowTriangulated), report);
     }
 
     if result.inlier_indices.len() < acceptance.min_inliers {
-        return Err(TwoViewRejectReason::LowInliers);
+        report.reject_reason = Some(TwoViewRejectReason::LowInliers);
+        return (Err(TwoViewRejectReason::LowInliers), report);
     }
 
-    let median_parallax_deg = result.median_parallax_deg(&reference_pts, &current_pts, camera);
-    if median_parallax_deg < config.estimation_config.triangulation.min_parallax_deg {
-        return Err(TwoViewRejectReason::LowParallax);
+    let median_parallax_deg = report.median_parallax_deg;
+    if median_parallax_deg < acceptance.min_parallax_deg {
+        report.reject_reason = Some(TwoViewRejectReason::LowParallax);
+        return (Err(TwoViewRejectReason::LowParallax), report);
     }
 
     let mut t_scaled = result.translation;
@@ -153,6 +291,7 @@ pub fn try_initialize_two_view(
         .filter(|&z| z > 0.0)
         .collect();
     let median_depth = median_in_place(&mut depths).filter(|&d| d > 1e-6);
+    report.median_depth = median_depth;
     if let Some(md) = median_depth {
         t_scaled /= md;
     }
@@ -163,7 +302,7 @@ pub fn try_initialize_two_view(
     );
     let inliers = result.inlier_indices.len();
 
-    Ok(TwoViewEstimate {
+    let estimate = TwoViewEstimate {
         estimate: Estimate {
             pose,
             matches,
@@ -172,7 +311,306 @@ pub fn try_initialize_two_view(
         points3d: result.points3d,
         inlier_indices: result.inlier_indices,
         median_depth,
-    })
+    };
+
+    report.two_view_accepted = true;
+    (Ok(estimate), report)
+}
+
+fn fill_diagnostics(
+    report: &mut TwoViewInitReport,
+    diag: &TwoViewDiagnostics,
+    ref_pts: &[Vec2F64],
+    cur_pts: &[Vec2F64],
+) {
+    report.inliers_f = diag.f_inlier_count;
+    report.inliers_h = diag.h_inlier_count;
+    report.candidate_ngood = diag.candidate_ngood.clone();
+    report.best_candidate_idx = diag.best_candidate_idx;
+    report.second_best_good = diag.second_best_good;
+    let sh = orb_slam3_homography_score(&diag.h_matrix, ref_pts, cur_pts);
+    let sf = orb_slam3_fundamental_score(&diag.f_matrix, ref_pts, cur_pts);
+    report.orb_slam3_sh = sh;
+    report.orb_slam3_sf = sf;
+    report.orb_slam3_rh = if sh + sf > 0.0 { sh / (sh + sf) } else { 0.0 };
+}
+
+fn fill_diagnostics_empty(
+    report: &mut TwoViewInitReport,
+    _ref_pts: &[Vec2F64],
+    _cur_pts: &[Vec2F64],
+) {
+    // Called when RANSAC itself failed; leave diagnostics at defaults.
+    report.candidate_ngood.clear();
+    report.best_candidate_idx = None;
+}
+
+/// ORB-SLAM3 symmetric-transfer score for a homography (CheckHomography).
+/// Assumes sigma = 1 px and chi-square threshold 5.991.
+fn orb_slam3_homography_score(h: &Mat3F64, x1: &[Vec2F64], x2: &[Vec2F64]) -> f64 {
+    let th = 5.991;
+    let inv = match invert_mat3(h) {
+        Some(m) => m,
+        None => return 0.0,
+    };
+    let mut score = 0.0;
+    for (p1, p2) in x1.iter().zip(x2.iter()) {
+        // x2in1 = H^-1 * x2
+        let w2 = inv.col(0).x * p2.x + inv.col(1).x * p2.y + inv.col(2).x;
+        let w = inv.col(0).y * p2.x + inv.col(1).y * p2.y + inv.col(2).y;
+        let denom = inv.col(0).z * p2.x + inv.col(1).z * p2.y + inv.col(2).z;
+        if denom.abs() < 1e-12 {
+            continue;
+        }
+        let u = w2 / denom;
+        let v = w / denom;
+        let d2_1 = (p1.x - u) * (p1.x - u) + (p1.y - v) * (p1.y - v);
+        if d2_1 <= th {
+            score += th - d2_1;
+        }
+
+        // x1in2 = H * x1
+        let u2 = h.col(0).x * p1.x + h.col(1).x * p1.y + h.col(2).x;
+        let v2 = h.col(0).y * p1.x + h.col(1).y * p1.y + h.col(2).y;
+        let w_fwd = h.col(0).z * p1.x + h.col(1).z * p1.y + h.col(2).z;
+        if w_fwd.abs() < 1e-12 {
+            continue;
+        }
+        let u2p = u2 / w_fwd;
+        let v2p = v2 / w_fwd;
+        let d2_2 = (p2.x - u2p) * (p2.x - u2p) + (p2.y - v2p) * (p2.y - v2p);
+        if d2_2 <= th {
+            score += th - d2_2;
+        }
+    }
+    score
+}
+
+/// ORB-SLAM3 symmetric-transfer score for a fundamental matrix (CheckFundamental).
+/// Sigma = 1 px, chi-square threshold per residual 3.841, bonus threshold 5.991.
+fn orb_slam3_fundamental_score(f: &Mat3F64, x1: &[Vec2F64], x2: &[Vec2F64]) -> f64 {
+    let th = 3.841;
+    let th_score = 5.991;
+    let mut score = 0.0;
+    for (p1, p2) in x1.iter().zip(x2.iter()) {
+        // l2 = F * x1; residual = (x2 . l2)^2 / (a2^2 + b2^2)
+        let a2 = f.col(0).x * p1.x + f.col(1).x * p1.y + f.col(2).x;
+        let b2 = f.col(0).y * p1.x + f.col(1).y * p1.y + f.col(2).y;
+        let c2 = f.col(0).z * p1.x + f.col(1).z * p1.y + f.col(2).z;
+        let num2 = a2 * p2.x + b2 * p2.y + c2;
+        let denom2 = a2 * a2 + b2 * b2;
+        if denom2 > 1e-12 {
+            let d2_1 = num2 * num2 / denom2;
+            if d2_1 <= th {
+                score += th_score - d2_1;
+            }
+        }
+
+        // l1 = F^T * x2
+        let a1 = f.col(0).x * p2.x + f.col(0).y * p2.y + f.col(0).z;
+        let b1 = f.col(1).x * p2.x + f.col(1).y * p2.y + f.col(1).z;
+        let c1 = f.col(2).x * p2.x + f.col(2).y * p2.y + f.col(2).z;
+        let num1 = a1 * p1.x + b1 * p1.y + c1;
+        let denom1 = a1 * a1 + b1 * b1;
+        if denom1 > 1e-12 {
+            let d2_2 = num1 * num1 / denom1;
+            if d2_2 <= th {
+                score += th_score - d2_2;
+            }
+        }
+    }
+    score
+}
+
+fn invert_mat3(m: &Mat3F64) -> Option<Mat3F64> {
+    let inv = m.inverse();
+    // glam returns zero matrix when singular. Detect by checking a diagonal.
+    let prod = *m * inv;
+    let trace = prod.col(0).x + prod.col(1).y + prod.col(2).z;
+    if (trace - 3.0).abs() > 1e-3 {
+        return None;
+    }
+    Some(inv)
+}
+
+/// Human-readable name for a two-view rejection reason.
+pub fn two_view_reject_reason_name(reason: TwoViewRejectReason) -> &'static str {
+    match reason {
+        TwoViewRejectReason::LowMatches => "low_matches",
+        TwoViewRejectReason::EstimationFailed => "estimation_failed",
+        TwoViewRejectReason::WrongModel => "wrong_model",
+        TwoViewRejectReason::LowTriangulated => "low_triangulated",
+        TwoViewRejectReason::LowInliers => "low_inliers",
+        TwoViewRejectReason::LowParallax => "low_parallax",
+    }
+}
+
+fn two_view_model_name(model: TwoViewModel) -> &'static str {
+    match model {
+        TwoViewModel::Fundamental(_) => "fundamental",
+        TwoViewModel::Homography(_) => "homography",
+    }
+}
+
+fn match_orb_descriptors_for_initialization(
+    ref_features: &OrbFeatures,
+    curr_features: &OrbFeatures,
+    config: OrbMatchConfig,
+    window_px: f32,
+) -> Vec<(usize, usize)> {
+    assert_eq!(
+        ref_features.orientations.len(),
+        ref_features.descriptors.len(),
+        "ref orientation/descriptor length mismatch",
+    );
+    assert_eq!(
+        ref_features.scales.len(),
+        ref_features.descriptors.len(),
+        "ref scale/descriptor length mismatch",
+    );
+    assert_eq!(
+        curr_features.orientations.len(),
+        curr_features.descriptors.len(),
+        "current orientation/descriptor length mismatch",
+    );
+    assert_eq!(
+        curr_features.scales.len(),
+        curr_features.descriptors.len(),
+        "current scale/descriptor length mismatch",
+    );
+
+    if ref_features.descriptors.is_empty() || curr_features.descriptors.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matches12: Vec<Option<usize>> = vec![None; ref_features.descriptors.len()];
+    let mut matches21: Vec<Option<usize>> = vec![None; curr_features.descriptors.len()];
+    let mut matched_distance: Vec<u32> = vec![u32::MAX; curr_features.descriptors.len()];
+    let mut rot_hist: Vec<Vec<usize>> = vec![Vec::new(); config.histo_length];
+    let factor = 1.0f32 / config.histo_length as f32;
+
+    for (i1, ref_desc) in ref_features.descriptors.iter().enumerate() {
+        if !is_base_octave(ref_features.scales[i1]) {
+            continue;
+        }
+        let ref_pt = ref_features.keypoints_xy[i1];
+        let mut best_dist = u32::MAX;
+        let mut second_dist = u32::MAX;
+        let mut best_idx = None;
+
+        for (i2, curr_desc) in curr_features.descriptors.iter().enumerate() {
+            if !is_base_octave(curr_features.scales[i2]) {
+                continue;
+            }
+            let curr_pt = curr_features.keypoints_xy[i2];
+            if (curr_pt[0] - ref_pt[0]).abs() > window_px
+                || (curr_pt[1] - ref_pt[1]).abs() > window_px
+            {
+                continue;
+            }
+
+            let dist = hamming_distance(ref_desc, curr_desc);
+            if matched_distance[i2] <= dist {
+                continue;
+            }
+
+            if dist < best_dist {
+                second_dist = best_dist;
+                best_dist = dist;
+                best_idx = Some(i2);
+            } else if dist < second_dist {
+                second_dist = dist;
+            }
+        }
+
+        let Some(i2) = best_idx else {
+            continue;
+        };
+        if best_dist > config.th_low || (best_dist as f32) >= config.nn_ratio * second_dist as f32 {
+            continue;
+        }
+
+        if let Some(prev_i1) = matches21[i2] {
+            matches12[prev_i1] = None;
+        }
+        matches12[i1] = Some(i2);
+        matches21[i2] = Some(i1);
+        matched_distance[i2] = best_dist;
+
+        if config.check_orientation {
+            let mut rot = ref_features.orientations[i1].to_degrees()
+                - curr_features.orientations[i2].to_degrees();
+            if rot < 0.0 {
+                rot += 360.0;
+            }
+            let mut bin = (rot * factor).round() as usize;
+            if bin == config.histo_length {
+                bin = 0;
+            }
+            rot_hist[bin].push(i1);
+        }
+    }
+
+    if config.check_orientation {
+        let (ind1, ind2, ind3) = three_maxima(&rot_hist);
+        for (bin_idx, bin) in rot_hist.iter().enumerate() {
+            if Some(bin_idx) == ind1 || Some(bin_idx) == ind2 || Some(bin_idx) == ind3 {
+                continue;
+            }
+            for &i1 in bin {
+                matches12[i1] = None;
+            }
+        }
+    }
+
+    matches12
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i1, i2)| i2.map(|i2| (i1, i2)))
+        .collect()
+}
+
+fn is_base_octave(scale: f32) -> bool {
+    (scale - 1.0).abs() <= 1e-3
+}
+
+fn three_maxima(histo: &[Vec<usize>]) -> (Option<usize>, Option<usize>, Option<usize>) {
+    let mut ind1 = None;
+    let mut ind2 = None;
+    let mut ind3 = None;
+    let mut max1 = 0usize;
+    let mut max2 = 0usize;
+    let mut max3 = 0usize;
+
+    for (i, bin) in histo.iter().enumerate() {
+        let size = bin.len();
+        if size > max1 {
+            max3 = max2;
+            ind3 = ind2;
+            max2 = max1;
+            ind2 = ind1;
+            max1 = size;
+            ind1 = Some(i);
+        } else if size > max2 {
+            max3 = max2;
+            ind3 = ind2;
+            max2 = size;
+            ind2 = Some(i);
+        } else if size > max3 {
+            max3 = size;
+            ind3 = Some(i);
+        }
+    }
+
+    let threshold = (0.1 * max1 as f32) as usize;
+    if max2 < threshold {
+        ind2 = None;
+        ind3 = None;
+    } else if max3 < threshold {
+        ind3 = None;
+    }
+
+    (ind1, ind2, ind3)
 }
 
 /// Computes the median of a mutable slice in-place.
@@ -183,4 +621,97 @@ fn median_in_place(values: &mut [f64]) -> Option<f64> {
     let mid = values.len() / 2;
     values.select_nth_unstable_by(mid, |a, b| a.total_cmp(b));
     Some(values[mid])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn descriptor(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    fn match_config() -> OrbMatchConfig {
+        OrbMatchConfig {
+            nn_ratio: 0.9,
+            th_low: 50,
+            check_orientation: true,
+            histo_length: 30,
+        }
+    }
+
+    #[test]
+    fn initialization_matcher_rejects_matches_outside_search_window() {
+        let ref_features = OrbFeatures {
+            keypoints_xy: vec![[10.0, 10.0]],
+            scales: vec![1.0],
+            orientations: vec![0.0],
+            descriptors: vec![descriptor(0)],
+        };
+        let curr_features = OrbFeatures {
+            keypoints_xy: vec![[200.0, 200.0], [15.0, 15.0]],
+            scales: vec![1.0, 1.0],
+            orientations: vec![0.0, 0.0],
+            descriptors: vec![descriptor(0), descriptor(1)],
+        };
+
+        let matches = match_orb_descriptors_for_initialization(
+            &ref_features,
+            &curr_features,
+            match_config(),
+            20.0,
+        );
+
+        assert_eq!(matches, vec![(0, 1)]);
+    }
+
+    #[test]
+    fn initialization_matcher_only_uses_base_octave_features() {
+        let ref_features = OrbFeatures {
+            keypoints_xy: vec![[10.0, 10.0], [20.0, 20.0]],
+            scales: vec![1.2, 1.0],
+            orientations: vec![0.0, 0.0],
+            descriptors: vec![descriptor(0), descriptor(1)],
+        };
+        let curr_features = OrbFeatures {
+            keypoints_xy: vec![[10.0, 10.0], [20.0, 20.0]],
+            scales: vec![1.0, 1.0],
+            orientations: vec![0.0, 0.0],
+            descriptors: vec![descriptor(0), descriptor(1)],
+        };
+
+        let matches = match_orb_descriptors_for_initialization(
+            &ref_features,
+            &curr_features,
+            match_config(),
+            20.0,
+        );
+
+        assert_eq!(matches, vec![(1, 1)]);
+    }
+
+    #[test]
+    fn initialization_matcher_keeps_one_to_one_current_frame_matches() {
+        let ref_features = OrbFeatures {
+            keypoints_xy: vec![[10.0, 10.0], [11.0, 11.0]],
+            scales: vec![1.0, 1.0],
+            orientations: vec![0.0, 0.0],
+            descriptors: vec![descriptor(1), descriptor(0)],
+        };
+        let curr_features = OrbFeatures {
+            keypoints_xy: vec![[12.0, 12.0]],
+            scales: vec![1.0],
+            orientations: vec![0.0],
+            descriptors: vec![descriptor(0)],
+        };
+
+        let matches = match_orb_descriptors_for_initialization(
+            &ref_features,
+            &curr_features,
+            match_config(),
+            20.0,
+        );
+
+        assert_eq!(matches, vec![(1, 0)]);
+    }
 }

--- a/crates/kornia-slam/src/factors/pose_prior.rs
+++ b/crates/kornia-slam/src/factors/pose_prior.rs
@@ -1,0 +1,217 @@
+//! Strong SE(3) prior factor used to anchor a keyframe in inertial BA.
+//!
+//! Workaround for the lack of a "fixed variable" mechanism in
+//! `kornia_algebra::optim::Problem`. Pinning a pose with a high-weight prior
+//! keeps the gauge fixed (yaw, xy translation, scale via inertial coupling)
+//! without moving it appreciably during optimization.
+//!
+//! Residual (6D, in SE(3) tangent):
+//!   r = log(T_target⁻¹ · T_x)
+//! where `T_x = (R_x, t_x)` is the current pose estimate. We use a small-angle
+//! linearization around the target — adequate because the pose is held nearly
+//! at the target by the strong weight, so the residual stays near zero.
+//!
+//! Tangent ordering: `[δυ(3), δω(3)]` — translation first, rotation second —
+//! matching `InertialFactor`.
+
+use kornia_algebra::optim::{Factor, FactorError, FactorResult, LinearizationResult};
+
+/// Pose tangent dimension (SE3).
+const POSE_DIM: usize = 6;
+
+/// SE(3) prior factor that pulls a pose variable toward a target.
+///
+/// `weight` scales both the residual and Jacobian; use a large value (e.g. 1e3)
+/// to behave as a near-hard constraint.
+pub struct PosePriorFactor {
+    target_quat: [f32; 4],   // [qw, qx, qy, qz]
+    target_trans: [f32; 3],  // [tx, ty, tz]
+    weight: f32,
+}
+
+impl PosePriorFactor {
+    /// `target_pose` is the SE3 parameter vector `[qw, qx, qy, qz, tx, ty, tz]`.
+    pub fn new(target_pose: &[f32; 7], weight: f32) -> Self {
+        Self {
+            target_quat: [target_pose[0], target_pose[1], target_pose[2], target_pose[3]],
+            target_trans: [target_pose[4], target_pose[5], target_pose[6]],
+            weight,
+        }
+    }
+}
+
+impl Factor for PosePriorFactor {
+    fn linearize(
+        &self,
+        params: &[&[f32]],
+        compute_jacobian: bool,
+    ) -> FactorResult<LinearizationResult> {
+        if params.len() != 1 {
+            return Err(FactorError::DimensionMismatch {
+                expected: 1,
+                actual: params.len(),
+            });
+        }
+        let pose = params[0];
+        if pose.len() != 7 {
+            return Err(FactorError::DimensionMismatch {
+                expected: 7,
+                actual: pose.len(),
+            });
+        }
+
+        // Translation residual in target's body frame: R_target^T · (t_x − t_target)
+        let r_target = quat_to_rot(&self.target_quat);
+        let dt = [
+            pose[4] - self.target_trans[0],
+            pose[5] - self.target_trans[1],
+            pose[6] - self.target_trans[2],
+        ];
+        // Note: the pose's `t` lives in the same global frame on both sides;
+        // expressing the residual in the target's body frame keeps the
+        // δυ-Jacobian identity (matching the SE3 tangent we use).
+        // For small displacements this is equivalent to dt itself; we use
+        // identity Jacobian below and let the residual just be `t_x − t_target`.
+        let _ = r_target;
+        let r_trans = dt;
+
+        // Rotation residual: log(R_target^T · R_x). For small rotations this
+        // is δω in body coords. We compute it via quaternion multiplication.
+        let q_target_inv = [
+            self.target_quat[0],
+            -self.target_quat[1],
+            -self.target_quat[2],
+            -self.target_quat[3],
+        ];
+        let q_err = quat_mul(&q_target_inv, &[pose[0], pose[1], pose[2], pose[3]]);
+        let r_rot = quat_log(&q_err);
+
+        // Stack residual: [δυ, δω], scaled by weight.
+        let mut residual = vec![
+            self.weight * r_trans[0],
+            self.weight * r_trans[1],
+            self.weight * r_trans[2],
+            self.weight * r_rot[0],
+            self.weight * r_rot[1],
+            self.weight * r_rot[2],
+        ];
+
+        let jacobian = if compute_jacobian {
+            // ∂r/∂[δυ, δω] = weight · I_6
+            // (small-angle approximation: for δυ block the perturbation is
+            // t_new = t + R · δυ, but R ≈ R_target so identity is fine when
+            // the residual is held small by the weight).
+            let mut jac = vec![0.0f32; POSE_DIM * POSE_DIM];
+            for i in 0..POSE_DIM {
+                jac[i * POSE_DIM + i] = self.weight;
+            }
+            // Apply weight scaling to residual is done above. Jacobian above
+            // already includes the same `self.weight` factor.
+            // (No extra whitening: the weight IS the sqrt_information.)
+            let _ = &mut residual; // residual already weighted
+            Some(jac)
+        } else {
+            None
+        };
+
+        Ok(LinearizationResult::new(residual, jacobian, POSE_DIM))
+    }
+
+    fn residual_dim(&self) -> usize {
+        POSE_DIM
+    }
+
+    fn num_variables(&self) -> usize {
+        1
+    }
+
+    fn variable_local_dim(&self, idx: usize) -> usize {
+        match idx {
+            0 => POSE_DIM,
+            _ => panic!("PosePriorFactor has 1 variable"),
+        }
+    }
+}
+
+// ── Quaternion / rotation helpers (f32) ──────────────────────────────────
+
+fn quat_to_rot(q: &[f32; 4]) -> [f32; 9] {
+    let (w, x, y, z) = (q[0], q[1], q[2], q[3]);
+    [
+        1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y + w * z), 2.0 * (x * z - w * y),
+        2.0 * (x * y - w * z), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z + w * x),
+        2.0 * (x * z + w * y), 2.0 * (y * z - w * x), 1.0 - 2.0 * (x * x + y * y),
+    ]
+}
+
+fn quat_mul(a: &[f32; 4], b: &[f32; 4]) -> [f32; 4] {
+    let (aw, ax, ay, az) = (a[0], a[1], a[2], a[3]);
+    let (bw, bx, by, bz) = (b[0], b[1], b[2], b[3]);
+    [
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    ]
+}
+
+/// Quaternion log: returns the axis-angle vector ω such that q = exp(ω/2) (in
+/// quaternion form). For small rotations, ω ≈ 2 · [qx, qy, qz].
+fn quat_log(q: &[f32; 4]) -> [f32; 3] {
+    let w = q[0].clamp(-1.0, 1.0);
+    let v = [q[1], q[2], q[3]];
+    let v_norm = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    if v_norm < 1e-7 {
+        // Identity rotation
+        [0.0, 0.0, 0.0]
+    } else {
+        let theta = 2.0 * v_norm.atan2(w.abs());
+        let scale = if w >= 0.0 { theta / v_norm } else { -theta / v_norm };
+        [v[0] * scale, v[1] * scale, v[2] * scale]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_residual_at_target() {
+        let target = [1.0f32, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0];
+        let factor = PosePriorFactor::new(&target, 1.0);
+        let result = factor.linearize(&[&target], false).unwrap();
+        for r in &result.residual {
+            assert!(r.abs() < 1e-5, "expected zero residual, got {r}");
+        }
+    }
+
+    #[test]
+    fn nonzero_residual_when_offset() {
+        let target = [1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let offset = [1.0f32, 0.0, 0.0, 0.0, 0.1, -0.2, 0.3];
+        let factor = PosePriorFactor::new(&target, 1.0);
+        let result = factor.linearize(&[&offset], false).unwrap();
+        // Translation residual = offset - target (identity)
+        assert!((result.residual[0] - 0.1).abs() < 1e-5);
+        assert!((result.residual[1] + 0.2).abs() < 1e-5);
+        assert!((result.residual[2] - 0.3).abs() < 1e-5);
+        // Rotation residual = 0
+        for i in 3..6 {
+            assert!(result.residual[i].abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn weight_scales_residual_and_jacobian() {
+        let target = [1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let offset = [1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let factor = PosePriorFactor::new(&target, 100.0);
+        let result = factor.linearize(&[&offset], true).unwrap();
+        assert!((result.residual[0] - 100.0).abs() < 1e-3);
+        let jac = result.jacobian.unwrap();
+        // Diagonal entries should be 100.0
+        for i in 0..POSE_DIM {
+            assert!((jac[i * POSE_DIM + i] - 100.0).abs() < 1e-3);
+        }
+    }
+}

--- a/crates/kornia-slam/src/factors/weighted_prior.rs
+++ b/crates/kornia-slam/src/factors/weighted_prior.rs
@@ -1,0 +1,100 @@
+//! Weighted Euclidean prior factor used to anchor velocity / bias variables.
+//!
+//! Mirrors `kornia_algebra::optim::PriorFactor` (identity Jacobian, residual
+//! `x − target`) but scales both residual and Jacobian by a `weight`, so a
+//! large weight can act as a near-hard constraint for gauge fixing.
+
+use kornia_algebra::optim::{Factor, FactorError, FactorResult, LinearizationResult};
+
+/// Weighted prior factor for a Euclidean variable (R^n, local_dim == global_dim).
+pub struct WeightedPriorFactor {
+    target: Vec<f32>,
+    weight: f32,
+}
+
+impl WeightedPriorFactor {
+    pub fn new(target: Vec<f32>, weight: f32) -> Self {
+        Self { target, weight }
+    }
+}
+
+impl Factor for WeightedPriorFactor {
+    fn linearize(
+        &self,
+        params: &[&[f32]],
+        compute_jacobian: bool,
+    ) -> FactorResult<LinearizationResult> {
+        if params.len() != 1 {
+            return Err(FactorError::DimensionMismatch {
+                expected: 1,
+                actual: params.len(),
+            });
+        }
+        let x = params[0];
+        if x.len() != self.target.len() {
+            return Err(FactorError::DimensionMismatch {
+                expected: self.target.len(),
+                actual: x.len(),
+            });
+        }
+
+        let n = x.len();
+        let residual: Vec<f32> = x
+            .iter()
+            .zip(&self.target)
+            .map(|(xi, ti)| self.weight * (xi - ti))
+            .collect();
+
+        let jacobian = if compute_jacobian {
+            let mut jac = vec![0.0f32; n * n];
+            for i in 0..n {
+                jac[i * n + i] = self.weight;
+            }
+            Some(jac)
+        } else {
+            None
+        };
+
+        Ok(LinearizationResult::new(residual, jacobian, n))
+    }
+
+    fn residual_dim(&self) -> usize {
+        self.target.len()
+    }
+
+    fn num_variables(&self) -> usize {
+        1
+    }
+
+    fn variable_local_dim(&self, _idx: usize) -> usize {
+        self.target.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_residual_at_target() {
+        let f = WeightedPriorFactor::new(vec![1.0, 2.0, 3.0], 10.0);
+        let x = [1.0f32, 2.0, 3.0];
+        let r = f.linearize(&[&x], false).unwrap();
+        for v in &r.residual {
+            assert!(v.abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn weight_scales_residual_and_jacobian() {
+        let f = WeightedPriorFactor::new(vec![0.0, 0.0], 100.0);
+        let x = [1.0f32, -2.0];
+        let r = f.linearize(&[&x], true).unwrap();
+        assert!((r.residual[0] - 100.0).abs() < 1e-4);
+        assert!((r.residual[1] + 200.0).abs() < 1e-4);
+        let j = r.jacobian.unwrap();
+        assert!((j[0] - 100.0).abs() < 1e-4);
+        assert!((j[3] - 100.0).abs() < 1e-4);
+        assert!(j[1].abs() < 1e-6 && j[2].abs() < 1e-6);
+    }
+}

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -31,9 +31,16 @@ use kornia_3d::ba::{self, BaObservation, BaParams};
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_algebra::Vec3F64;
+use kornia_bow::metric::Hamming;
+use kornia_bow::orb_slam3::pack_orb_descriptor;
+use kornia_bow::{BoW, DirectIndex, Vocabulary};
 use kornia_image::ImageSize;
+use kornia_imgproc::features::hamming_distance;
 
 use crate::frame::Frame;
+
+const ORB_SCALE_FACTOR: f64 = 1.2;
+const ORB_N_LEVELS: usize = 8;
 
 /// A frame promoted into the map, with descriptor-to-map-point associations.
 #[derive(Debug, Clone)]
@@ -41,6 +48,13 @@ pub struct Keyframe {
     pub frame: Frame,
     /// For each descriptor index in `frame.features`, associated map-point index.
     pub map_point_by_desc_idx: Vec<Option<usize>>,
+    /// Bag-of-Words histogram computed against the ORB-SLAM3 vocabulary. Populated
+    /// lazily via [`Keyframe::compute_bow`].
+    pub bow: Option<BoW>,
+    /// Direct index: tree node → list of descriptor indices that traverse through
+    /// it at a chosen mid-tree level. Used by `SearchForTriangulation`-style
+    /// BoW-accelerated matching.
+    pub direct_index: Option<DirectIndex>,
 }
 
 impl Keyframe {
@@ -50,7 +64,36 @@ impl Keyframe {
         Self {
             frame,
             map_point_by_desc_idx,
+            bow: None,
+            direct_index: None,
         }
+    }
+
+    /// Computes the BoW vector and DirectIndex against the given vocabulary.
+    ///
+    /// `direct_index_level` selects the tree depth at which descriptors are
+    /// grouped in the direct index (ORB-SLAM3 uses level 2 of a depth-6 tree).
+    pub fn compute_bow(
+        &mut self,
+        vocab: &Vocabulary<10, Hamming<4>>,
+        direct_index_level: usize,
+    ) -> Result<(), kornia_bow::BowError> {
+        if self.frame.features.descriptors.is_empty() {
+            self.bow = None;
+            self.direct_index = None;
+            return Ok(());
+        }
+        let packed: Vec<_> = self
+            .frame
+            .features
+            .descriptors
+            .iter()
+            .map(pack_orb_descriptor)
+            .collect();
+        let (bow, di) = vocab.transform_with_direct_index(&packed, direct_index_level)?;
+        self.bow = Some(bow);
+        self.direct_index = Some(di);
+        Ok(())
     }
 
     /// Associates a descriptor slot with a persistent map point.
@@ -101,6 +144,27 @@ pub struct MapPoint {
     pub n_found: u32,
     /// Whether this point has been culled (logically deleted).
     pub culled: bool,
+    /// Average viewing direction from observing camera centers toward the point.
+    pub normal: Vec3F64,
+    /// Reference minimum distance for scale invariance.
+    pub min_distance: f64,
+    /// Reference maximum distance for scale invariance.
+    pub max_distance: f64,
+    /// Optional override for the observation count used by Fuse conflict
+    /// resolution. ORB-SLAM3's `MapPoint::Observations()` reads `mObservations.size()`
+    /// directly, which can disagree with the per-keyframe `mvpMapPoints` slot
+    /// state (some `Erase`/`Replace` paths leave stale entries). Parity replays
+    /// seed this from the dump's `observations` field so winner-selection
+    /// matches C++ exactly. None falls back to the inverse-index count.
+    pub observation_count_override: Option<u32>,
+    /// Optional set of keyframe indices observed by this MP, seeded from
+    /// `mObservations` for parity replay. ORB-SLAM3's
+    /// `MapPoint::IsInKeyFrame(pKF)` reads this directly; Rust's default
+    /// "is in kf" check scans the forward `mvpMapPoints` slot-list, which can
+    /// disagree when stale entries exist. When set, Fuse's IsInKF gate
+    /// honors this set in addition to the forward scan, so kornia skips
+    /// candidates exactly where ORB-SLAM3 does.
+    pub observed_keyframes_override: Option<std::collections::HashSet<usize>>,
 }
 
 impl MapPoint {
@@ -119,6 +183,11 @@ impl MapPoint {
             n_visible: 1,
             n_found: 1,
             culled: false,
+            normal: Vec3F64::new(0.0, 0.0, 1.0),
+            min_distance: 0.0,
+            max_distance: f64::INFINITY,
+            observation_count_override: None,
+            observed_keyframes_override: None,
         }
     }
 
@@ -134,6 +203,58 @@ impl MapPoint {
         }
         self.n_found as f64 / self.n_visible as f64
     }
+
+    /// Sets viewing-geometry metadata used by ORB-SLAM3-style frustum gating.
+    pub fn set_view_geometry(&mut self, normal: Vec3F64, min_distance: f64, max_distance: f64) {
+        self.normal = if normal.length() > 0.0 {
+            normal.normalize()
+        } else {
+            Vec3F64::new(0.0, 0.0, 1.0)
+        };
+        self.min_distance = min_distance.max(0.0);
+        self.max_distance = max_distance.max(self.min_distance);
+    }
+
+    /// Returns the viewing normal used by frustum gating.
+    pub fn viewing_normal(&self) -> Vec3F64 {
+        self.normal
+    }
+
+    /// Lower distance-invariance bound with ORB-SLAM3 slack.
+    pub fn min_distance_invariance(&self) -> f64 {
+        0.8 * self.min_distance
+    }
+
+    /// Upper distance-invariance bound with ORB-SLAM3 slack.
+    pub fn max_distance_invariance(&self) -> f64 {
+        1.2 * self.max_distance
+    }
+
+    /// Predicts the expected pyramid level for a current viewing distance.
+    pub fn predict_scale(&self, current_dist: f64, scale_factor: f64, n_levels: usize) -> usize {
+        if !self.max_distance.is_finite() || current_dist <= 0.0 || scale_factor <= 1.0 || n_levels == 0
+        {
+            return 0;
+        }
+        let ratio = self.max_distance / current_dist;
+        let level = (ratio.ln() / scale_factor.ln()).ceil() as isize;
+        level.clamp(0, n_levels.saturating_sub(1) as isize) as usize
+    }
+}
+
+/// Fusion policy for [`Map::fuse_projected_map_points_into_keyframe_limited_with_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FuseMode {
+    /// Only assign projected map points to keypoints that don't already own one.
+    /// Existing associations are never replaced. Safe default; used by the
+    /// pipeline's `SearchInNeighbors` step to promote 2-obs points to 3+ obs
+    /// without risking map corruption.
+    AddOnly,
+    /// When two map points compete for the same keypoint, keep the one observed
+    /// by more keyframes and replace the other. Mirrors ORB-SLAM3
+    /// `ORBmatcher::Fuse` replacement, but without its viewing-angle,
+    /// scale-invariance, or chi² gates.
+    ReplaceWeaker,
 }
 
 /// In-memory map storage for keyframes and persistent map points.
@@ -141,6 +262,10 @@ impl MapPoint {
 pub struct Map {
     keyframes: Vec<Keyframe>,
     map_points: Vec<MapPoint>,
+    observations_by_map_point: Vec<Vec<(usize, usize)>>,
+    /// Frame index of the origin (first) keyframe. Pinned fixed in every local BA
+    /// to lock the global frame — mirrors ORB-SLAM3's `Map::GetInitKFid()`.
+    origin_kf_frame_idx: Option<usize>,
 }
 
 impl Map {
@@ -164,22 +289,704 @@ impl Map {
         self.map_points.len()
     }
 
+    /// Returns the number of active, non-culled map points.
+    pub fn num_active_map_points(&self) -> usize {
+        self.map_points.iter().filter(|mp| !mp.culled).count()
+    }
+
     /// Returns the keyframe with frame index `idx`, if present.
     pub fn get_keyframe(&self, idx: usize) -> Option<&Keyframe> {
         self.keyframes.iter().find(|kf| kf.frame.idx == idx)
     }
 
+    /// Returns a mutable reference to the keyframe with frame index `idx`, if present.
+    pub fn get_keyframe_mut(&mut self, idx: usize) -> Option<&mut Keyframe> {
+        self.keyframes.iter_mut().find(|kf| kf.frame.idx == idx)
+    }
+
+    /// Counts how many map points associated with `kf_idx` are observed by at least
+    /// `min_obs` keyframes. This mirrors ORB-SLAM3's `KeyFrame::TrackedMapPoints(nMinObs)`.
+    pub fn tracked_map_points(&self, kf_idx: usize, min_obs: usize) -> usize {
+        let Some(pos) = self.keyframes.iter().position(|kf| kf.frame.idx == kf_idx) else {
+            return 0;
+        };
+        self.keyframes[pos]
+            .map_point_by_desc_idx
+            .iter()
+            .flatten()
+            .filter(|&mp_idx| {
+                self.map_points.get(*mp_idx).is_some_and(|mp| !mp.culled)
+                    && self.map_point_observation_count(*mp_idx) >= min_obs
+            })
+            .count()
+    }
+
     /// Inserts or replaces a keyframe by frame index.
     pub fn upsert_keyframe(&mut self, keyframe: Keyframe) {
+        let mut affected_points = HashSet::new();
         if let Some(pos) = self
             .keyframes
             .iter()
             .position(|kf| kf.frame.idx == keyframe.frame.idx)
         {
+            for mp_idx in self.keyframes[pos].map_point_by_desc_idx.iter().flatten() {
+                affected_points.insert(*mp_idx);
+            }
+            for mp_idx in keyframe.map_point_by_desc_idx.iter().flatten() {
+                affected_points.insert(*mp_idx);
+            }
             self.keyframes[pos] = keyframe;
         } else {
+            if self.origin_kf_frame_idx.is_none() {
+                self.origin_kf_frame_idx = Some(keyframe.frame.idx);
+            }
+            for mp_idx in keyframe.map_point_by_desc_idx.iter().flatten() {
+                affected_points.insert(*mp_idx);
+            }
             self.keyframes.push(keyframe);
         }
+        self.rebuild_observation_index();
+        self.refresh_map_points_metadata(affected_points);
+    }
+
+    /// Returns the origin keyframe's frame index, if any.
+    pub fn origin_kf_frame_idx(&self) -> Option<usize> {
+        self.origin_kf_frame_idx
+    }
+
+    /// Returns the global indices of non-culled map points observed by the
+    /// most recent `n_kfs` keyframes. Used by the tracker to restrict
+    /// projection-guided matching to a locally-relevant subset of the map,
+    /// approximating ORB-SLAM3's `TrackLocalMap` scope.
+    pub fn recent_kf_mp_indices(&self, n_kfs: usize) -> HashSet<usize> {
+        let total = self.keyframes.len();
+        let start = total.saturating_sub(n_kfs);
+        let mut set = HashSet::new();
+        for kf in &self.keyframes[start..] {
+            for mp_idx in kf.map_point_by_desc_idx.iter().flatten() {
+                if self.map_points.get(*mp_idx).is_some_and(|mp| !mp.culled) {
+                    set.insert(*mp_idx);
+                }
+            }
+        }
+        set
+    }
+
+    pub fn associate_keyframe_map_point(&mut self, kf_idx: usize, desc_idx: usize, mp_idx: usize) -> bool {
+        let Some(kf_pos) = self.keyframes.iter().position(|kf| kf.frame.idx == kf_idx) else {
+            return false;
+        };
+        let Some(slot) = self.keyframes[kf_pos].map_point_by_desc_idx.get_mut(desc_idx) else {
+            return false;
+        };
+
+        let mut affected_points = HashSet::new();
+        if let Some(prev_mp_idx) = *slot {
+            affected_points.insert(prev_mp_idx);
+        }
+        *slot = Some(mp_idx);
+        affected_points.insert(mp_idx);
+        self.rebuild_observation_index();
+        self.refresh_map_points_metadata(affected_points);
+        true
+    }
+
+    fn rebuild_observation_index(&mut self) {
+        let mut observations_by_map_point = vec![Vec::new(); self.map_points.len()];
+        for kf in &self.keyframes {
+            for (desc_idx, mp_idx) in kf.map_point_by_desc_idx.iter().enumerate() {
+                let Some(mp_idx) = *mp_idx else {
+                    continue;
+                };
+                if self.map_points.get(mp_idx).is_some_and(|mp| !mp.culled)
+                    && mp_idx < observations_by_map_point.len()
+                {
+                    observations_by_map_point[mp_idx].push((kf.frame.idx, desc_idx));
+                }
+            }
+        }
+        self.observations_by_map_point = observations_by_map_point;
+    }
+
+    fn map_point_observations(&self, mp_idx: usize) -> &[(usize, usize)] {
+        self.observations_by_map_point
+            .get(mp_idx)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    fn map_point_observation_count(&self, mp_idx: usize) -> usize {
+        if self.map_points.get(mp_idx).is_some_and(|mp| !mp.culled) {
+            self.map_point_observations(mp_idx).len()
+        } else {
+            0
+        }
+    }
+
+    fn map_point_observation_counts(&self) -> HashMap<usize, usize> {
+        self.observations_by_map_point
+            .iter()
+            .enumerate()
+            .filter_map(|(mp_idx, observations)| {
+                let mp = self.map_points.get(mp_idx)?;
+                if mp.culled {
+                    return None;
+                }
+                let count = mp
+                    .observation_count_override
+                    .map(|c| c as usize)
+                    .unwrap_or(observations.len());
+                Some((mp_idx, count))
+            })
+            .collect()
+    }
+
+    fn active_observations_by_map_point(&self) -> HashMap<usize, Vec<usize>> {
+        self.observations_by_map_point
+            .iter()
+            .enumerate()
+            .filter_map(|(mp_idx, observations)| {
+                self.map_points.get(mp_idx).is_some_and(|mp| !mp.culled).then(|| {
+                    (
+                        mp_idx,
+                        observations.iter().map(|(kf_idx, _)| *kf_idx).collect::<Vec<_>>(),
+                    )
+                })
+            })
+            .collect()
+    }
+
+    fn keypoint_octave(scale: f32) -> usize {
+        let raw = ((scale as f64).ln() / ORB_SCALE_FACTOR.ln()).round() as isize;
+        raw.clamp(0, ORB_N_LEVELS.saturating_sub(1) as isize) as usize
+    }
+
+    fn refresh_map_points_metadata<I>(&mut self, mp_indices: I)
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        let unique: HashSet<_> = mp_indices.into_iter().collect();
+        for mp_idx in unique {
+            self.refresh_map_point_metadata(mp_idx);
+        }
+    }
+
+    fn refresh_map_point_metadata(&mut self, mp_idx: usize) {
+        let Some(mp) = self.map_points.get(mp_idx) else {
+            return;
+        };
+        if mp.culled {
+            return;
+        }
+        let observations = self.map_point_observations(mp_idx);
+        if observations.is_empty() {
+            return;
+        }
+
+        let mut descriptors = Vec::new();
+        let mut normal_sum = Vec3F64::new(0.0, 0.0, 0.0);
+        let mut normal_count = 0usize;
+        let position = mp.position;
+        let desired_ref_kf_idx = mp.keyframe_idx;
+        let mut fallback_ref = None;
+        let mut chosen_ref = None;
+
+        for &(kf_idx, desc_idx) in observations {
+            let Some(kf) = self.get_keyframe(kf_idx) else {
+                continue;
+            };
+            let Some(descriptor) = kf.frame.features.descriptors.get(desc_idx).copied() else {
+                continue;
+            };
+            descriptors.push((kf_idx, desc_idx, descriptor));
+
+            let center = kf.frame.pose_world_to_cam.inverse().translation;
+            let viewing_ray = position - center;
+            let dist = viewing_ray.length();
+            if dist > 0.0 {
+                normal_sum += viewing_ray / dist;
+                normal_count += 1;
+                let scale = kf
+                    .frame
+                    .features
+                    .scales
+                    .get(desc_idx)
+                    .copied()
+                    .unwrap_or(1.0)
+                    .max(1.0) as f64;
+                let candidate_ref = (kf_idx, dist, scale);
+                if fallback_ref.is_none() {
+                    fallback_ref = Some(candidate_ref);
+                }
+                if kf_idx == desired_ref_kf_idx && chosen_ref.is_none() {
+                    chosen_ref = Some(candidate_ref);
+                }
+            }
+        }
+
+        if descriptors.is_empty() {
+            return;
+        }
+
+        let descriptor = if descriptors.len() == 1 {
+            descriptors[0].2
+        } else {
+            let mut best_descriptor = descriptors[0].2;
+            let mut best_median = u32::MAX;
+            for (i, &(_, _, descriptor_i)) in descriptors.iter().enumerate() {
+                let mut distances = Vec::with_capacity(descriptors.len().saturating_sub(1));
+                for (j, &(_, _, descriptor_j)) in descriptors.iter().enumerate() {
+                    if i == j {
+                        continue;
+                    }
+                    distances.push(hamming_distance(&descriptor_i, &descriptor_j));
+                }
+                distances.sort_unstable();
+                let median = distances[distances.len() / 2];
+                if median < best_median {
+                    best_median = median;
+                    best_descriptor = descriptor_i;
+                }
+            }
+            best_descriptor
+        };
+
+        let Some((ref_kf_idx, ref_dist, ref_scale)) = chosen_ref.or(fallback_ref) else {
+            return;
+        };
+        let max_distance = ref_dist * ref_scale;
+        let min_distance =
+            max_distance / ORB_SCALE_FACTOR.powi(ORB_N_LEVELS.saturating_sub(1) as i32);
+        let normal = if normal_count > 0 {
+            normal_sum / normal_count as f64
+        } else {
+            Vec3F64::new(0.0, 0.0, 1.0)
+        };
+
+        if let Some(mp_mut) = self.map_points.get_mut(mp_idx) {
+            mp_mut.descriptor = descriptor;
+            mp_mut.keyframe_idx = ref_kf_idx;
+            mp_mut.set_view_geometry(normal, min_distance, max_distance);
+        }
+    }
+
+    /// Returns keyframes that share active map points with `kf_idx`, sorted by
+    /// descending shared-point count. This is the on-demand equivalent of
+    /// ORB-SLAM3's covisibility graph connections.
+    pub fn covisibility_neighbors(&self, kf_idx: usize, top_n: usize) -> Vec<(usize, usize)> {
+        if top_n == 0 || self.get_keyframe(kf_idx).is_none() {
+            return Vec::new();
+        }
+
+        let observers = self.active_observations_by_map_point();
+        let mut shared_counts: HashMap<usize, usize> = HashMap::new();
+        let Some(kf) = self.get_keyframe(kf_idx) else {
+            return Vec::new();
+        };
+
+        let mut seen = HashSet::new();
+        for mp_idx in kf.map_point_by_desc_idx.iter().flatten() {
+            if !seen.insert(*mp_idx) {
+                continue;
+            }
+            let Some(mp) = self.map_points.get(*mp_idx) else {
+                continue;
+            };
+            if mp.culled {
+                continue;
+            }
+            let Some(mp_observers) = observers.get(mp_idx) else {
+                continue;
+            };
+            for &other_kf_idx in mp_observers {
+                if other_kf_idx != kf_idx {
+                    *shared_counts.entry(other_kf_idx).or_insert(0) += 1;
+                }
+            }
+        }
+
+        let mut neighbors: Vec<_> = shared_counts.into_iter().collect();
+        neighbors.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        neighbors.truncate(top_n);
+        neighbors
+    }
+
+    fn local_keyframe_indices(
+        &self,
+        tracked_matches: &[(usize, usize)],
+        current_keyframe: Option<&Keyframe>,
+        max_keyframes: usize,
+    ) -> Vec<usize> {
+        const MAX_COVISIBLE_PER_SEED: usize = 10;
+        const RECENT_FALLBACK_KEYFRAMES: usize = 10;
+
+        let observers = self.active_observations_by_map_point();
+        let mut keyframe_votes: HashMap<usize, usize> = HashMap::new();
+        for &(mp_idx, _) in tracked_matches {
+            let Some(mp_observers) = observers.get(&mp_idx) else {
+                continue;
+            };
+            for &kf_idx in mp_observers {
+                *keyframe_votes.entry(kf_idx).or_insert(0) += 1;
+            }
+        }
+
+        let mut voted_kfs: Vec<(usize, usize)> = keyframe_votes.into_iter().collect();
+        voted_kfs.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+        let mut local_kfs = Vec::new();
+        let mut seen = HashSet::new();
+        let push_kf = |kf_idx: usize, local_kfs: &mut Vec<usize>, seen: &mut HashSet<usize>| {
+            if local_kfs.len() < max_keyframes && seen.insert(kf_idx) {
+                local_kfs.push(kf_idx);
+            }
+        };
+
+        if let Some(kf) = current_keyframe {
+            push_kf(kf.frame.idx, &mut local_kfs, &mut seen);
+        }
+        for (kf_idx, _) in voted_kfs {
+            push_kf(kf_idx, &mut local_kfs, &mut seen);
+        }
+
+        // If tracking has too few matches to vote, keep the tracker alive with
+        // a temporal fallback. Once covisibility exists, the neighbor expansion
+        // below dominates this list.
+        if local_kfs.len() < 2 {
+            for kf in self.keyframes.iter().rev().take(RECENT_FALLBACK_KEYFRAMES) {
+                push_kf(kf.frame.idx, &mut local_kfs, &mut seen);
+            }
+        }
+
+        let seeds = local_kfs.clone();
+        for seed_idx in seeds {
+            if local_kfs.len() >= max_keyframes {
+                break;
+            }
+            for (neighbor_idx, _) in self.covisibility_neighbors(seed_idx, MAX_COVISIBLE_PER_SEED) {
+                push_kf(neighbor_idx, &mut local_kfs, &mut seen);
+                if local_kfs.len() >= max_keyframes {
+                    break;
+                }
+            }
+        }
+
+        local_kfs
+    }
+
+    /// Returns active map-point indices observed by a keyframe.
+    pub fn keyframe_map_point_indices(&self, kf_idx: usize) -> Vec<usize> {
+        let Some(kf) = self.get_keyframe(kf_idx) else {
+            return Vec::new();
+        };
+        let mut seen = HashSet::new();
+        let mut indices = Vec::new();
+        for mp_idx in kf.map_point_by_desc_idx.iter().flatten() {
+            if seen.insert(*mp_idx) && self.map_points.get(*mp_idx).is_some_and(|mp| !mp.culled) {
+                indices.push(*mp_idx);
+            }
+        }
+        indices
+    }
+
+    /// Replaces every observation of `from_mp_idx` with `to_mp_idx` and marks the
+    /// replaced point culled. If a keyframe already observes the survivor, the
+    /// duplicate observation is cleared to keep one map-point slot per keyframe.
+    fn replace_map_point_slots(&mut self, from_mp_idx: usize, to_mp_idx: usize) -> bool {
+        if from_mp_idx == to_mp_idx
+            || from_mp_idx >= self.map_points.len()
+            || to_mp_idx >= self.map_points.len()
+            || self.map_points[to_mp_idx].culled
+        {
+            return false;
+        }
+
+        for kf in &mut self.keyframes {
+            let has_survivor = kf
+                .map_point_by_desc_idx
+                .iter()
+                .any(|slot| *slot == Some(to_mp_idx));
+            let mut survivor_assigned_here = has_survivor;
+            for slot in &mut kf.map_point_by_desc_idx {
+                if *slot != Some(from_mp_idx) {
+                    continue;
+                }
+                if survivor_assigned_here {
+                    *slot = None;
+                } else {
+                    *slot = Some(to_mp_idx);
+                    survivor_assigned_here = true;
+                }
+            }
+        }
+
+        if let Some(mp) = self.map_points.get_mut(from_mp_idx) {
+            mp.mark_culled();
+        }
+        true
+    }
+
+    pub fn replace_map_point(&mut self, from_mp_idx: usize, to_mp_idx: usize) -> bool {
+        if !self.replace_map_point_slots(from_mp_idx, to_mp_idx) {
+            return false;
+        }
+        self.rebuild_observation_index();
+        self.refresh_map_points_metadata([to_mp_idx]);
+        true
+    }
+
+    /// Projects candidate map points into `kf_idx` and fuses descriptor matches.
+    ///
+    /// This is a compact monocular analogue of ORB-SLAM3 `ORBmatcher::Fuse`:
+    /// points already observed by the target keyframe are skipped, unclaimed
+    /// keypoints add a new observation, and conflicting map points are replaced
+    /// by the one with more keyframe observations.
+    pub fn fuse_projected_map_points_into_keyframe(
+        &mut self,
+        kf_idx: usize,
+        candidate_mp_indices: &[usize],
+        camera: &PinholeCamera,
+    ) -> usize {
+        self.fuse_projected_map_points_into_keyframe_limited_with_mode(
+            kf_idx,
+            candidate_mp_indices,
+            camera,
+            usize::MAX,
+            FuseMode::ReplaceWeaker,
+        )
+    }
+
+    /// Same as [`Map::fuse_projected_map_points_into_keyframe`], but stops after
+    /// `max_fused` accepted observations/replacements.
+    pub fn fuse_projected_map_points_into_keyframe_limited(
+        &mut self,
+        kf_idx: usize,
+        candidate_mp_indices: &[usize],
+        camera: &PinholeCamera,
+        max_fused: usize,
+    ) -> usize {
+        self.fuse_projected_map_points_into_keyframe_limited_with_mode(
+            kf_idx,
+            candidate_mp_indices,
+            camera,
+            max_fused,
+            FuseMode::ReplaceWeaker,
+        )
+    }
+
+    /// Variant of [`Map::fuse_projected_map_points_into_keyframe_limited`] that
+    /// selects whether conflicting map points may replace one another. With
+    /// [`FuseMode::AddOnly`], only unclaimed keypoints receive a new observation;
+    /// existing associations are never disturbed. This is the safe mode used by
+    /// the pipeline's `SearchInNeighbors` step until full ORB-SLAM3 `Fuse` gates
+    /// (viewing angle, scale invariance, chi² reprojection) are implemented.
+    pub fn fuse_projected_map_points_into_keyframe_limited_with_mode(
+        &mut self,
+        kf_idx: usize,
+        candidate_mp_indices: &[usize],
+        camera: &PinholeCamera,
+        max_fused: usize,
+        mode: FuseMode,
+    ) -> usize {
+        // Matches ORB-SLAM3 `ORBmatcher::Fuse` gates:
+        //   viewing angle cos >= 0.5, distance invariance, predicted octave
+        //   filter `[pred-1, pred]`, chi-square reprojection gate
+        //   `e^2 * invLevelSigma^2 <= 5.99`.
+        const FUSE_TH: f32 = 3.0;
+        const CHI2_MONO: f32 = 5.991;
+        const ORB_SCALE_FACTOR_F32: f32 = 1.2;
+        const ORB_N_LEVELS_LOCAL: usize = 8;
+        const MAX_HAMMING: u32 = 50;
+        const GRID_CELL_SIZE: f32 = 32.0;
+
+        let Some(kf_pos) = self.keyframes.iter().position(|kf| kf.frame.idx == kf_idx) else {
+            return 0;
+        };
+        if candidate_mp_indices.is_empty() || max_fused == 0 {
+            return 0;
+        }
+
+        let pose_world_to_cam = self.keyframes[kf_pos].frame.pose_world_to_cam;
+        let camera_center_world = pose_world_to_cam.inverse().translation;
+        let image_size = self.keyframes[kf_pos].frame.image_size;
+        let keypoints_undist: Vec<[f32; 2]> = self.keyframes[kf_pos]
+            .frame
+            .features
+            .keypoints_xy
+            .iter()
+            .map(|kp| {
+                let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                [p.x as f32, p.y as f32]
+            })
+            .collect();
+        let scales = self.keyframes[kf_pos].frame.features.scales.clone();
+        let descriptors = self.keyframes[kf_pos].frame.features.descriptors.clone();
+        let observation_counts = self.map_point_observation_counts();
+        // Precompute per-kp octave; used for predicted-level filter and chi-square sigma.
+        let kp_octaves: Vec<usize> = scales
+            .iter()
+            .map(|&s| Self::keypoint_octave(s))
+            .collect();
+        let max_level_scale =
+            ORB_SCALE_FACTOR_F32.powi(ORB_N_LEVELS_LOCAL.saturating_sub(1) as i32);
+        let max_query_radius = FUSE_TH * max_level_scale;
+        let mut keypoint_grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
+        for (kp_idx, kp) in keypoints_undist.iter().enumerate() {
+            let cell = (
+                (kp[0] / GRID_CELL_SIZE).floor() as i32,
+                (kp[1] / GRID_CELL_SIZE).floor() as i32,
+            );
+            keypoint_grid.entry(cell).or_default().push(kp_idx);
+        }
+
+        let mut fused = 0usize;
+        let mut touched_map_points = HashSet::new();
+        let mut seen_candidates = HashSet::new();
+        for candidate_mp_idx in candidate_mp_indices.iter().copied() {
+            if fused >= max_fused {
+                break;
+            }
+            if !seen_candidates.insert(candidate_mp_idx) {
+                continue;
+            }
+            let Some(candidate_mp) = self.map_points.get(candidate_mp_idx) else {
+                continue;
+            };
+            // ORB-SLAM3 `MapPoint::IsInKeyFrame(pKF)` reads `mObservations`
+            // directly. When `observed_keyframes_override` is set (parity
+            // replay), use it as the authoritative source — that's what C++
+            // does. Otherwise scan the forward `mvpMapPoints` slot-list.
+            let is_in_kf = match candidate_mp.observed_keyframes_override.as_ref() {
+                Some(set) => set.contains(&kf_idx),
+                None => self.keyframes[kf_pos]
+                    .map_point_by_desc_idx
+                    .iter()
+                    .any(|slot| *slot == Some(candidate_mp_idx)),
+            };
+            if candidate_mp.culled || is_in_kf {
+                continue;
+            }
+
+            // Positive depth + image bounds.
+            let p_cam = pose_world_to_cam.transform_point(&candidate_mp.position);
+            let Ok(pixel) = camera.project_to_image(&p_cam, 0.0, image_size) else {
+                continue;
+            };
+            let u = pixel.x as f32;
+            let v = pixel.y as f32;
+
+            // Distance invariance gate.
+            let po = candidate_mp.position - camera_center_world;
+            let dist3d = po.length();
+            if dist3d <= 0.0
+                || dist3d < candidate_mp.min_distance_invariance()
+                || dist3d > candidate_mp.max_distance_invariance()
+            {
+                continue;
+            }
+
+            // Viewing angle gate (cos >= 0.5 → angle <= 60 deg).
+            let normal = candidate_mp.viewing_normal();
+            if normal.dot(po) < 0.5 * dist3d {
+                continue;
+            }
+
+            // Predicted octave and per-level search radius.
+            let predicted_level =
+                candidate_mp.predict_scale(dist3d, ORB_SCALE_FACTOR, ORB_N_LEVELS);
+            let pred_level_scale = ORB_SCALE_FACTOR_F32.powi(predicted_level as i32);
+            let search_radius = FUSE_TH * pred_level_scale;
+            let min_level = predicted_level.saturating_sub(1);
+            let max_level = predicted_level;
+
+            let mut best_dist = u32::MAX;
+            let mut best_idx = None;
+            let min_cell_x = ((u - max_query_radius) / GRID_CELL_SIZE).floor() as i32;
+            let max_cell_x = ((u + max_query_radius) / GRID_CELL_SIZE).floor() as i32;
+            let min_cell_y = ((v - max_query_radius) / GRID_CELL_SIZE).floor() as i32;
+            let max_cell_y = ((v + max_query_radius) / GRID_CELL_SIZE).floor() as i32;
+            for cell_y in min_cell_y..=max_cell_y {
+                for cell_x in min_cell_x..=max_cell_x {
+                    let Some(indices) = keypoint_grid.get(&(cell_x, cell_y)) else {
+                        continue;
+                    };
+                    for &kp_idx in indices {
+                        let kp_level = kp_octaves[kp_idx];
+                        if kp_level < min_level || kp_level > max_level {
+                            continue;
+                        }
+                        let kp = &keypoints_undist[kp_idx];
+                        let dx = kp[0] - u;
+                        let dy = kp[1] - v;
+                        let e2 = dx * dx + dy * dy;
+                        if e2 > search_radius * search_radius {
+                            continue;
+                        }
+                        // Chi-square monocular gate: e^2 * invLevelSigma^2 <= 5.99,
+                        // i.e. e^2 <= 5.99 * levelSigma^2 = 5.99 * scaleFactor^(2L).
+                        let level_sigma2 = ORB_SCALE_FACTOR_F32.powi(2 * kp_level as i32);
+                        if e2 > CHI2_MONO * level_sigma2 {
+                            continue;
+                        }
+                        let Some(desc) = descriptors.get(kp_idx) else {
+                            continue;
+                        };
+                        let dist = hamming_distance(&candidate_mp.descriptor, desc);
+                        if dist < best_dist {
+                            best_dist = dist;
+                            best_idx = Some(kp_idx);
+                        }
+                    }
+                }
+            }
+
+            if best_dist > MAX_HAMMING {
+                continue;
+            }
+            let Some(best_idx) = best_idx else {
+                continue;
+            };
+
+            match self.keyframes[kf_pos].map_point(best_idx) {
+                None => {
+                    self.keyframes[kf_pos].associate_map_point(best_idx, candidate_mp_idx);
+                    touched_map_points.insert(candidate_mp_idx);
+                    fused += 1;
+                }
+                Some(existing_mp_idx) if existing_mp_idx == candidate_mp_idx => {}
+                Some(existing_mp_idx) => match mode {
+                    FuseMode::AddOnly => continue,
+                    FuseMode::ReplaceWeaker => {
+                        let existing_obs = observation_counts
+                            .get(&existing_mp_idx)
+                            .copied()
+                            .unwrap_or(0);
+                        let candidate_obs = observation_counts
+                            .get(&candidate_mp_idx)
+                            .copied()
+                            .unwrap_or(0);
+                        if existing_obs > candidate_obs {
+                            if self.replace_map_point_slots(candidate_mp_idx, existing_mp_idx) {
+                                touched_map_points.insert(existing_mp_idx);
+                                fused += 1;
+                            }
+                        } else if self.replace_map_point_slots(existing_mp_idx, candidate_mp_idx) {
+                            self.keyframes[kf_pos]
+                                .associate_map_point(best_idx, candidate_mp_idx);
+                            touched_map_points.insert(candidate_mp_idx);
+                            fused += 1;
+                        }
+                    }
+                },
+            }
+        }
+
+        if !touched_map_points.is_empty() {
+            self.rebuild_observation_index();
+            self.refresh_map_points_metadata(touched_map_points);
+        }
+
+        fused
     }
 
     /// Inserts triangulated 3D points as map points and associates them to keyframes.
@@ -198,8 +1005,50 @@ impl Map {
         keyframe_idx: usize,
     ) -> usize {
         let first_mp_idx = self.map_points.len();
+        let curr_center = curr_kf.frame.pose_world_to_cam.inverse().translation;
+        let curr_max_scale = curr_kf
+            .frame
+            .features
+            .scales
+            .iter()
+            .copied()
+            .fold(1.0_f32, f32::max) as f64;
+        let prev_center = prev_kf
+            .as_ref()
+            .map(|kf| kf.frame.pose_world_to_cam.inverse().translation);
         for (i, &(position, descriptor, color, _, curr_desc_idx)) in points.iter().enumerate() {
-            self.push_map_point(MapPoint::new(position, descriptor, color, keyframe_idx));
+            let mut map_point = MapPoint::new(position, descriptor, color, keyframe_idx);
+            let mut normal = position - curr_center;
+            let mut n_normals = 0.0;
+            if normal.length() > 0.0 {
+                normal = normal.normalize();
+                n_normals += 1.0;
+            }
+            if let Some(prev_center) = prev_center {
+                let prev_normal = position - prev_center;
+                if prev_normal.length() > 0.0 {
+                    normal += prev_normal.normalize();
+                    n_normals += 1.0;
+                }
+            }
+            let ref_dist = (position - curr_center).length();
+            let level_scale = curr_kf
+                .frame
+                .features
+                .scales
+                .get(curr_desc_idx)
+                .copied()
+                .unwrap_or(1.0) as f64;
+            let max_distance = ref_dist * level_scale.max(1.0);
+            let min_distance = if curr_max_scale > 0.0 {
+                max_distance / curr_max_scale
+            } else {
+                max_distance
+            };
+            if n_normals > 0.0 {
+                map_point.set_view_geometry(normal / n_normals, min_distance, max_distance);
+            }
+            self.push_map_point(map_point);
             curr_kf.associate_map_point(curr_desc_idx, first_mp_idx + i);
         }
         if let Some(prev) = prev_kf {
@@ -214,6 +1063,7 @@ impl Map {
     pub fn push_map_point(&mut self, map_point: MapPoint) -> usize {
         let idx = self.map_points.len();
         self.map_points.push(map_point);
+        self.observations_by_map_point.push(Vec::new());
         idx
     }
 
@@ -271,33 +1121,16 @@ impl Map {
         tracked_matches: &[(usize, usize)],
         current_keyframe: Option<&Keyframe>,
     ) -> (Vec<MapPoint>, Vec<usize>) {
-        const MAX_VOTED_KEYFRAMES: usize = 10;
-        const MAX_RECENT_KEYFRAMES: usize = 10;
+        const MAX_LOCAL_KEYFRAMES: usize = 80;
 
-        let mut keyframe_votes: HashMap<usize, usize> = HashMap::new();
-        for &(mp_idx, _) in tracked_matches {
-            if let Some(mp) = self.map_points.get(mp_idx) {
-                *keyframe_votes.entry(mp.keyframe_idx).or_insert(0) += 1;
-            }
-        }
-
-        let mut voted_kfs: Vec<(usize, usize)> = keyframe_votes.into_iter().collect();
-        voted_kfs.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| b.0.cmp(&a.0)));
-
-        let mut local_kf_indices: HashSet<usize> = HashSet::new();
-        if let Some(kf) = current_keyframe {
-            local_kf_indices.insert(kf.frame.idx);
-        }
-        for (kf_idx, _) in voted_kfs.into_iter().take(MAX_VOTED_KEYFRAMES) {
-            local_kf_indices.insert(kf_idx);
-        }
-        for kf in self.keyframes.iter().rev().take(MAX_RECENT_KEYFRAMES) {
-            local_kf_indices.insert(kf.frame.idx);
-        }
+        let local_kf_indices: HashSet<usize> = self
+            .local_keyframe_indices(tracked_matches, current_keyframe, MAX_LOCAL_KEYFRAMES)
+            .into_iter()
+            .collect();
 
         let mut mp_indices: HashSet<usize> = HashSet::new();
         for &(mp_idx, _) in tracked_matches {
-            if mp_idx < self.map_points.len() {
+            if self.map_points.get(mp_idx).is_some_and(|mp| !mp.culled) {
                 mp_indices.insert(mp_idx);
             }
         }
@@ -319,11 +1152,236 @@ impl Map {
             global_indices = (0..self.map_points.len()).collect();
         }
 
-        let local_map_points: Vec<MapPoint> = global_indices
+        let mut local_map_points = Vec::new();
+        let mut active_global_indices = Vec::new();
+        for idx in global_indices {
+            let Some(mp) = self.map_points.get(idx) else {
+                continue;
+            };
+            if mp.culled {
+                continue;
+            }
+            active_global_indices.push(idx);
+            local_map_points.push(mp.clone());
+        }
+        (local_map_points, active_global_indices)
+    }
+
+    /// Port of ORB-SLAM3 `LocalMapping::MapPointCulling` for the monocular case.
+    ///
+    /// Evaluates recently-added map points (≤3 KFs old) and culls those that fail
+    /// either the found-ratio test (found/visible < 0.25) or the observation test
+    /// (age ≥ 2 KFs and observed by ≤ 2 KFs). Points that survive until they are
+    /// more than 3 KFs old are "promoted" and no longer revisited here.
+    pub fn map_point_culling(&mut self) -> usize {
+        const MONO_MIN_OBS: usize = 2;
+        const FOUND_RATIO_MIN: f64 = 0.25;
+        const RECENT_WINDOW_KFS: usize = 3;
+
+        let n_kfs = self.keyframes.len();
+        if n_kfs == 0 {
+            return 0;
+        }
+        let current_kf_order = n_kfs - 1;
+
+        let kf_order: HashMap<usize, usize> = self
+            .keyframes
             .iter()
-            .filter_map(|&idx| self.map_points.get(idx).filter(|mp| !mp.culled).cloned())
+            .enumerate()
+            .map(|(i, kf)| (kf.frame.idx, i))
             .collect();
-        (local_map_points, global_indices)
+        let obs_count = self.map_point_observation_counts();
+
+        let mut n_culled = 0usize;
+        for (mp_idx, mp) in self.map_points.iter_mut().enumerate() {
+            if mp.culled {
+                continue;
+            }
+            let Some(&first_order) = kf_order.get(&mp.keyframe_idx) else {
+                continue;
+            };
+            let age = current_kf_order.saturating_sub(first_order);
+            if age > RECENT_WINDOW_KFS {
+                continue;
+            }
+
+            if mp.found_ratio() < FOUND_RATIO_MIN {
+                mp.mark_culled();
+                n_culled += 1;
+                continue;
+            }
+
+            let obs = obs_count.get(&mp_idx).copied().unwrap_or(0);
+            if age >= 2 && obs <= MONO_MIN_OBS {
+                mp.mark_culled();
+                n_culled += 1;
+            }
+        }
+
+        if n_culled > 0 {
+            let culled_set: HashSet<usize> = self
+                .map_points
+                .iter()
+                .enumerate()
+                .filter(|(_, mp)| mp.culled)
+                .map(|(i, _)| i)
+                .collect();
+            for kf in &mut self.keyframes {
+                for desc_idx in 0..kf.map_point_by_desc_idx.len() {
+                    if let Some(mp) = kf.map_point(desc_idx)
+                        && culled_set.contains(&mp)
+                    {
+                        kf.clear_map_point(desc_idx);
+                    }
+                }
+            }
+            self.rebuild_observation_index();
+        }
+
+        n_culled
+    }
+
+    /// Port of ORB-SLAM3 `LocalMapping::KeyFrameCulling` for the monocular case.
+    ///
+    /// Only covisible neighbors of the current (most recent) keyframe are
+    /// evaluated. A keyframe is redundant if >90% of its map points are also
+    /// observed by more than 3 other keyframes at the same or finer scale (+1
+    /// octave slack, matching the ORB-SLAM3 code path).
+    pub fn keyframe_culling(&mut self) -> usize {
+        const REDUNDANT_RATIO: f64 = 0.9;
+        const N_TH_OBS: usize = 3;
+        if self.keyframes.len() <= 1 {
+            return 0;
+        }
+
+        let current_kf_idx = self
+            .keyframes
+            .last()
+            .map(|kf| kf.frame.idx)
+            .expect("checked non-empty keyframes");
+        let origin = self.origin_kf_frame_idx;
+
+        let mut observations_by_mp: HashMap<usize, HashMap<usize, usize>> = HashMap::new();
+        for kf in &self.keyframes {
+            for (desc_idx, mp_idx) in kf.map_point_by_desc_idx.iter().enumerate() {
+                let Some(mp_idx) = *mp_idx else {
+                    continue;
+                };
+                let Some(mp) = self.map_points.get(mp_idx) else {
+                    continue;
+                };
+                if mp.culled {
+                    continue;
+                }
+                let octave = kf
+                    .frame
+                    .features
+                    .scales
+                    .get(desc_idx)
+                    .copied()
+                    .map(Self::keypoint_octave)
+                    .unwrap_or(0);
+                observations_by_mp
+                    .entry(mp_idx)
+                    .or_default()
+                    .entry(kf.frame.idx)
+                    .and_modify(|existing| *existing = (*existing).min(octave))
+                    .or_insert(octave);
+            }
+        }
+
+        let mut to_remove_frame_indices: Vec<usize> = Vec::new();
+        for (candidate_kf_idx, _) in self.covisibility_neighbors(current_kf_idx, self.keyframes.len()) {
+            let Some(kf) = self.get_keyframe(candidate_kf_idx) else {
+                continue;
+            };
+            if Some(kf.frame.idx) == origin {
+                continue;
+            }
+
+            let mut total = 0usize;
+            let mut redundant_observations = 0usize;
+            for (desc_idx, mp_idx) in kf.map_point_by_desc_idx.iter().enumerate() {
+                let Some(mp_idx) = *mp_idx else {
+                    continue;
+                };
+                let Some(mp) = self.map_points.get(mp_idx) else {
+                    continue;
+                };
+                if mp.culled {
+                    continue;
+                }
+                total += 1;
+                let Some(observers) = observations_by_mp.get(&mp_idx) else {
+                    continue;
+                };
+                if observers.len() <= N_TH_OBS {
+                    continue;
+                }
+
+                let scale_level = kf
+                    .frame
+                    .features
+                    .scales
+                    .get(desc_idx)
+                    .copied()
+                    .map(Self::keypoint_octave)
+                    .unwrap_or(0);
+                let mut supporting_obs = 0usize;
+                for (&observer_kf_idx, &observer_scale_level) in observers {
+                    if observer_kf_idx == kf.frame.idx {
+                        continue;
+                    }
+                    if observer_scale_level <= scale_level + 1 {
+                        supporting_obs += 1;
+                        if supporting_obs > N_TH_OBS {
+                            break;
+                        }
+                    }
+                }
+
+                if supporting_obs > N_TH_OBS {
+                    redundant_observations += 1;
+                }
+            }
+            if total > 0 && (redundant_observations as f64 / total as f64) > REDUNDANT_RATIO {
+                to_remove_frame_indices.push(candidate_kf_idx);
+            }
+        }
+
+        if to_remove_frame_indices.is_empty() {
+            return 0;
+        }
+
+        let remove_set: HashSet<_> = to_remove_frame_indices.iter().copied().collect();
+        let mut affected_points = HashSet::new();
+        for kf in &self.keyframes {
+            if remove_set.contains(&kf.frame.idx) {
+                for mp_idx in kf.map_point_by_desc_idx.iter().flatten() {
+                    affected_points.insert(*mp_idx);
+                }
+            }
+        }
+        self.keyframes
+            .retain(|kf| !remove_set.contains(&kf.frame.idx));
+        self.rebuild_observation_index();
+
+        let mut live_obs: HashSet<usize> = HashSet::new();
+        for kf in &self.keyframes {
+            for mp_idx in kf.map_point_by_desc_idx.iter().flatten() {
+                live_obs.insert(*mp_idx);
+            }
+        }
+
+        for (i, mp) in self.map_points.iter_mut().enumerate() {
+            if !mp.culled && !live_obs.contains(&i) {
+                mp.mark_culled();
+            }
+        }
+
+        self.refresh_map_points_metadata(affected_points);
+
+        to_remove_frame_indices.len()
     }
 
     /// Cull map points with poor observation ratios or that project behind cameras.
@@ -384,6 +1442,7 @@ impl Map {
                     }
                 }
             }
+            self.rebuild_observation_index();
         }
     }
 
@@ -393,6 +1452,10 @@ impl Map {
     /// via camera), calls `kornia_3d::ba::bundle_adjust`, and writes back optimized poses
     /// and point positions.
     pub fn run_local_ba(&mut self, camera: &PinholeCamera) {
+        // Optimize only the 3 most recent KF poses; every earlier KF is a fixed
+        // constraint. Observations come from ALL KFs touching the optimized
+        // map-point set, so old KFs anchor the geometry even though their poses
+        // don't move. Keeping the active window tiny is what makes this stable.
         const MAX_ACTIVE_KFS: usize = 3;
         const MIN_OBSERVATIONS: usize = 8;
 
@@ -419,7 +1482,6 @@ impl Map {
 
         let mut mp_global_indices: Vec<usize> = mp_set.iter().copied().collect();
         mp_global_indices.sort_unstable();
-
         let mp_global_to_local: HashMap<usize, usize> = mp_global_indices
             .iter()
             .enumerate()
@@ -485,16 +1547,41 @@ impl Map {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kornia_algebra::Mat3F64;
     use kornia_3d::pose::Pose3d;
     use kornia_image::ImageSize;
     use kornia_imgproc::features::OrbFeatures;
 
+    fn test_camera() -> PinholeCamera {
+        PinholeCamera {
+            fx: 200.0,
+            fy: 200.0,
+            cx: 320.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        }
+    }
+
     fn test_frame(idx: usize, descriptors: Vec<[u8; 32]>) -> Frame {
+        let n = descriptors.len();
+        let keypoints_xy = (0..n).map(|i| [i as f32, i as f32]).collect();
+        test_frame_with_keypoints(idx, descriptors, keypoints_xy)
+    }
+
+    fn test_frame_with_keypoints(
+        idx: usize,
+        descriptors: Vec<[u8; 32]>,
+        keypoints_xy: Vec<[f32; 2]>,
+    ) -> Frame {
         let n = descriptors.len();
         Frame {
             idx,
             features: OrbFeatures {
-                keypoints_xy: (0..n).map(|i| [i as f32, i as f32]).collect(),
+                keypoints_xy,
+                scales: vec![1.0; n],
                 orientations: vec![0.0; n],
                 descriptors,
             },
@@ -505,6 +1592,36 @@ mod tests {
             },
             keypoint_colors: vec![[0; 3]; n],
         }
+    }
+
+    fn test_frame_with_scales(idx: usize, descriptors: Vec<[u8; 32]>, scales: Vec<f32>) -> Frame {
+        let n = descriptors.len();
+        assert_eq!(scales.len(), n);
+        Frame {
+            idx,
+            features: OrbFeatures {
+                keypoints_xy: (0..n).map(|i| [i as f32, i as f32]).collect(),
+                scales,
+                orientations: vec![0.0; n],
+                descriptors,
+            },
+            pose_world_to_cam: Pose3d::IDENTITY,
+            image_size: ImageSize {
+                width: 640,
+                height: 480,
+            },
+            keypoint_colors: vec![[0; 3]; n],
+        }
+    }
+
+    fn test_frame_with_pose(
+        idx: usize,
+        descriptors: Vec<[u8; 32]>,
+        translation_world_to_cam: Vec3F64,
+    ) -> Frame {
+        let mut frame = test_frame(idx, descriptors);
+        frame.pose_world_to_cam = Pose3d::new(Mat3F64::IDENTITY, translation_world_to_cam);
+        frame
     }
 
     #[test]
@@ -604,6 +1721,222 @@ mod tests {
     }
 
     #[test]
+    fn covisibility_neighbors_are_sorted_by_shared_observations() {
+        let mut map = Map::new();
+        let mp0 = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [0u8; 32],
+            [0; 3],
+            0,
+        ));
+        let mp1 = map.push_map_point(MapPoint::new(
+            Vec3F64::new(1.0, 0.0, 5.0),
+            [1u8; 32],
+            [0; 3],
+            0,
+        ));
+
+        let mut kf0 = Keyframe::from_frame(test_frame(0, vec![[0u8; 32], [1u8; 32]]));
+        kf0.associate_map_point(0, mp0);
+        kf0.associate_map_point(1, mp1);
+        let mut kf1 = Keyframe::from_frame(test_frame(1, vec![[0u8; 32], [1u8; 32]]));
+        kf1.associate_map_point(0, mp0);
+        kf1.associate_map_point(1, mp1);
+        let mut kf2 = Keyframe::from_frame(test_frame(2, vec![[1u8; 32]]));
+        kf2.associate_map_point(0, mp1);
+
+        map.upsert_keyframe(kf0);
+        map.upsert_keyframe(kf1);
+        map.upsert_keyframe(kf2);
+
+        assert_eq!(map.covisibility_neighbors(0, 10), vec![(1, 2), (2, 1)]);
+    }
+
+    #[test]
+    fn local_map_points_include_covisible_neighbor_points() {
+        let mut map = Map::new();
+        let mp0 = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [0u8; 32],
+            [0; 3],
+            0,
+        ));
+        let mp1 = map.push_map_point(MapPoint::new(
+            Vec3F64::new(1.0, 0.0, 5.0),
+            [1u8; 32],
+            [0; 3],
+            1,
+        ));
+
+        let mut current = Keyframe::from_frame(test_frame(0, vec![[0u8; 32]]));
+        current.associate_map_point(0, mp0);
+        let mut neighbor = Keyframe::from_frame(test_frame(1, vec![[0u8; 32], [1u8; 32]]));
+        neighbor.associate_map_point(0, mp0);
+        neighbor.associate_map_point(1, mp1);
+
+        map.upsert_keyframe(current.clone());
+        map.upsert_keyframe(neighbor);
+
+        let (_, indices) = map.build_local_map_points(&[(mp0, 0)], Some(&current));
+
+        assert_eq!(indices, vec![mp0, mp1]);
+    }
+
+    #[test]
+    fn local_map_points_keep_global_indices_aligned_after_culling() {
+        let mut map = Map::new();
+        for i in 0..4 {
+            map.push_map_point(MapPoint::new(
+                Vec3F64::new(i as f64, 0.0, 5.0),
+                [i as u8; 32],
+                [0; 3],
+                0,
+            ));
+        }
+        map.map_points_mut()[0].mark_culled();
+        map.map_points_mut()[2].mark_culled();
+
+        let (points, indices) = map.build_local_map_points(&[], None);
+
+        assert_eq!(points.len(), 2);
+        assert_eq!(indices, vec![1, 3]);
+        assert_eq!(points[0].descriptor, [1u8; 32]);
+        assert_eq!(points[1].descriptor, [3u8; 32]);
+    }
+
+    #[test]
+    fn observation_index_tracks_stored_keyframe_associations() {
+        let mut map = Map::new();
+        let mp = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [1u8; 32],
+            [0; 3],
+            0,
+        ));
+
+        let mut kf0 = Keyframe::from_frame(test_frame(0, vec![[1u8; 32]]));
+        kf0.associate_map_point(0, mp);
+        map.upsert_keyframe(kf0);
+        map.upsert_keyframe(Keyframe::from_frame(test_frame(1, vec![[2u8; 32]])));
+
+        assert_eq!(map.map_point_observation_count(mp), 1);
+        assert_eq!(map.map_point_observations(mp), &[(0, 0)]);
+
+        assert!(map.associate_keyframe_map_point(1, 0, mp));
+        assert_eq!(map.map_point_observation_count(mp), 2);
+        assert_eq!(map.map_point_observations(mp), &[(0, 0), (1, 0)]);
+    }
+
+    #[test]
+    fn descriptor_refresh_picks_median_observer_descriptor() {
+        let mut map = Map::new();
+        let mp = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [0x00; 32],
+            [0; 3],
+            0,
+        ));
+
+        let descriptor_a = [0x00; 32];
+        let descriptor_b = [0x0F; 32];
+        let descriptor_c = [0xFF; 32];
+
+        let mut kf0 = Keyframe::from_frame(test_frame_with_pose(
+            0,
+            vec![descriptor_a],
+            Vec3F64::ZERO,
+        ));
+        kf0.associate_map_point(0, mp);
+        map.upsert_keyframe(kf0);
+
+        let mut kf1 = Keyframe::from_frame(test_frame_with_pose(
+            1,
+            vec![descriptor_b],
+            Vec3F64::new(-1.0, 0.0, 0.0),
+        ));
+        kf1.associate_map_point(0, mp);
+        map.upsert_keyframe(kf1);
+
+        // Two observers tie on median distance, so the original descriptor stays.
+        assert_eq!(map.map_points()[mp].descriptor, descriptor_a);
+
+        map.upsert_keyframe(Keyframe::from_frame(test_frame_with_pose(
+            2,
+            vec![descriptor_c],
+            Vec3F64::new(1.0, 0.0, 0.0),
+        )));
+        assert!(map.associate_keyframe_map_point(2, 0, mp));
+
+        assert_eq!(map.map_points()[mp].descriptor, descriptor_b);
+        assert_eq!(map.map_point_observation_count(mp), 3);
+        assert!(map.map_points()[mp].viewing_normal().z > 0.0);
+        assert!(map.map_points()[mp].max_distance > map.map_points()[mp].min_distance);
+    }
+
+    #[test]
+    fn fuse_projected_map_points_adds_new_observation() {
+        let mut map = Map::new();
+        let mp = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [7u8; 32],
+            [0; 3],
+            0,
+        ));
+        let kf = Keyframe::from_frame(test_frame_with_keypoints(
+            0,
+            vec![[7u8; 32]],
+            vec![[320.0, 240.0]],
+        ));
+        map.upsert_keyframe(kf);
+
+        let fused = map.fuse_projected_map_points_into_keyframe(0, &[mp], &test_camera());
+
+        assert_eq!(fused, 1);
+        assert_eq!(map.get_keyframe(0).and_then(|kf| kf.map_point(0)), Some(mp));
+    }
+
+    #[test]
+    fn fuse_projected_map_points_replaces_weaker_duplicate() {
+        let mut map = Map::new();
+        let survivor = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [9u8; 32],
+            [0; 3],
+            0,
+        ));
+        let duplicate = map.push_map_point(MapPoint::new(
+            Vec3F64::new(0.0, 0.0, 5.0),
+            [9u8; 32],
+            [0; 3],
+            2,
+        ));
+
+        let mut kf0 = Keyframe::from_frame(test_frame(0, vec![[9u8; 32]]));
+        kf0.associate_map_point(0, survivor);
+        let mut kf1 = Keyframe::from_frame(test_frame(1, vec![[9u8; 32]]));
+        kf1.associate_map_point(0, survivor);
+        let mut target = Keyframe::from_frame(test_frame_with_keypoints(
+            2,
+            vec![[9u8; 32]],
+            vec![[320.0, 240.0]],
+        ));
+        target.associate_map_point(0, duplicate);
+
+        map.upsert_keyframe(kf0);
+        map.upsert_keyframe(kf1);
+        map.upsert_keyframe(target);
+
+        let fused = map.fuse_projected_map_points_into_keyframe(2, &[survivor], &test_camera());
+
+        assert_eq!(fused, 1);
+        assert!(map.map_points()[duplicate].culled);
+        assert_eq!(
+            map.get_keyframe(2).and_then(|kf| kf.map_point(0)),
+            Some(survivor)
+        );
+    }
+
+    #[test]
     fn cull_map_points_removes_low_ratio() {
         let mut map = Map::new();
 
@@ -628,5 +1961,126 @@ mod tests {
 
         assert!(map.map_points()[first_idx].culled);
         assert!(!map.map_points()[second_idx].culled);
+    }
+
+    #[test]
+    fn keyframe_culling_only_evaluates_local_covisibility_neighbors() {
+        let mut map = Map::new();
+        let mut shared_mp_indices = Vec::new();
+        for i in 0..20 {
+            shared_mp_indices.push(map.push_map_point(MapPoint::new(
+                Vec3F64::new(i as f64 * 0.01, 0.0, 5.0),
+                [i as u8; 32],
+                [0; 3],
+                0,
+            )));
+        }
+
+        let mut remote_mp_indices = Vec::new();
+        for i in 20..40 {
+            remote_mp_indices.push(map.push_map_point(MapPoint::new(
+                Vec3F64::new(i as f64 * 0.01, 0.0, 5.0),
+                [i as u8; 32],
+                [0; 3],
+                10,
+            )));
+        }
+
+        for kf_idx in 0..1 {
+            let descriptors: Vec<[u8; 32]> = (0..20).map(|i| [i as u8; 32]).collect();
+            let mut keyframe = Keyframe::from_frame(test_frame(kf_idx, descriptors));
+            for (desc_idx, &mp_idx) in shared_mp_indices.iter().enumerate() {
+                keyframe.associate_map_point(desc_idx, mp_idx);
+            }
+            map.upsert_keyframe(keyframe);
+        }
+
+        // Keyframe 10 is redundant within its own disconnected component, but it
+        // is not covisible with the current keyframe (4), so ORB-SLAM3-style
+        // local culling should not touch it.
+        for kf_idx in 10..14 {
+            let descriptors: Vec<[u8; 32]> = (20..40).map(|i| [i as u8; 32]).collect();
+            let mut keyframe = Keyframe::from_frame(test_frame(kf_idx, descriptors));
+            for (desc_idx, &mp_idx) in remote_mp_indices.iter().enumerate() {
+                keyframe.associate_map_point(desc_idx, mp_idx);
+            }
+            map.upsert_keyframe(keyframe);
+        }
+
+        for kf_idx in 1..5 {
+            let descriptors: Vec<[u8; 32]> = (0..20).map(|i| [i as u8; 32]).collect();
+            let mut keyframe = Keyframe::from_frame(test_frame(kf_idx, descriptors));
+            for (desc_idx, &mp_idx) in shared_mp_indices.iter().enumerate() {
+                keyframe.associate_map_point(desc_idx, mp_idx);
+            }
+            map.upsert_keyframe(keyframe);
+        }
+
+        let removed = map.keyframe_culling();
+
+        assert_eq!(removed, 3);
+        assert!(map.get_keyframe(1).is_none());
+        assert!(map.get_keyframe(2).is_none());
+        assert!(map.get_keyframe(3).is_none());
+        assert!(map.get_keyframe(0).is_some());
+        assert!(map.get_keyframe(10).is_some());
+        assert!(map.get_keyframe(11).is_some());
+        assert!(map.get_keyframe(12).is_some());
+        assert!(map.get_keyframe(13).is_some());
+        assert_eq!(map.keyframes().len(), 6);
+    }
+
+    #[test]
+    fn keyframe_culling_requires_same_or_finer_scale_support() {
+        let mut map = Map::new();
+        let mut mp_indices = Vec::new();
+        for i in 0..20 {
+            mp_indices.push(map.push_map_point(MapPoint::new(
+                Vec3F64::new(i as f64 * 0.01, 0.0, 5.0),
+                [i as u8; 32],
+                [0; 3],
+                0,
+            )));
+        }
+
+        let base_descriptors: Vec<[u8; 32]> = (0..20).map(|i| [i as u8; 32]).collect();
+        let mut origin = Keyframe::from_frame(test_frame_with_scales(
+            0,
+            base_descriptors.clone(),
+            vec![1.0; 20],
+        ));
+        for (desc_idx, &mp_idx) in mp_indices.iter().enumerate() {
+            origin.associate_map_point(desc_idx, mp_idx);
+        }
+        map.upsert_keyframe(origin);
+
+        let mut candidate = Keyframe::from_frame(test_frame_with_scales(
+            1,
+            base_descriptors.clone(),
+            vec![1.0; 20],
+        ));
+        for (desc_idx, &mp_idx) in mp_indices.iter().enumerate() {
+            candidate.associate_map_point(desc_idx, mp_idx);
+        }
+        map.upsert_keyframe(candidate);
+
+        for kf_idx in 2..5 {
+            let mut supporting = Keyframe::from_frame(test_frame_with_scales(
+                kf_idx,
+                base_descriptors.clone(),
+                vec![1.2_f32.powi(4); 20],
+            ));
+            for (desc_idx, &mp_idx) in mp_indices.iter().enumerate() {
+                supporting.associate_map_point(desc_idx, mp_idx);
+            }
+            map.upsert_keyframe(supporting);
+        }
+
+        let removed = map.keyframe_culling();
+
+        assert_eq!(removed, 2);
+        assert!(map.get_keyframe(1).is_some());
+        assert!(map.get_keyframe(2).is_none());
+        assert!(map.get_keyframe(3).is_none());
     }
 }

--- a/crates/kornia-slam/src/system.rs
+++ b/crates/kornia-slam/src/system.rs
@@ -17,16 +17,26 @@ pub struct KeyframePolicy {
 
 impl Default for KeyframePolicy {
     fn default() -> Self {
+        // ORB-SLAM3 mono uses min=0 with async local mapping + idle check; since
+        // our pipeline is synchronous we keep a small debounce.
         Self {
             min_frames_between: 3,
-            max_frames_between: 8,
-            ref_ratio: 0.6,
+            max_frames_between: 10,
+            ref_ratio: 0.75,
         }
     }
 }
 
 impl KeyframePolicy {
     /// Decide whether a new keyframe should be inserted.
+    ///
+    /// Approximation of ORB-SLAM3's `Tracking::NeedNewKeyFrame` for the
+    /// monocular case. ORB-SLAM3 gates `c1a` by `c2`, but that assumes local
+    /// mapping has already promoted enough 2-observation points into
+    /// `TrackedMapPoints(nMinObs=3)`. Until our local mapping has full parity,
+    /// forcing `c1a` prevents reference-keyframe starvation.
+    ///
+    /// `n_ref_map_points` is `TrackedMapPoints(nMinObs=3)` of the reference KF.
     pub fn should_insert(
         &self,
         curr_idx: usize,
@@ -38,20 +48,25 @@ impl KeyframePolicy {
             return true;
         };
 
-        let frames_since_last_kf = curr_idx.saturating_sub(last_kf_idx);
-        if frames_since_last_kf < self.min_frames_between {
+        let gap = curr_idx.saturating_sub(last_kf_idx);
+        if gap < self.min_frames_between {
             return false;
         }
-        if frames_since_last_kf >= self.max_frames_between {
+        if gap >= self.max_frames_between {
             return true;
         }
 
+        if tracked_inliers <= 15 {
+            return false;
+        }
+
+        // c2: ref_ratio acts as a lower bound on the allowed tracked fraction.
         if n_ref_map_points == 0 {
             return true;
         }
 
         let weak_threshold = (n_ref_map_points as f64 * self.ref_ratio) as usize;
-        tracked_inliers >= 15 && tracked_inliers < weak_threshold
+        tracked_inliers < weak_threshold
     }
 }
 

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -10,6 +10,7 @@ argh = "0.1"
 kornia-slam = { path = "../../crates/kornia-slam" }
 kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
+kornia-bow = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-io = { git = "https://github.com/kornia/kornia-rs", branch = "main" }

--- a/examples/orb_slam/src/config.rs
+++ b/examples/orb_slam/src/config.rs
@@ -8,11 +8,26 @@ pub struct PipelineConfig {
     pub map_projection: MapProjectionConfig,
     pub keyframe_policy: KeyframePolicy,
     pub enable_local_ba: bool,
+    pub enable_neighbor_fusion: bool,
+    pub mapping_cooldown_frames: usize,
+    pub tracking_orb_keypoints: usize,
+    pub initial_orb_keypoint_multiplier: usize,
+    pub initial_orb_window_frames: usize,
+}
+
+impl PipelineConfig {
+    pub fn initial_orb_keypoints(&self) -> usize {
+        self.tracking_orb_keypoints * self.initial_orb_keypoint_multiplier
+    }
 }
 
 impl Default for PipelineConfig {
     fn default() -> Self {
         let mut two_view_init = TwoViewInitConfig::default();
+        two_view_init
+            .estimation_config
+            .triangulation
+            .min_parallax_deg = (0.99998_f64).acos().to_degrees();
         two_view_init
             .estimation_config
             .triangulation
@@ -27,6 +42,11 @@ impl Default for PipelineConfig {
             map_projection: MapProjectionConfig::default(),
             keyframe_policy: KeyframePolicy::default(),
             enable_local_ba: true,
+            enable_neighbor_fusion: true,
+            mapping_cooldown_frames: 0,
+            tracking_orb_keypoints: 1000,
+            initial_orb_keypoint_multiplier: 5,
+            initial_orb_window_frames: 20,
         }
     }
 }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -11,14 +11,17 @@ mod config;
 #[path = "../../common/datasets/mod.rs"]
 mod datasets;
 mod pipeline;
+mod trace;
 mod utils;
 
 use config::PipelineConfig;
 use kornia_3d::pose::Pose3d;
+use kornia_imgproc::features::OrbDetector;
 use kornia_io::png::read_image_png_mono8;
 use kornia_slam::Frame;
 
 use pipeline::Pipeline;
+use trace::TraceWriter;
 
 use datasets::EurocDataset;
 
@@ -46,6 +49,26 @@ struct Args {
     /// skip this many initial frames
     #[argh(option, default = "0")]
     start_frame: usize,
+
+    /// output prefix for CSV trace files
+    #[argh(option)]
+    trace_prefix: Option<String>,
+
+    /// optional path to an ORB-SLAM3 ORBvoc.txt vocabulary file
+    #[argh(option)]
+    vocabulary: Option<String>,
+
+    /// disable SearchInNeighbors-style map-point fusion (add-only mode, on by default)
+    #[argh(switch)]
+    no_neighbor_fusion: bool,
+
+    /// frames after a keyframe insert where local mapping is treated as busy
+    #[argh(option, default = "0")]
+    mapping_cooldown: usize,
+
+    /// optional path to write a TUM-format trajectory (timestamp tx ty tz qx qy qz qw)
+    #[argh(option)]
+    trajectory: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -70,14 +93,48 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Camera (from EuRoC cam0 sensor.yaml) ───────────────────────────────
     let camera = dataset.camera();
 
-    // ── ORB detector (used externally before feeding Pipeline) ─────────────
-    let detector = kornia_imgproc::features::OrbDetector {
-        n_keypoints: 1000,
+    let mut pipeline_config = PipelineConfig::default();
+    pipeline_config.enable_neighbor_fusion = !args.no_neighbor_fusion;
+    pipeline_config.mapping_cooldown_frames = args.mapping_cooldown;
+
+    // ── ORB detectors (used externally before feeding Pipeline) ────────────
+    let tracking_detector = OrbDetector {
+        n_keypoints: pipeline_config.tracking_orb_keypoints,
+        ..Default::default()
+    };
+    let initial_detector = OrbDetector {
+        n_keypoints: pipeline_config.initial_orb_keypoints(),
         ..Default::default()
     };
 
     // ── SLAM config & system ───────────────────────────────────────────────
-    let mut system = Pipeline::new(camera.clone(), PipelineConfig::default());
+    let mut system = Pipeline::new(camera.clone(), pipeline_config);
+    if let Some(voc_path) = args.vocabulary.as_ref() {
+        eprintln!("Loading ORB-SLAM3 vocabulary from {}", voc_path);
+        let t0 = std::time::Instant::now();
+        let vocab = kornia_bow::orb_slam3::load_orb_slam3_vocabulary(voc_path)?;
+        eprintln!(
+            "Vocabulary loaded: {} blocks in {:.2}s",
+            vocab.blocks.len(),
+            t0.elapsed().as_secs_f32()
+        );
+        system = system.with_vocabulary(std::sync::Arc::new(vocab), 2);
+    }
+    let mut trace_writer = args
+        .trace_prefix
+        .as_ref()
+        .map(TraceWriter::new)
+        .transpose()?;
+
+    let mut trajectory_writer = args
+        .trajectory
+        .as_ref()
+        .map(
+            |p| -> Result<std::io::BufWriter<std::fs::File>, std::io::Error> {
+                Ok(std::io::BufWriter::new(std::fs::File::create(p)?))
+            },
+        )
+        .transpose()?;
 
     // ── Rerun ──────────────────────────────────────────────────────────────
     let rec = if args.rerun_stream {
@@ -118,6 +175,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         // Extract ORB features.
+        let detector = if system.use_initial_orb_extractor(idx) {
+            &initial_detector
+        } else {
+            &tracking_detector
+        };
         let features = detector.detect_and_extract(&gray_f32)?;
         if let Some(ref rec) = rec {
             log_frame_to_rerun(rec, &gray_u8, &features.keypoints_xy);
@@ -143,16 +205,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             image_size,
             keypoint_colors,
         };
+        let feature_count = frame.features.descriptors.len();
+        let timestamp_ns = (sample.timestamp_sec * 1e9).round() as i64;
         let t0 = std::time::Instant::now();
-        let result = system.process_frame(frame);
+        let (result, trace) = system.process_frame_with_trace(frame);
         let frame_ms = t0.elapsed().as_secs_f64() * 1000.0;
         let keyframe_idx = system.current_keyframe_idx().unwrap_or(idx);
         let map_point_count = system.num_map_points();
+        let active_map_point_count = system.num_active_map_points();
 
-        // Status line.
+        // Status line. pts=<active>/<total>.
         let status_line = format!(
-            "[{idx:>5}] {:?}  kf={:<4} pts={:<5} {frame_ms:>6.1}ms",
-            result.status, keyframe_idx, map_point_count,
+            "[{idx:>5}] {:?}  kf={:<4} pts={}/{} {frame_ms:>6.1}ms",
+            result.status, keyframe_idx, active_map_point_count, map_point_count,
         );
         eprintln!("{status_line}");
 
@@ -165,9 +230,81 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log_camera_to_rerun(rec, &result.pose_world_to_cam, &camera, image_size);
             log_map_points_to_rerun(rec, system.map_points());
         }
+
+        if let Some(writer) = trajectory_writer.as_mut() {
+            use std::io::Write;
+            // camera-to-world pose (standard TUM convention)
+            let twc = result.pose_world_to_cam.inverse();
+            let t = twc.translation;
+            let q = rotmat_to_quat_xyzw(&twc.rotation);
+            writeln!(
+                writer,
+                "{:.9} {} {} {} {} {} {} {}",
+                sample.timestamp_sec, t.x, t.y, t.z, q[0], q[1], q[2], q[3]
+            )?;
+        }
+
+        if let Some(writer) = trace_writer.as_mut() {
+            writer.write_frame(
+                idx,
+                timestamp_ns,
+                feature_count,
+                map_point_count,
+                active_map_point_count,
+                system.num_keyframes(),
+                result.status,
+                frame_ms,
+                &trace,
+            )?;
+        }
     }
 
-    let final_line = format!("Done. Final map: {} points", system.map_points().len());
+    let final_line = format!(
+        "Done. Final map: {} active / {} total points, {} keyframes",
+        system.num_active_map_points(),
+        system.map_points().len(),
+        system.num_keyframes(),
+    );
     eprintln!("{final_line}");
     Ok(())
+}
+
+fn rotmat_to_quat_xyzw(r: &kornia_algebra::Mat3F64) -> [f64; 4] {
+    // glam DMat3 stores columns; reshape to row-major for the trace formula.
+    let c = r.to_cols_array();
+    let m = [[c[0], c[3], c[6]], [c[1], c[4], c[7]], [c[2], c[5], c[8]]];
+    let trace: f64 = m[0][0] + m[1][1] + m[2][2];
+    if trace > 0.0 {
+        let s: f64 = (trace + 1.0).sqrt() * 2.0;
+        [
+            (m[2][1] - m[1][2]) / s,
+            (m[0][2] - m[2][0]) / s,
+            (m[1][0] - m[0][1]) / s,
+            0.25 * s,
+        ]
+    } else if m[0][0] > m[1][1] && m[0][0] > m[2][2] {
+        let s: f64 = (1.0 + m[0][0] - m[1][1] - m[2][2]).sqrt() * 2.0;
+        [
+            0.25 * s,
+            (m[0][1] + m[1][0]) / s,
+            (m[0][2] + m[2][0]) / s,
+            (m[2][1] - m[1][2]) / s,
+        ]
+    } else if m[1][1] > m[2][2] {
+        let s: f64 = (1.0 + m[1][1] - m[0][0] - m[2][2]).sqrt() * 2.0;
+        [
+            (m[0][1] + m[1][0]) / s,
+            0.25 * s,
+            (m[1][2] + m[2][1]) / s,
+            (m[0][2] - m[2][0]) / s,
+        ]
+    } else {
+        let s: f64 = (1.0 + m[2][2] - m[0][0] - m[1][1]).sqrt() * 2.0;
+        [
+            (m[0][2] + m[2][0]) / s,
+            (m[1][2] + m[2][1]) / s,
+            0.25 * s,
+            (m[1][0] - m[0][1]) / s,
+        ]
+    }
 }

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -4,17 +4,26 @@
 //! to bottom in the same order frames move through the system.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use crate::config::PipelineConfig;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_3d::pose::{TwoViewConfig, TwoViewModel, triangulate_matched_points, two_view_estimate};
 use kornia_algebra::Vec3F64;
+use kornia_bow::Vocabulary;
+use kornia_bow::metric::Hamming;
 use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
 use kornia_slam::Frame;
 use kornia_slam::estimation::MapProjectionEstimator;
-use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
-use kornia_slam::map::{Keyframe, Map, MapPoint};
+use kornia_slam::estimation::map_projection::MapProjectionReport;
+use kornia_slam::estimation::triangulation_search::{
+    TriangulationSearchConfig, search_for_triangulation,
+};
+use kornia_slam::estimation::two_view::{
+    TwoViewInitConfig, TwoViewInitReport, try_initialize_two_view_with_report,
+};
+use kornia_slam::map::{FuseMode, Keyframe, Map, MapPoint};
 use kornia_slam::system::{
     KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus,
 };
@@ -31,10 +40,56 @@ pub struct Pipeline {
     keyframe_policy: KeyframePolicy,
     // Enable local bundle adjustment after keyframe insertion
     enable_local_ba: bool,
+    // Experimental SearchInNeighbors-style fusion. Kept disabled by default
+    // until its association heuristics are stable over longer runs.
+    enable_neighbor_fusion: bool,
+    // Synchronous approximation of ORB-SLAM3's LocalMapping busy/idle gate.
+    mapping_cooldown_frames: usize,
+    mapping_busy_until_frame: Option<usize>,
+    // Keep using the high-capacity initial ORB detector until this frame index.
+    initial_orb_until_frame: Option<usize>,
+    // ORB-SLAM3 keeps the initial detector active for a short window after map init.
+    initial_orb_window_frames: usize,
     // Map object
     map: Map,
     // System state
     state: SystemState,
+    // ORB-SLAM3 vocabulary for BoW-accelerated matching (optional).
+    vocabulary: Option<Arc<Vocabulary<10, Hamming<4>>>>,
+    // Tree level at which direct-index groups are collected (ORB-SLAM3 uses 2).
+    direct_index_level: usize,
+}
+
+/// Non-behavioral trace data produced while processing one frame.
+#[derive(Debug, Clone)]
+pub struct PipelineTrace {
+    pub mode_before: SystemMode,
+    pub mode_after: SystemMode,
+    pub tracked_inliers: usize,
+    pub init: Option<PipelineInitTrace>,
+    pub tracking: Option<MapProjectionReport>,
+}
+
+impl PipelineTrace {
+    fn new(mode: SystemMode) -> Self {
+        Self {
+            mode_before: mode,
+            mode_after: mode,
+            tracked_inliers: 0,
+            init: None,
+            tracking: None,
+        }
+    }
+}
+
+/// Trace data for a bootstrap two-view attempt.
+#[derive(Debug, Clone)]
+pub struct PipelineInitTrace {
+    pub frame_idx_ref: usize,
+    pub frame_idx_cur: usize,
+    pub feature_count_ref: usize,
+    pub feature_count_cur: usize,
+    pub report: TwoViewInitReport,
 }
 
 impl Pipeline {
@@ -46,17 +101,74 @@ impl Pipeline {
             two_view_init_config: config.two_view_init,
             keyframe_policy: config.keyframe_policy,
             enable_local_ba: config.enable_local_ba,
+            enable_neighbor_fusion: config.enable_neighbor_fusion,
+            mapping_cooldown_frames: config.mapping_cooldown_frames,
+            mapping_busy_until_frame: None,
+            initial_orb_until_frame: None,
+            initial_orb_window_frames: config.initial_orb_window_frames,
             map: Map::new(),
             state: SystemState::new(),
+            vocabulary: None,
+            direct_index_level: 2,
+        }
+    }
+
+    /// Attaches an ORB-SLAM3 vocabulary so BoW/DirectIndex are computed for new keyframes.
+    pub fn with_vocabulary(
+        mut self,
+        vocabulary: Arc<Vocabulary<10, Hamming<4>>>,
+        direct_index_level: usize,
+    ) -> Self {
+        self.vocabulary = Some(vocabulary);
+        self.direct_index_level = direct_index_level;
+        self
+    }
+
+    fn attach_bow(&self, kf: &mut Keyframe) {
+        if let Some(vocab) = self.vocabulary.as_ref() {
+            if let Err(e) = kf.compute_bow(vocab, self.direct_index_level) {
+                eprintln!(
+                    "[pipeline] warn: compute_bow failed for kf idx {}: {:?}",
+                    kf.frame.idx, e
+                );
+            }
         }
     }
 
     /// Processes one frame (pre-extracted features) and returns the tracking result.
+    #[allow(dead_code)]
     pub fn process_frame(&mut self, frame: Frame) -> TrackingResult {
+        self.process_frame_with_trace(frame).0
+    }
+
+    /// Processes one frame and returns trace counters alongside the tracking result.
+    pub fn process_frame_with_trace(&mut self, frame: Frame) -> (TrackingResult, PipelineTrace) {
+        let mode_before = self.state.mode;
+        let (result, mut trace) = match self.state.mode {
+            SystemMode::Bootstrap => self.bootstrap_step(frame),
+            SystemMode::Tracking => self.tracking_step(frame),
+        };
+        trace.mode_before = mode_before;
+        trace.mode_after = self.state.mode;
+        (result, trace)
+    }
+
+    /// Processes one frame (pre-extracted features) and returns the tracking result.
+    #[allow(dead_code)]
+    pub fn process_frame_without_trace(&mut self, frame: Frame) -> TrackingResult {
         match self.state.mode {
             SystemMode::Bootstrap => self.bootstrap_step(frame),
             SystemMode::Tracking => self.tracking_step(frame),
         }
+        .0
+    }
+
+    /// Returns true when the caller should use the high-capacity initial ORB detector.
+    pub fn use_initial_orb_extractor(&self, next_frame_idx: usize) -> bool {
+        self.state.mode == SystemMode::Bootstrap
+            || self
+                .initial_orb_until_frame
+                .is_some_and(|until| next_frame_idx < until)
     }
 
     /// Returns all persistent map points.
@@ -76,34 +188,58 @@ impl Pipeline {
         self.map.map_points().len()
     }
 
-    fn bootstrap_step(&mut self, mut curr_frame: Frame) -> TrackingResult {
+    /// Returns the number of active, non-culled persistent map points.
+    pub fn num_active_map_points(&self) -> usize {
+        self.map.num_active_map_points()
+    }
+
+    /// Returns the total number of keyframes.
+    pub fn num_keyframes(&self) -> usize {
+        self.map.keyframes().len()
+    }
+
+    fn bootstrap_step(&mut self, mut curr_frame: Frame) -> (TrackingResult, PipelineTrace) {
+        let mut trace = PipelineTrace::new(SystemMode::Bootstrap);
         // Stamp frames with current odometry pose so bootstrap builds
         // the new map in the existing coordinate frame.
         curr_frame.pose_world_to_cam = self.state.pose_world_to_cam;
 
         let Some(prev_bootstrap_frame) = self.state.bootstrap_frame.take() else {
             self.state.bootstrap_frame = Some(curr_frame);
-            return TrackingResult {
-                pose_world_to_cam: self.state.pose_world_to_cam,
-                status: TrackingStatus::Skipped,
-            };
+            return (
+                TrackingResult {
+                    pose_world_to_cam: self.state.pose_world_to_cam,
+                    status: TrackingStatus::Skipped,
+                },
+                trace,
+            );
         };
 
-        let result = try_initialize_two_view(
+        let (result, init_report) = try_initialize_two_view_with_report(
             &prev_bootstrap_frame.features,
             &prev_bootstrap_frame.pose_world_to_cam,
             &curr_frame.features,
             &self.camera,
             &self.two_view_init_config,
         );
+        trace.init = Some(PipelineInitTrace {
+            frame_idx_ref: prev_bootstrap_frame.idx,
+            frame_idx_cur: curr_frame.idx,
+            feature_count_ref: prev_bootstrap_frame.features.descriptors.len(),
+            feature_count_cur: curr_frame.features.descriptors.len(),
+            report: init_report,
+        });
 
         let two_view_estimate = match result {
             Err(_) => {
                 self.state.bootstrap_frame = Some(prev_bootstrap_frame);
-                return TrackingResult {
-                    pose_world_to_cam: self.state.pose_world_to_cam,
-                    status: TrackingStatus::Skipped,
-                };
+                return (
+                    TrackingResult {
+                        pose_world_to_cam: self.state.pose_world_to_cam,
+                        status: TrackingStatus::Skipped,
+                    },
+                    trace,
+                );
             }
             Ok(tv) => tv,
         };
@@ -117,8 +253,10 @@ impl Pipeline {
         curr_frame.pose_world_to_cam = estimated_pose;
 
         // Promote to Keyframes
-        let reference_kf = Keyframe::from_frame(prev_bootstrap_frame);
-        let current_kf = Keyframe::from_frame(curr_frame);
+        let mut reference_kf = Keyframe::from_frame(prev_bootstrap_frame);
+        let mut current_kf = Keyframe::from_frame(curr_frame);
+        self.attach_bow(&mut reference_kf);
+        self.attach_bow(&mut current_kf);
         let curr_idx = current_kf.frame.idx;
 
         self.build_initial_map(
@@ -132,11 +270,16 @@ impl Pipeline {
         self.state.current_keyframe_idx = Some(curr_idx);
         self.state.last_keyframe_idx = Some(curr_idx);
         self.state.mode = SystemMode::Tracking;
+        self.initial_orb_until_frame = Some(curr_idx + self.initial_orb_window_frames);
+        trace.tracked_inliers = two_view_estimate.estimate.inliers;
 
-        TrackingResult {
-            pose_world_to_cam: self.state.pose_world_to_cam,
-            status: TrackingStatus::KeyframeAccepted,
-        }
+        (
+            TrackingResult {
+                pose_world_to_cam: self.state.pose_world_to_cam,
+                status: TrackingStatus::KeyframeAccepted,
+            },
+            trace,
+        )
     }
 
     fn build_initial_map(
@@ -201,7 +344,8 @@ impl Pipeline {
         added
     }
 
-    fn tracking_step(&mut self, frame: Frame) -> TrackingResult {
+    fn tracking_step(&mut self, frame: Frame) -> (TrackingResult, PipelineTrace) {
+        let mut trace = PipelineTrace::new(SystemMode::Tracking);
         let pose_before_tracking = self.state.pose_world_to_cam;
         let image_size = frame.image_size;
 
@@ -211,7 +355,7 @@ impl Pipeline {
             self.state.pose_world_to_cam
         };
 
-        let result = self.estimator.estimate_pose(
+        let (result, tracking_report) = self.estimator.estimate_pose_with_report(
             &frame,
             &candidate_pose,
             &pose_before_tracking,
@@ -219,6 +363,20 @@ impl Pipeline {
             &self.camera,
             self.state.current_keyframe_idx,
         );
+        if result.is_err() {
+            eprintln!(
+                "[diag] frame {} TRACK_FAIL: proj_matches={} proj_pnp_in={} ref_matches={} ref_corr={} local_matches={} local_pnp_in={} reason={:?}",
+                frame.idx,
+                tracking_report.projection_matches,
+                tracking_report.projection_pnp_inliers,
+                tracking_report.reference_matches,
+                tracking_report.reference_correspondences,
+                tracking_report.local_projection_matches,
+                tracking_report.local_pnp_inliers,
+                tracking_report.reject_reason,
+            );
+        }
+        trace.tracking = Some(tracking_report);
 
         let (mut status, matches, tracked_inliers) = match result {
             Ok(estimate) => {
@@ -228,6 +386,7 @@ impl Pipeline {
             }
             Err(_) => (TrackingStatus::Skipped, Vec::new(), 0),
         };
+        trace.tracked_inliers = tracked_inliers;
 
         if status == TrackingStatus::Tracked {
             let visible = self
@@ -244,16 +403,22 @@ impl Pipeline {
             self.state.consecutive_failures += 1;
             if self.state.consecutive_failures >= self.state.max_consecutive_failures {
                 self.state.reset();
-                return self.bootstrap_step(frame);
+                self.initial_orb_until_frame = None;
+                let (result, mut reset_trace) = self.bootstrap_step(frame);
+                reset_trace.tracking = trace.tracking;
+                return (result, reset_trace);
             }
         } else {
             self.state.consecutive_failures = 0;
         }
 
-        TrackingResult {
-            pose_world_to_cam: self.state.pose_world_to_cam,
-            status,
-        }
+        (
+            TrackingResult {
+                pose_world_to_cam: self.state.pose_world_to_cam,
+                status,
+            },
+            trace,
+        )
     }
 
     fn try_insert_keyframe(
@@ -262,12 +427,30 @@ impl Pipeline {
         tracked_inliers: usize,
         matches: &[(usize, usize)],
     ) -> bool {
+        // ORB-SLAM3 NeedNewKeyFrame uses TrackedMapPoints(nMinObs) of the
+        // reference KF — points observed by >=3 KFs once the map has grown.
         let n_ref_map_points = self
             .state
             .current_keyframe_idx
-            .and_then(|ki| self.map.get_keyframe(ki))
-            .map(|kf| kf.num_associated_points())
+            .map(|ki| {
+                let min_obs = if self.map.keyframes().len() <= 2 {
+                    2
+                } else {
+                    3
+                };
+                self.map.tracked_map_points(ki, min_obs)
+            })
             .unwrap_or(0);
+
+        let mapping_busy = self
+            .mapping_busy_until_frame
+            .is_some_and(|until| frame.idx < until);
+        let forced_by_max_gap = self.state.last_keyframe_idx.is_some_and(|last| {
+            frame.idx.saturating_sub(last) >= self.keyframe_policy.max_frames_between
+        });
+        if mapping_busy && !forced_by_max_gap {
+            return false;
+        }
 
         if !self.keyframe_policy.should_insert(
             frame.idx,
@@ -294,6 +477,7 @@ impl Pipeline {
             image_size: frame.image_size,
             keypoint_colors: frame.keypoint_colors.clone(),
         });
+        self.attach_bow(&mut curr_kf);
         for &(mp_idx, curr_idx) in matches {
             curr_kf.associate_map_point(curr_idx, mp_idx);
         }
@@ -312,6 +496,18 @@ impl Pipeline {
         self.state.current_keyframe_idx = Some(frame.idx);
         self.state.last_keyframe_idx = Some(frame.idx);
 
+        if self.enable_neighbor_fusion {
+            let fused = self.search_in_neighbors(frame.idx);
+            if fused > 0 {
+                eprintln!("[pipeline] SearchInNeighbors fused {} observations", fused);
+            }
+        }
+
+        let culled = self.map.map_point_culling();
+        if culled > 0 {
+            eprintln!("[pipeline] map point culling removed {} points", culled);
+        }
+
         if enable_local_ba {
             self.map.run_local_ba(&self.camera);
             if let Some(newest_kf) = self.map.keyframes().last() {
@@ -319,8 +515,111 @@ impl Pipeline {
             }
         }
 
+        let culled_keyframes = self.map.keyframe_culling();
+        if culled_keyframes > 0 {
+            eprintln!(
+                "[pipeline] keyframe culling removed {} keyframes",
+                culled_keyframes
+            );
+        }
+
         self.map.cull();
+        if self.mapping_cooldown_frames > 0 {
+            self.mapping_busy_until_frame = Some(frame.idx + self.mapping_cooldown_frames);
+        }
         true
+    }
+
+    fn search_in_neighbors(&mut self, curr_kf_idx: usize) -> usize {
+        // ORB-SLAM3 `LocalMapping::SearchInNeighbors` calls `Fuse(..)` once per
+        // target KF (forward) and once for the union of target-KF MPs into
+        // currKF (backward), with NO cap and full Replace semantics. Module 6
+        // replay parity (`parity/rust/src/bin/parity_local_mapping.rs`) found
+        // that:
+        //   - `FuseMode::AddOnly` causes Rust to never cull loser MPs in
+        //     conflicts, so they keep getting projected into later target KFs
+        //     (~75% of replay mismatches). `ReplaceWeaker` drops this.
+        //   - `MAX_FUSED_PER_INSERT = 120` was only "safe" because of
+        //     `AddOnly`; with proper Replace, ORB-SLAM3 has no such cap.
+        // The two combined cut replay diff by ~30% on the smoke set.
+        const FIRST_ORDER_NEIGHBORS: usize = 30;
+        const SECOND_ORDER_NEIGHBORS: usize = 20;
+        const MAX_TARGET_KEYFRAMES: usize = 50;
+
+        let mut target_kfs = Vec::new();
+        let mut seen = HashSet::new();
+        let push_target = |kf_idx: usize, targets: &mut Vec<usize>, seen: &mut HashSet<usize>| {
+            if kf_idx != curr_kf_idx && targets.len() < MAX_TARGET_KEYFRAMES && seen.insert(kf_idx)
+            {
+                targets.push(kf_idx);
+            }
+        };
+
+        for (neighbor_idx, _) in self
+            .map
+            .covisibility_neighbors(curr_kf_idx, FIRST_ORDER_NEIGHBORS)
+        {
+            push_target(neighbor_idx, &mut target_kfs, &mut seen);
+        }
+
+        let first_order = target_kfs.clone();
+        for kf_idx in first_order {
+            if target_kfs.len() >= MAX_TARGET_KEYFRAMES {
+                break;
+            }
+            for (second_idx, _) in self
+                .map
+                .covisibility_neighbors(kf_idx, SECOND_ORDER_NEIGHBORS)
+            {
+                push_target(second_idx, &mut target_kfs, &mut seen);
+                if target_kfs.len() >= MAX_TARGET_KEYFRAMES {
+                    break;
+                }
+            }
+        }
+
+        if target_kfs.is_empty() {
+            return 0;
+        }
+
+        let current_map_points = self.map.keyframe_map_point_indices(curr_kf_idx);
+        let mut fused = 0usize;
+        for target_kf_idx in target_kfs.iter().copied() {
+            fused += self
+                .map
+                .fuse_projected_map_points_into_keyframe_limited_with_mode(
+                    target_kf_idx,
+                    &current_map_points,
+                    &self.camera,
+                    usize::MAX,
+                    FuseMode::ReplaceWeaker,
+                );
+        }
+
+        // Match ORB-SLAM3 backward pass: union of target KFs' MPs in first-seen
+        // order across target KFs (each KF's MPs in keypoint-index order via
+        // `keyframe_map_point_indices`). Sequential Replace makes order
+        // matter.
+        let mut fuse_candidates: Vec<usize> = Vec::new();
+        let mut seen_candidates = HashSet::new();
+        for target_kf_idx in target_kfs.iter().copied() {
+            for mp_idx in self.map.keyframe_map_point_indices(target_kf_idx) {
+                if seen_candidates.insert(mp_idx) {
+                    fuse_candidates.push(mp_idx);
+                }
+            }
+        }
+        fused += self
+            .map
+            .fuse_projected_map_points_into_keyframe_limited_with_mode(
+                curr_kf_idx,
+                &fuse_candidates,
+                &self.camera,
+                usize::MAX,
+                FuseMode::ReplaceWeaker,
+            );
+
+        fused
     }
 
     fn grow_map_points_from_keyframe_pair(
@@ -380,7 +679,6 @@ impl Pipeline {
             return 0;
         }
 
-        // Collect inlier undistorted points for triangulation.
         let inlier_prev: Vec<_> = two_view
             .inlier_indices
             .iter()
@@ -432,5 +730,159 @@ impl Pipeline {
         let kf_idx = curr_kf.frame.idx;
         self.map
             .add_triangulated_points(None, curr_kf, &points, kf_idx)
+    }
+
+    /// Grows new map points from BoW-matched pairs against the most recent
+    /// keyframes. Port of ORB-SLAM3's `LocalMapping::CreateNewMapPoints`.
+    ///
+    /// Unlike [`grow_map_points_from_keyframe_pair`] this skips brute-force
+    /// descriptor matching and a second two-view RANSAC, trusting the existing
+    /// poses + the BoW/epipolar filter in [`search_for_triangulation`].
+    fn grow_map_points_bow_against_recent(
+        &mut self,
+        curr_kf: &mut Keyframe,
+        two_view_config: &TwoViewConfig,
+        num_neighbors: usize,
+    ) -> usize {
+        if self.vocabulary.is_none() || curr_kf.direct_index.is_none() {
+            return 0;
+        }
+        let search_config = TriangulationSearchConfig::default();
+        let triangulation_config = &two_view_config.triangulation;
+        let camera = self.camera.clone();
+
+        // Snapshot the neighbor keyframes so we can pass an immutable borrow of
+        // each through the search + triangulation loop while holding `&mut self`.
+        let neighbor_kfs: Vec<Keyframe> = self
+            .map
+            .keyframes()
+            .iter()
+            .rev()
+            .filter(|kf| kf.frame.idx != curr_kf.frame.idx)
+            .filter(|kf| kf.direct_index.is_some())
+            .take(num_neighbors)
+            .cloned()
+            .collect();
+
+        let mut total_added = 0usize;
+        for neighbor in neighbor_kfs.iter() {
+            let pairs = search_for_triangulation(neighbor, curr_kf, &camera, &search_config);
+            eprintln!(
+                "[pipeline]   bow pairs kf{} <-> kf{}: {} (neighbor desc={}, curr desc={})",
+                neighbor.frame.idx,
+                curr_kf.frame.idx,
+                pairs.len(),
+                neighbor.frame.features.descriptors.len(),
+                curr_kf.frame.features.descriptors.len(),
+            );
+            if pairs.is_empty() {
+                continue;
+            }
+
+            let (prev_pts, curr_pts) = camera.undistort_matched_pairs(
+                &neighbor.frame.features.keypoints_xy,
+                &curr_kf.frame.features.keypoints_xy,
+                &pairs,
+            );
+
+            let triangulated = match triangulate_matched_points(
+                &prev_pts,
+                &curr_pts,
+                &neighbor.frame.pose_world_to_cam,
+                &curr_kf.frame.pose_world_to_cam,
+                &camera,
+                triangulation_config,
+            ) {
+                Ok(pts) => pts,
+                Err(_) => continue,
+            };
+            if triangulated.is_empty() {
+                continue;
+            }
+
+            let mut points = Vec::new();
+            let mut used_curr: HashSet<usize> = HashSet::new();
+            for tp in &triangulated {
+                let Some(&(prev_idx, curr_idx)) = pairs.get(tp.pair_index) else {
+                    continue;
+                };
+                if curr_kf.map_point(curr_idx).is_some() {
+                    continue;
+                }
+                if neighbor.map_point(prev_idx).is_some() {
+                    // Would only happen if the neighbor acquired a map point at this
+                    // feature since BoW was computed — skip to avoid duplicates.
+                    continue;
+                }
+                if !used_curr.insert(curr_idx) {
+                    continue;
+                }
+                let color = curr_kf
+                    .frame
+                    .keypoint_colors
+                    .get(curr_idx)
+                    .copied()
+                    .unwrap_or([128; 3]);
+                points.push((
+                    tp.position,
+                    curr_kf.frame.features.descriptors[curr_idx],
+                    color,
+                    prev_idx,
+                    curr_idx,
+                ));
+            }
+
+            if points.is_empty() {
+                continue;
+            }
+
+            let kf_idx = curr_kf.frame.idx;
+            // Back-associate on the neighbor too: look up its mutable reference
+            // via frame idx after insertion.
+            let neighbor_idx = neighbor.frame.idx;
+            let added = self
+                .map
+                .add_triangulated_points(None, curr_kf, &points, kf_idx);
+            if added > 0 {
+                if let Some(mp_start) = self.map.map_points().len().checked_sub(added) {
+                    for (i, &(_, _, _, prev_desc_idx, _)) in points.iter().enumerate() {
+                        self.map
+                            .associate_keyframe_map_point(neighbor_idx, prev_desc_idx, mp_start + i);
+                    }
+                }
+            }
+            total_added += added;
+        }
+        total_added
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_camera() -> PinholeCamera {
+        PinholeCamera {
+            fx: 458.654,
+            fy: 457.296,
+            cx: 367.215,
+            cy: 248.375,
+            k1: -0.28340811,
+            k2: 0.07395907,
+            p1: 0.00019359,
+            p2: 0.00001762,
+        }
+    }
+
+    #[test]
+    fn initial_orb_extractor_window_switches_back_to_tracking_detector() {
+        let mut pipeline = Pipeline::new(test_camera(), PipelineConfig::default());
+        assert!(pipeline.use_initial_orb_extractor(0));
+
+        pipeline.state.mode = SystemMode::Tracking;
+        pipeline.initial_orb_until_frame = Some(22);
+
+        assert!(pipeline.use_initial_orb_extractor(21));
+        assert!(!pipeline.use_initial_orb_extractor(22));
     }
 }

--- a/examples/orb_slam/src/trace.rs
+++ b/examples/orb_slam/src/trace.rs
@@ -1,0 +1,171 @@
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::{Path, PathBuf},
+};
+
+use crate::pipeline::PipelineTrace;
+use kornia_slam::estimation::map_projection::map_projection_reject_reason_name;
+use kornia_slam::estimation::two_view::two_view_reject_reason_name;
+use kornia_slam::system::{SystemMode, TrackingStatus};
+
+pub struct TraceWriter {
+    frames: BufWriter<File>,
+    init: BufWriter<File>,
+    tracking: BufWriter<File>,
+    map: BufWriter<File>,
+}
+
+impl TraceWriter {
+    pub fn new(prefix: impl AsRef<Path>) -> io::Result<Self> {
+        let prefix = prefix.as_ref();
+        let mut writer = Self {
+            frames: BufWriter::new(File::create(suffixed_path(prefix, "frames"))?),
+            init: BufWriter::new(File::create(suffixed_path(prefix, "init"))?),
+            tracking: BufWriter::new(File::create(suffixed_path(prefix, "tracking"))?),
+            map: BufWriter::new(File::create(suffixed_path(prefix, "map"))?),
+        };
+        writer.write_headers()?;
+        Ok(writer)
+    }
+
+    pub fn write_frame(
+        &mut self,
+        frame_idx: usize,
+        timestamp_ns: i64,
+        feature_count: usize,
+        map_points: usize,
+        active_map_points: usize,
+        keyframes: usize,
+        status: TrackingStatus,
+        elapsed_ms: f64,
+        trace: &PipelineTrace,
+    ) -> io::Result<()> {
+        writeln!(
+            self.frames,
+            "{frame_idx},{timestamp_ns},{},{},{},{feature_count},{map_points},{keyframes},{},{elapsed_ms:.6}",
+            mode_name(trace.mode_before),
+            mode_name(trace.mode_after),
+            status_name(status),
+            trace.tracked_inliers,
+        )?;
+
+        if let Some(init) = &trace.init {
+            let reject_reason = init
+                .report
+                .reject_reason
+                .map(two_view_reject_reason_name)
+                .unwrap_or("none");
+            let r = &init.report;
+            let mut ng = [0usize; 8];
+            for (i, v) in r.candidate_ngood.iter().take(8).enumerate() {
+                ng[i] = *v;
+            }
+            let best_cand_idx: i32 = r.best_candidate_idx.map(|i| i as i32).unwrap_or(-1);
+            let ran_i = if r.two_view_ran { 1 } else { 0 };
+            let acc_i = if r.two_view_accepted { 1 } else { 0 };
+            writeln!(
+                self.init,
+                "{fir},{fic},{fcr},{fcc},{mtc},{mdl},{inl},{tri},{mdp:.12},{rej},\
+{ran},{att},{acc},{tm},{sh:.4},{sf:.4},{rh:.4},{ih},{ifi},\
+{n0},{n1},{n2},{n3},{n4},{n5},{n6},{n7},\
+{bg},{sbg},{bci},{bpd:.4},{ns}",
+                fir = init.frame_idx_ref,
+                fic = init.frame_idx_cur,
+                fcr = init.feature_count_ref,
+                fcc = init.feature_count_cur,
+                mtc = r.matches,
+                mdl = r.model,
+                inl = r.inliers,
+                tri = r.triangulated,
+                mdp = r.median_depth.unwrap_or(0.0),
+                rej = reject_reason,
+                ran = ran_i,
+                att = ran_i,
+                acc = acc_i,
+                tm = r.model,
+                sh = r.orb_slam3_sh,
+                sf = r.orb_slam3_sf,
+                rh = r.orb_slam3_rh,
+                ih = r.inliers_h,
+                ifi = r.inliers_f,
+                n0 = ng[0],
+                n1 = ng[1],
+                n2 = ng[2],
+                n3 = ng[3],
+                n4 = ng[4],
+                n5 = ng[5],
+                n6 = ng[6],
+                n7 = ng[7],
+                bg = r.triangulated,
+                sbg = r.second_best_good,
+                bci = best_cand_idx,
+                bpd = r.median_parallax_deg,
+                ns = 0,
+            )?;
+        }
+
+        if let Some(tracking) = &trace.tracking {
+            let reject_reason = tracking
+                .reject_reason
+                .map(map_projection_reject_reason_name)
+                .unwrap_or("none");
+            writeln!(
+                self.tracking,
+                "{frame_idx},{},{},{},{},{},{},{}",
+                tracking.projection_matches,
+                tracking.projection_pnp_inliers,
+                tracking.reference_matches,
+                tracking.reference_correspondences,
+                tracking.local_projection_matches,
+                tracking.local_pnp_inliers,
+                reject_reason,
+            )?;
+        }
+
+        writeln!(
+            self.map,
+            "{frame_idx},{keyframes},{map_points},{active_map_points}"
+        )?;
+        Ok(())
+    }
+
+    fn write_headers(&mut self) -> io::Result<()> {
+        writeln!(
+            self.frames,
+            "frame_idx,timestamp_ns,mode_before,mode_after,status,feature_count,map_points,keyframes,tracked_inliers,elapsed_ms"
+        )?;
+        writeln!(
+            self.init,
+            "frame_idx_ref,frame_idx_cur,feature_count_ref,feature_count_cur,descriptor_matches,model,inliers,triangulated,median_depth,reject_reason,\
+tv_ran,tv_attempted,tv_accepted,tv_model,sh,sf,rh,inliers_h,inliers_f,\
+ngood_0,ngood_1,ngood_2,ngood_3,ngood_4,ngood_5,ngood_6,ngood_7,\
+best_good,second_best_good,best_cand_idx,best_parallax_deg,n_similar"
+        )?;
+        writeln!(
+            self.tracking,
+            "frame_idx,projection_matches,projection_pnp_inliers,reference_matches,reference_correspondences,local_projection_matches,local_pnp_inliers,reject_reason"
+        )?;
+        writeln!(self.map, "frame_idx,keyframes,map_points,active_map_points")?;
+        Ok(())
+    }
+}
+
+fn suffixed_path(prefix: &Path, name: &str) -> PathBuf {
+    PathBuf::from(format!("{}_{}.csv", prefix.display(), name))
+}
+
+fn mode_name(mode: SystemMode) -> &'static str {
+    match mode {
+        SystemMode::Bootstrap => "bootstrap",
+        SystemMode::Tracking => "tracking",
+    }
+}
+
+fn status_name(status: TrackingStatus) -> &'static str {
+    match status {
+        TrackingStatus::Tracked => "tracked",
+        TrackingStatus::Skipped => "skipped",
+        TrackingStatus::KeyframeAccepted => "keyframe_accepted",
+    }
+}


### PR DESCRIPTION
## Goal

Match ORB-SLAM3's monocular SLAM output on EuRoC `MH_01_easy`: about `55` keyframes, about `2930` active map points, `0` tracking failures. Long-running PR, updated incrementally as each module reaches parity.

## Strategy

Module-by-module parity testing using a snapshot-and-replay harness. For each ORB-SLAM3 module the C++ side dumps state before/after the step; the Rust side replays the same step on the same input and the comparator diffs per-decision outputs. This localises divergence rather than inferring it from end-to-end metrics.

The C++ instrumentation, dump format, and Rust comparators live under `parity/` and related local tooling. They are forensic infrastructure for parity work, not library surface.

Same forensic loop has now run on multiple monocular subsystems. Each loop found exact parity bugs that source translation alone had missed.

- Module 1 — invalid 4-of-16-cardinal-point FAST pretest, Harris-vs-FAST-response ranking in `DistributeOctTree`, missing 3x3 NMS, threshold-margin FAST score, pyramid pre-blur, `IC_Angle` patch shape.
- Module 2 — vLapping `{0,0}` vs `{0,1000}` mismatch reversing keypoint order between dumpers; parity harness double-applying the `0.8 / 1.2` distance slack.
- Module 6 — `AddOnly` vs `Replace` asymmetry preventing in-step culling of loser MPs; `MapPoint::Observations()` reading the wrong structure; `KeyFrameCulling` using `>= 3` instead of `> 3`; `MIN_KEYFRAMES_BEFORE_FUSION = 8` heuristic with no C++ counterpart; non-ORB `ComputeDistinctiveDescriptors` median rule.

## Module status

| # | Module | Status | Latest measurement |
|---|--------|--------|--------------------|
| 1 | ORB extraction | ✅ closed | ~92% spatial match, median Hamming 3, median `|Δθ|` 0.02° on MH_01 frames 0–9 |
| 2 | `SearchByProjection` + `isInFrustum` + `PredictScale` | ✅ closed | 99.8% native accepted-match overlap, 100% predicted-octave agreement on frames 160–190 |
| 3 | Two-view init | — | not separately measured |
| 4 | Triangulation | — | `SearchForTriangulation` added as a Module-6 dependency, not separately measured |
| 5 | `PoseOptimization` | 🟡 stable, not bit-exact | active-set 4-pass with octave-weighted chi-square gate, `0 TRACK_FAIL` through 500 frames |
| 6 | `SearchInNeighbors` + `KeyFrameCulling` + `MapPointCulling` | 🟡 very close, not closed | exact Fuse parity on checked frame-38 replay dump; exact pre-culling culling parity when replay uses exact C++ candidate order; remaining live gap is covisibility-order source |

## Current end-to-end

### Pushed PR head

```text
30 KFs, 711 active / 4822 total points, 0 TRACK_FAIL
```

### Current working tree / follow-up parity work

This is newer than the pushed PR head and comes from the current local workspace:

```text
27 KFs, 695 active / 3842 total points, 0 TRACK_FAIL
```

ORB-SLAM3 target band:

```text
~55 KFs, ~2930 active points, 0 TRACK_FAIL
```

The system is still under-keyframing relative to ORB-SLAM3. At this point the remaining evidence does **not** point to Fuse or `KeyFrameCulling` logic itself; it points to the live covisibility ordering that feeds culling.

## What's in this branch

### Module 2 — `SearchByProjection` + frustum (closed)

- `MapPoint`: viewing normal, distance invariance, `predict_scale()` matching ORB-SLAM3 `PredictScale`.
- `MapProjectionEstimator`: 5-gate `isInFrustum` filter.
- `keypoint_grid`: 64x48 fixed grid over undistorted image bounds, rounded `PosInGrid`-style binning, `GetFeaturesInArea`-style square window with octave filter.
- Module-2 replay numbers above come from feeding a real ORB-SLAM3 snapshot through the Rust matcher.

### Module 5 — `PoseOptimization` (stable, approximation)

- `solve_pnp_with_octaves`: octave-weighted chi-square gate `5.991 * 1.2^(2 * octave)` matching ORB-SLAM3 mono.
- 4-pass active-set loop: optimise current inlier set, reclassify correspondences, keep best-by-inlier-count pose.
- Tracking PnP now threads per-correspondence keypoint scale through to the gate.
- Still not bit-equivalent to `Optimizer::PoseOptimization`:
  - kornia LM, not g2o
  - no Huber kernel in early passes
  - one-shot LM per pass instead of g2o's iteratively reclassified loop

### Module 6 — local mapping (current frontier)

- Inverse observation index and parity-only observation overrides:
  - `Map::observations_by_map_point`
  - `MapPoint.observation_count_override`
  - `MapPoint.observed_keyframes_override`
  - `MapPoint.observation_slots_override`
  - `MapPoint.reference_keyframe_override`
- `Map::fuse_projected_map_points_into_keyframe_limited_with_mode` now matches ORB-SLAM3 `Fuse` gates:
  - viewing angle
  - distance invariance
  - `PredictScale`-based octave filter `[pred-1, pred]`
  - mono chi-square reprojection gate
  - no artificial fusion cap
  - `ReplaceWeaker` semantics
- `ComputeDistinctiveDescriptors` parity fix:
  - Rust now includes self-distance `0` and uses ORB-SLAM3's median index rule
  - this closed the final checked Fuse mismatch on the current frame-38 dump
- `KeyFrameCulling` parity fixes:
  - local-covisibility scope
  - same-or-finer support rule
  - exact `> 3` threshold
  - sequential removal semantics

### Exact replay status for Module 6

Checked dump:

```text
/tmp/local_mapping_gdb_trace_target13_desc2/local_mapping/step_000018_frame_000038.yaml
```

On that dump:

```text
Fuse:
  exact=19064
  decision_mismatch=0
  cpp_only=0
  rust_only=0

Backward candidate order:
  exact
```

Pre-culling replay:

- with Rust's native live candidate order:

```text
cpp_order  = [2, 1, 0, 3, 4, 12, 17, 13, 5, 16, 11, 6, 10, 15, 9, 7, 8]
rust_order = [1, 2, 0, 3, 12, 4, 13, 17, 5, 16, 11, 10, 6, 15, 9, 7, 8]
mismatched_records = 1
```

- with replay forced to use the exact C++ culling order:

```text
mismatched_records = 0
```

That is the important current conclusion: the remaining Module 6 gap is the **source of covisibility/culling order**, not Fuse or culling logic itself.

## Other infrastructure

- `BoW` + `DirectIndex` on keyframes (`Keyframe::compute_bow`, vocabulary injection on `Pipeline`)
- `triangulation_search`: ORB-SLAM3 `SearchForTriangulation`-style epipolar match
- `factors/pose_prior.rs`, `factors/weighted_prior.rs`: groundwork for inertial, not wired into mono
- `examples/orb_slam`:
  - `--vocabulary`
  - `--mapping-cooldown`
  - `--no-neighbor-fusion`
  - initial high-capacity ORB extractor window
  - structured trace output for parity runs

## Known divergences still open

1. **Module 6 live covisibility ordering**
   - exact checked replay shows Fuse is closed
   - exact checked replay shows `KeyFrameCulling` is closed when fed the exact C++ candidate order
   - remaining live gap is that Rust does not yet produce the same culling candidate order as ORB-SLAM3 on the checked step
   - next exact task is to dump / compare covisibility weights and ordering against the current KF

2. **Module 5** is still not bit-exact
   - deeper parity needs a dedicated C++ snapshot dump of `Optimizer::PoseOptimization`

3. **Modules 3 and 4** are still under-instrumented
   - working functionally
   - not yet validated with the same depth of C++ replay

## Out of scope

- Inertial / IMU mode
- Loop closure
- Multi-map / Atlas
