### PR TITLE
feat: use OrbDetector::detect_and_extract_u8 in orb_slam example

### DIFF
--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -756,6 +756,7 @@ impl Map {
                             point_idx,
                             pixel: [p.x as f32, p.y as f32],
                             fixed_pose: is_fixed,
+                            fixed_point: false,
                         });
                     }
                 }
@@ -898,6 +899,7 @@ impl Map {
                             point_idx,
                             pixel: [p.x as f32, p.y as f32],
                             fixed_pose: is_fixed,
+                            fixed_point: false,
                         });
                     }
                 }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -100,25 +100,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let idx = args.start_frame + i;
 
-        // Load grayscale image and convert u8 → f32.
+        // Load grayscale image.
         let gray_u8 = read_image_png_mono8(&sample.image_path)?;
         let image_size = gray_u8.size();
-        let gray_f32 = {
-            let mut dst = kornia_image::Image::from_size_val(
-                image_size,
-                0.0f32,
-                kornia_tensor::CpuAllocator,
-            )?;
-            gray_u8
-                .as_slice()
-                .iter()
-                .zip(dst.as_slice_mut())
-                .for_each(|(&s, d)| *d = s as f32 / 255.0);
-            dst
-        };
 
         // Extract ORB features.
-        let features = detector.detect_and_extract(&gray_f32)?;
+        let features = detector.detect_and_extract_u8(&gray_u8)?;
         if let Some(ref rec) = rec {
             log_frame_to_rerun(rec, &gray_u8, &features.keypoints_xy);
         }


### PR DESCRIPTION
## Summary
- Switch the `orb_slam` example to `OrbDetector::detect_and_extract_u8`, dropping the per-frame u8→f32 allocation and divide-by-255 in the main loop.
- `ini_fast_threshold` / `min_fast_threshold` / `harris_k` stay in [0,1] units — the u8 path in kornia-rs rescales internally (`threshold_u8 = (threshold * 255.0).round() as u8`), so detector behavior is unchanged with the default config.
- Add the new `fixed_point: false` field to the two `BaObservation` initializers in `crates/kornia-slam/src/map.rs` to track the recent `kornia_3d::ba::BaObservation` change that introduced a motion-only-BA flag. These are local BA call sites where the 3D points are refined alongside poses, so `false` is the correct value.

## Test plan
- [x] `cargo check -p orb_slam` (passes locally)
- [x] Run `orb_slam` on EuRoC easy, first 500 frames, and verify trajectory + KF/map-point counts are unchanged vs. the f32 pipeline
- [x] Spot-check that ORB keypoint counts per frame match (default thresholds → u8 threshold 20 / 7, matching ORB-SLAM3 semantics)