### PR TITLE
feat: align monocular bootstrap with ORB-SLAM3

### DIFF
--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -474,6 +474,7 @@ mod matching_tests {
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, 5.0),
             descriptor: desc_a,
+            observed_descriptors: vec![desc_a],
             color: [0; 3],
             keyframe_idx: 0,
             n_visible: 0,
@@ -517,6 +518,7 @@ mod matching_tests {
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, -5.0),
             descriptor: [0u8; 32],
+            observed_descriptors: vec![[0u8; 32]],
             color: [0; 3],
             keyframe_idx: 0,
             n_visible: 0,
@@ -557,6 +559,7 @@ mod matching_tests {
         let map_points = vec![MapPoint {
             position: Vec3F64::new(0.0, 0.0, 5.0),
             descriptor: [0u8; 32],
+            observed_descriptors: vec![[0u8; 32]],
             color: [0; 3],
             keyframe_idx: 0,
             n_visible: 0,

--- a/crates/kornia-slam/src/estimation/two_view.rs
+++ b/crates/kornia-slam/src/estimation/two_view.rs
@@ -51,7 +51,12 @@ impl Default for TwoViewInitConfig {
                 check_orientation: true,
                 histo_length: 30,
             },
-            triangulation_config: TriangulationConfig::default(),
+            // Match ORB-SLAM3's `secondBestGood < 0.75 * bestGood` cheirality
+            // ambiguity threshold (default in kornia-3d is 0.70).
+            triangulation_config: TriangulationConfig {
+                cheirality_ambiguity_max: 0.75,
+                ..TriangulationConfig::default()
+            },
             acceptance_config: TwoViewAcceptanceConfig {
                 min_matches: 100,
                 min_inliers: 30,
@@ -68,8 +73,6 @@ pub enum TwoViewRejectReason {
     LowMatches,
     /// Two-view estimation failed.
     EstimationFailed,
-    /// Homography was selected instead of fundamental model.
-    WrongModel,
     /// Too few triangulated points.
     LowTriangulated,
     /// Too few inliers in estimated model.
@@ -89,6 +92,9 @@ pub struct TwoViewEstimate {
     pub inlier_indices: Vec<usize>,
     /// Median positive depth in the two-view triangulation (if available).
     pub median_depth: Option<f64>,
+    /// Which model the estimator committed to: `'F'` (fundamental/essential)
+    /// or `'H'` (homography). Useful for diagnostics on planar scenes.
+    pub model_kind: char,
 }
 
 /// Attempt two-view initialization between a reference frame and the current frame.
@@ -126,9 +132,10 @@ pub fn try_initialize_two_view(
         .estimate(&reference_pts, &current_pts, &k, &k)
         .map_err(|_| TwoViewRejectReason::EstimationFailed)?;
 
-    if !matches!(result.model, TwoViewModel::Fundamental(_)) {
-        return Err(TwoViewRejectReason::WrongModel);
-    }
+    let model_kind = match result.model {
+        TwoViewModel::Homography(_) => 'H',
+        _ => 'F',
+    };
 
     if result.points3d.len() < acceptance.min_triangulated {
         return Err(TwoViewRejectReason::LowTriangulated);
@@ -170,6 +177,7 @@ pub fn try_initialize_two_view(
         points3d: result.points3d,
         inlier_indices: result.inlier_indices,
         median_depth,
+        model_kind,
     })
 }
 

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -33,6 +33,7 @@ use kornia_3d::pose::Pose3d;
 use kornia_3d::ransac::RobustKernelKind;
 use kornia_algebra::Vec3F64;
 use kornia_image::ImageSize;
+use kornia_imgproc::features::hamming_distance;
 
 use crate::frame::Frame;
 
@@ -90,8 +91,14 @@ pub type TriangulatedPoint = (Vec3F64, [u8; 32], [u8; 3], usize, usize);
 pub struct MapPoint {
     /// 3D position in world frame.
     pub position: Vec3F64,
-    /// ORB descriptor used for projection-guided matching.
+    /// Representative ORB descriptor used for projection-guided matching.
+    /// Recomputed as the descriptor with minimum median Hamming distance to
+    /// all observations whenever a new observation is added (mirrors
+    /// ORB-SLAM3's `MapPoint::ComputeDistinctiveDescriptors`).
     pub descriptor: [u8; 32],
+    /// All descriptors of this point across observing keyframes. Used to
+    /// recompute `descriptor` (the representative) as viewpoint changes.
+    pub observed_descriptors: Vec<[u8; 32]>,
     /// Pixel color sampled at the keypoint that created this point.
     pub color: [u8; 3],
     /// Index of the keyframe that first observed this point.
@@ -105,7 +112,7 @@ pub struct MapPoint {
 }
 
 impl MapPoint {
-    /// Creates a fresh active map point.
+    /// Creates a fresh active map point with one observed descriptor.
     pub fn new(
         position: Vec3F64,
         descriptor: [u8; 32],
@@ -115,6 +122,7 @@ impl MapPoint {
         Self {
             position,
             descriptor,
+            observed_descriptors: vec![descriptor],
             color,
             keyframe_idx,
             n_visible: 1,
@@ -134,6 +142,47 @@ impl MapPoint {
             return 0.0;
         }
         self.n_found as f64 / self.n_visible as f64
+    }
+
+    /// Records a new observed descriptor and refreshes the representative.
+    ///
+    /// The representative is the observed descriptor with minimum median
+    /// Hamming distance to all others (ORB-SLAM3's
+    /// `ComputeDistinctiveDescriptors`). With <=2 observations the choice is
+    /// trivial; with >=3 we run the O(n^2) pairwise distance scan.
+    pub fn add_observation_descriptor(&mut self, descriptor: [u8; 32]) {
+        self.observed_descriptors.push(descriptor);
+        self.recompute_representative_descriptor();
+    }
+
+    fn recompute_representative_descriptor(&mut self) {
+        let n = self.observed_descriptors.len();
+        match n {
+            0 => {}
+            1 => self.descriptor = self.observed_descriptors[0],
+            2 => self.descriptor = self.observed_descriptors[0],
+            _ => {
+                let mut dist_buf = vec![0u32; n];
+                let mut best_idx = 0usize;
+                let mut best_median = u32::MAX;
+                for i in 0..n {
+                    for j in 0..n {
+                        dist_buf[j] = hamming_distance(
+                            &self.observed_descriptors[i],
+                            &self.observed_descriptors[j],
+                        );
+                    }
+                    let mid = n / 2;
+                    dist_buf.select_nth_unstable(mid);
+                    let median = dist_buf[mid];
+                    if median < best_median {
+                        best_median = median;
+                        best_idx = i;
+                    }
+                }
+                self.descriptor = self.observed_descriptors[best_idx];
+            }
+        }
     }
 }
 
@@ -283,9 +332,28 @@ impl Map {
         if let Some(prev) = prev_kf {
             for (i, &(_, _, _, prev_desc_idx, _)) in points.iter().enumerate() {
                 prev.associate_map_point(prev_desc_idx, first_mp_idx + i);
+                // Feed the prev KF's descriptor as a second observation so the
+                // representative descriptor is computed from both viewpoints.
+                if let Some(&prev_desc) = prev.frame.features.descriptors.get(prev_desc_idx)
+                    && let Some(mp) = self.map_points.get_mut(first_mp_idx + i)
+                {
+                    mp.add_observation_descriptor(prev_desc);
+                }
             }
         }
         points.len()
+    }
+
+    /// Records that an existing map point was observed at `desc_idx` in
+    /// `keyframe`, pushing the descriptor into the map point's observation
+    /// list and refreshing the representative.
+    pub fn register_observation(&mut self, mp_idx: usize, keyframe: &Keyframe, desc_idx: usize) {
+        let Some(&descriptor) = keyframe.frame.features.descriptors.get(desc_idx) else {
+            return;
+        };
+        if let Some(mp) = self.map_points.get_mut(mp_idx) {
+            mp.add_observation_descriptor(descriptor);
+        }
     }
 
     /// Appends a map point and returns its index.
@@ -756,6 +824,7 @@ mod tests {
                 keypoints_xy: (0..n).map(|i| [i as f32, i as f32]).collect(),
                 orientations: vec![0.0; n],
                 descriptors,
+                octaves: vec![0; n],
             },
             pose_world_to_cam: Pose3d::IDENTITY,
             image_size: ImageSize {

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -137,6 +137,19 @@ impl MapPoint {
     }
 }
 
+/// Quality metrics for a freshly-bootstrapped 2-keyframe map.
+///
+/// Used as the gate for accepting a bootstrap result. Mirrors
+/// ORB-SLAM3's reset criteria in `CreateInitialMapMonocular`:
+/// `medianDepth < 0 || TrackedMapPoints(1) < 50`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InitialMapHealth {
+    /// Number of map points with positive depth in both bootstrap KFs.
+    pub valid_in_both: usize,
+    /// Median depth of valid points in the older KF's frame.
+    pub median_depth_older_kf: f64,
+}
+
 /// In-memory map storage for keyframes and persistent map points.
 #[derive(Debug, Clone, Default)]
 pub struct Map {
@@ -163,6 +176,70 @@ impl Map {
     /// Returns the number of persistent map points.
     pub fn num_map_points(&self) -> usize {
         self.map_points.len()
+    }
+
+    /// Wipes all keyframes and map points. Used to discard a failed bootstrap.
+    pub fn clear_active(&mut self) {
+        self.keyframes.clear();
+        self.map_points.clear();
+    }
+
+    /// Health metrics for the just-bootstrapped pair of keyframes.
+    ///
+    /// Inspects the last two keyframes in insertion order and reports how
+    /// many associated map points still have positive depth in both KFs,
+    /// plus the median depth in the older KF's frame. Used to decide whether
+    /// a freshly-bootstrapped map is safe to commit.
+    pub fn initial_map_health(&self) -> InitialMapHealth {
+        let n = self.keyframes.len();
+        if n < 2 {
+            return InitialMapHealth::default();
+        }
+        let kf_older = &self.keyframes[n - 2];
+        let kf_newer = &self.keyframes[n - 1];
+        let pose_older = kf_older.frame.pose_world_to_cam;
+        let pose_newer = kf_newer.frame.pose_world_to_cam;
+
+        // Collect MPs observed by either KF, dedup.
+        let mut seen: HashSet<usize> = HashSet::new();
+        for mp_idx in kf_older
+            .map_point_by_desc_idx
+            .iter()
+            .chain(kf_newer.map_point_by_desc_idx.iter())
+            .flatten()
+        {
+            seen.insert(*mp_idx);
+        }
+
+        let mut depths_older: Vec<f64> = Vec::with_capacity(seen.len());
+        let mut valid_in_both = 0usize;
+        for idx in seen {
+            let Some(mp) = self.map_points.get(idx) else {
+                continue;
+            };
+            if mp.culled {
+                continue;
+            }
+            let z_older = pose_older.transform_point(&mp.position).z;
+            let z_newer = pose_newer.transform_point(&mp.position).z;
+            if z_older > 0.0 && z_newer > 0.0 {
+                valid_in_both += 1;
+                depths_older.push(z_older);
+            }
+        }
+
+        let median_depth = if depths_older.is_empty() {
+            0.0
+        } else {
+            let mid = depths_older.len() / 2;
+            depths_older.select_nth_unstable_by(mid, |a, b| a.total_cmp(b));
+            depths_older[mid]
+        };
+
+        InitialMapHealth {
+            valid_in_both,
+            median_depth_older_kf: median_depth,
+        }
     }
 
     /// Returns the keyframe with frame index `idx`, if present.

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -30,6 +30,7 @@ use std::collections::{HashMap, HashSet};
 use kornia_3d::ba::{self, BaObservation, BaParams};
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
+use kornia_3d::ransac::RobustKernelKind;
 use kornia_algebra::Vec3F64;
 use kornia_image::ImageSize;
 
@@ -387,6 +388,140 @@ impl Map {
         }
     }
 
+    /// Run a 2-keyframe bundle adjustment over the bootstrap pair.
+    ///
+    /// Operates on the two most recently inserted keyframes (the bootstrap
+    /// pair). Optimizes the newer KF's pose and all map points observed by
+    /// either KF; the older KF is held fixed as the gauge anchor. Mirrors
+    /// ORB-SLAM3's `GlobalBundleAdjustemnt(map, 20)` in
+    /// `CreateInitialMapMonocular`.
+    ///
+    /// Returns `true` if BA ran and wrote back optimized values; `false` if
+    /// there were too few observations or the optimizer errored (map left
+    /// untouched in that case).
+    pub fn run_initial_ba(&mut self, camera: &PinholeCamera) -> bool {
+        const MAX_ITERS: usize = 5;
+        const HUBER_SCALE_SQ: f32 = 5.991;
+        const MIN_OBSERVATIONS: usize = 8;
+
+        let n = self.keyframes.len();
+        if n < 2 {
+            return false;
+        }
+
+        // Last two keyframes; older is gauge-fixed.
+        let kf_indices = [n - 2, n - 1];
+
+        let mut mp_set: HashSet<usize> = HashSet::new();
+        for &kf_idx in &kf_indices {
+            for mp_idx in self.keyframes[kf_idx].map_point_by_desc_idx.iter().flatten() {
+                if let Some(mp) = self.map_points.get(*mp_idx)
+                    && !mp.culled
+                {
+                    mp_set.insert(*mp_idx);
+                }
+            }
+        }
+        if mp_set.is_empty() {
+            return false;
+        }
+
+        let mut mp_global_indices: Vec<usize> = mp_set.iter().copied().collect();
+        mp_global_indices.sort_unstable();
+
+        let mp_global_to_local: HashMap<usize, usize> = mp_global_indices
+            .iter()
+            .enumerate()
+            .map(|(local, &global)| (global, local))
+            .collect();
+
+        let points: Vec<Vec3F64> = mp_global_indices
+            .iter()
+            .map(|&idx| self.map_points[idx].position)
+            .collect();
+
+        let poses: Vec<Pose3d> = kf_indices
+            .iter()
+            .map(|&i| self.keyframes[i].frame.pose_world_to_cam)
+            .collect();
+
+        let mut observations = Vec::new();
+        for (pose_idx, &kf_idx) in kf_indices.iter().enumerate() {
+            let is_fixed = pose_idx == 0;
+            let kf = &self.keyframes[kf_idx];
+            for (desc_idx, mp_opt) in kf.map_point_by_desc_idx.iter().enumerate() {
+                if let Some(mp_idx) = mp_opt {
+                    let Some(&point_idx) = mp_global_to_local.get(mp_idx) else {
+                        continue;
+                    };
+                    if let Some(kp) = kf.frame.features.keypoints_xy.get(desc_idx) {
+                        let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                        observations.push(BaObservation {
+                            pose_idx,
+                            point_idx,
+                            pixel: [p.x as f32, p.y as f32],
+                            fixed_pose: is_fixed,
+                        });
+                    }
+                }
+            }
+        }
+
+        if observations.len() < MIN_OBSERVATIONS {
+            return false;
+        }
+
+        let (sq_err_before, depth_before, kf1_t_before) =
+            initial_ba_diagnostics(&poses, &points, &observations, camera);
+
+        let params = BaParams {
+            max_iterations: MAX_ITERS,
+            // Two-view monocular BA has a 1-DOF scale gauge (only KF0 is
+            // fixed). Bump LM damping so the augmented normal equations stay
+            // well-conditioned even though H is rank-deficient.
+            initial_lambda: 1.0,
+            robust: RobustKernelKind::Huber,
+            robust_scale_sq: HUBER_SCALE_SQ,
+            ..BaParams::default()
+        };
+
+        let ba_result = match ba::bundle_adjust(&poses, &points, &observations, camera, &params) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[init_ba] bundle_adjust failed: {e}");
+                return false;
+            }
+        };
+
+        let (sq_err_after, depth_after, kf1_t_after) =
+            initial_ba_diagnostics(&ba_result.poses, &ba_result.points, &observations, camera);
+
+        eprintln!(
+            "[init_ba] before: reproj_rms={:.3}px median_depth={:.3} kf1_t_norm={:.3} obs={}",
+            sq_err_before.sqrt(),
+            depth_before,
+            kf1_t_before,
+            observations.len()
+        );
+        eprintln!(
+            "[init_ba] after:  reproj_rms={:.3}px median_depth={:.3} kf1_t_norm={:.3} iters={} converged={}",
+            sq_err_after.sqrt(),
+            depth_after,
+            kf1_t_after,
+            ba_result.iterations,
+            ba_result.converged
+        );
+
+        self.keyframes[kf_indices[1]].frame.pose_world_to_cam = ba_result.poses[1];
+        for (local_idx, &global_idx) in mp_global_indices.iter().enumerate() {
+            if let Some(mp) = self.map_points.get_mut(global_idx) {
+                mp.position = ba_result.points[local_idx];
+            }
+        }
+
+        true
+    }
+
     /// Run local bundle adjustment over recent keyframes and their observed map points.
     ///
     /// Collects the last N active keyframes, gathers observations (undistorting keypoints
@@ -480,6 +615,53 @@ impl Map {
             }
         }
     }
+}
+
+/// Returns (mean_sq_reproj_error, median_depth_in_kf0_frame, kf1_translation_norm).
+fn initial_ba_diagnostics(
+    poses: &[Pose3d],
+    points: &[Vec3F64],
+    observations: &[BaObservation],
+    camera: &PinholeCamera,
+) -> (f64, f64, f64) {
+    let mut sum_sq = 0.0;
+    let mut count = 0usize;
+    for obs in observations {
+        if let (Some(pose), Some(pt)) = (poses.get(obs.pose_idx), points.get(obs.point_idx))
+            && let Some(err_sq) = camera.reprojection_error_sq_world(
+                pose,
+                pt,
+                obs.pixel[0] as f64,
+                obs.pixel[1] as f64,
+            )
+        {
+            sum_sq += err_sq;
+            count += 1;
+        }
+    }
+    let mean_sq = if count > 0 { sum_sq / count as f64 } else { 0.0 };
+
+    let median_depth = match poses.first() {
+        Some(kf0) => {
+            let mut depths: Vec<f64> = points
+                .iter()
+                .map(|p| kf0.transform_point(p).z)
+                .filter(|&z| z > 0.0)
+                .collect();
+            if depths.is_empty() {
+                0.0
+            } else {
+                let mid = depths.len() / 2;
+                depths.select_nth_unstable_by(mid, |a, b| a.total_cmp(b));
+                depths[mid]
+            }
+        }
+        None => 0.0,
+    };
+
+    let kf1_t_norm = poses.get(1).map(|p| p.translation.length()).unwrap_or(0.0);
+
+    (mean_sq, median_depth, kf1_t_norm)
 }
 
 #[cfg(test)]

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -111,10 +111,7 @@ impl Pipeline {
         };
 
         let estimated_pose = two_view_estimate.estimate.pose;
-        self.state.velocity = Some(Pose3d::between(
-            &curr_frame.pose_world_to_cam,
-            &estimated_pose,
-        ));
+        let prev_pose_world_to_cam = curr_frame.pose_world_to_cam;
         self.state.pose_world_to_cam = estimated_pose;
         curr_frame.pose_world_to_cam = estimated_pose;
 
@@ -131,6 +128,17 @@ impl Pipeline {
             &two_view_estimate.inlier_indices,
             two_view_estimate.median_depth,
         );
+
+        // BA inside build_initial_map may have refined KF1's pose; sync state
+        // and recompute velocity from the post-BA pose.
+        if let Some(kf) = self.map.get_keyframe(curr_idx) {
+            self.state.pose_world_to_cam = kf.frame.pose_world_to_cam;
+        }
+        self.state.velocity = Some(Pose3d::between(
+            &prev_pose_world_to_cam,
+            &self.state.pose_world_to_cam,
+        ));
+
         self.state.current_keyframe_idx = Some(curr_idx);
         self.state.last_keyframe_idx = Some(curr_idx);
         self.state.mode = SystemMode::Tracking;
@@ -200,6 +208,9 @@ impl Pipeline {
 
         self.map.upsert_keyframe(reference_kf);
         self.map.upsert_keyframe(current_kf);
+
+        self.map.run_initial_ba(&self.camera);
+
         added
     }
 

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -83,6 +83,19 @@ impl Pipeline {
         // the new map in the existing coordinate frame.
         curr_frame.pose_world_to_cam = self.state.pose_world_to_cam;
 
+        // Staleness guard (mirrors ORB-SLAM3's MonocularInitialization):
+        // a frame with too few keypoints is neither a viable reference nor
+        // a viable current frame. If we already had a reference, drop it
+        // and wait for a feature-rich frame to start over.
+        const MIN_KEYPOINTS_FOR_BOOTSTRAP: usize = 100;
+        if curr_frame.features.keypoints_xy.len() <= MIN_KEYPOINTS_FOR_BOOTSTRAP {
+            self.state.bootstrap_frame = None;
+            return TrackingResult {
+                pose_world_to_cam: self.state.pose_world_to_cam,
+                status: TrackingStatus::Skipped,
+            };
+        }
+
         let Some(prev_bootstrap_frame) = self.state.bootstrap_frame.take() else {
             self.state.bootstrap_frame = Some(curr_frame);
             return TrackingResult {

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -347,6 +347,7 @@ impl Pipeline {
         });
         for &(mp_idx, curr_idx) in matches {
             curr_kf.associate_map_point(curr_idx, mp_idx);
+            self.map.register_observation(mp_idx, &curr_kf, curr_idx);
         }
 
         let enable_local_ba = self.enable_local_ba;

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -129,6 +129,24 @@ impl Pipeline {
             two_view_estimate.median_depth,
         );
 
+        // Post-BA sanity gate (mirrors ORB-SLAM3's reset criteria in
+        // CreateInitialMapMonocular). Discard the bootstrap if the resulting
+        // map has too few valid points or a degenerate scale.
+        const MIN_VALID_POINTS: usize = 50;
+        let health = self.map.initial_map_health();
+        if health.valid_in_both < MIN_VALID_POINTS || health.median_depth_older_kf <= 0.0 {
+            eprintln!(
+                "[init_gate] reject: valid_in_both={} median_depth={:.3} (need >= {} and > 0)",
+                health.valid_in_both, health.median_depth_older_kf, MIN_VALID_POINTS,
+            );
+            self.map.clear_active();
+            self.state.reset();
+            return TrackingResult {
+                pose_world_to_cam: self.state.pose_world_to_cam,
+                status: TrackingStatus::Skipped,
+            };
+        }
+
         // BA inside build_initial_map may have refined KF1's pose; sync state
         // and recompute velocity from the post-BA pose.
         if let Some(kf) = self.map.get_keyframe(curr_idx) {

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -110,6 +110,13 @@ impl Pipeline {
             Ok(tv) => tv,
         };
 
+        eprintln!(
+            "[bootstrap] model={} triangulated={} inliers={}",
+            two_view_estimate.model_kind,
+            two_view_estimate.points3d.len(),
+            two_view_estimate.estimate.inliers,
+        );
+
         let estimated_pose = two_view_estimate.estimate.pose;
         let prev_pose_world_to_cam = curr_frame.pose_world_to_cam;
         self.state.pose_world_to_cam = estimated_pose;


### PR DESCRIPTION
## Summary

Closes a series of gaps between kornia-slam's monocular bootstrap and ORB-SLAM3's `MonocularInitialization` + `CreateInitialMapMonocular`. All five commits are scoped to the bootstrap stage; downstream tracking and local mapping are untouched.

| # | Commit | Item |
|---|--------|------|
| 1 | `761b6e8` | Post-bootstrap Global BA (mirrors `Optimizer::GlobalBundleAdjustemnt(map, 20)`) |
| 2 | `4b161f7` | Post-init sanity gate (`TrackedMapPoints < 50` / `medianDepth ≤ 0` → reset) |
| 3 | `7a5e14e` | Accept H bootstraps + ambiguity threshold 0.70 → 0.75 |
| 4 | `25c2e05` | Staleness guard: drop reference frame when current has ≤ 100 keypoints |
| 5 | `4a4fb9a` | Distill representative MapPoint descriptor (`ComputeDistinctiveDescriptors`) |

## Verification

All commits verified end-to-end on EuRoC MH_01_easy, first 500 frames (`--max-frames 500`), with `[init_ba]`/`[init_gate]`/`[bootstrap]` diagnostic logs:

| Run | Tracked | KFs | Skipped | Final pts | Bootstrap reproj RMS |
|---|---|---|---|---|---|
| Baseline (no BA) | 363 | 135 | 2 | 3363 | n/a |
| #1 only | 380 | 115 | 5 | 2956 | 2.26 → 0.35 px |
| #1+#7+#4+#9+#8 | 380 | 115 | 5 | 2956 | (no change vs #1) |
| #1+#7+#4+#9+#8+#2 | 382 | 113 | 5 | 2623 | (no change vs #1) |

Bootstrap event itself is verified equivalent to ORB-SLAM3's `mono_vo_euroc` trace on the same MH_01 data:

| | Ours | ORB-SLAM3 |
|---|---|---|
| Bootstrap frame | 2 | 2 |
| Model selected | F | F |
| Triangulated | 175 | 171 |
| Parallax (deg) | > 1.0 | 2.05 |
| H/F discriminator | 0.67 < 0.8 → F | RH 0.36 < 0.5 → F |

## What's deferred

- **#5 (score-based H/F selection):** unlikely to change behavior on EuRoC; both methods make the same decision unless very close to the boundary. Needs a kornia-3d API change to plumb the symmetric-transfer-error scores out. Skipped for now.
- **#6 (triangulated-fraction gate):** as documented in the #8 commit, the natural ORB-SLAM3 mapping requires kornia-3d to expose `count_cheirality_fast`'s output (the relaxed cheirality count). Without that, the gate as commonly described would reject healthy bootstraps. Bundle with #5 if/when we touch kornia-3d.
- **#3 (MapPoint scale-invariance state + scale-aware matcher):** larger change that touches `MapPoint`, `Map`, and `MapProjectionEstimator`. Will land in a follow-up PR — without scale-aware projection matching, the scale state would be dead weight.

## Test plan

- [x] `cargo test --release -p kornia-slam` — 17 passed, 0 failed.
- [x] EuRoC MH_01_easy 500-frame end-to-end smoke (numbers above).
- [x] Force-rejection test for #7 (`MIN_VALID_POINTS = 1000`): clear+reset+retry loop works.
- [ ] Verify #4 on a planar sequence (V1_01_easy or similar) — left as a follow-up since the H path is dormant on MH_01.