### PR TITLE
feat: switch LBA to Schur-complement BA solver (~232× speedup)

### DIFF
--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -27,7 +27,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use kornia_3d::ba::{self, BaObservation, BaParams};
+use kornia_3d::ba::{BaObservation, BaParams};
+use kornia_3d::ba_schur::bundle_adjust_schur;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_3d::ransac::RobustKernelKind;
@@ -781,7 +782,7 @@ impl Map {
             ..BaParams::default()
         };
 
-        let ba_result = match ba::bundle_adjust(&poses, &points, &observations, camera, &params) {
+        let ba_result = match bundle_adjust_schur(&poses, &points, &observations, camera, &params) {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("[init_ba] bundle_adjust failed: {e}");
@@ -911,7 +912,7 @@ impl Map {
         }
 
         let ba_result =
-            match ba::bundle_adjust(&poses, &points, &observations, camera, &BaParams::default()) {
+            match bundle_adjust_schur(&poses, &points, &observations, camera, &BaParams::default()) {
                 Ok(r) => r,
                 Err(_) => return,
             };


### PR DESCRIPTION
## Summary
- Swap both BA call sites in `crates/kornia-slam/src/map.rs` (`Map::run_initial_ba` and `Map::run_local_ba`) from `kornia_3d::ba::bundle_adjust` (dense LU on the full damped Hessian) to `kornia_3d::ba_schur::bundle_adjust_schur` (block-diagonal point marginalization + dense Cholesky on the 6P×6P reduced pose system).
- Same signature, same `BaResult`, same fixed-pose / fixed-point semantics, so the diff is a single `use` line plus two `match` heads — **+4 / -3** in one file.

## Motivation
Profiling `process_frame` on EuRoC MH_01 (first 500 frames) showed `run_local_ba` accounting for **89.7%** of total wall time. Drilling into LM, 99% of per-iteration cost was the dense LU solve on the `(21 + 3·N_active_points)`-dim damped Hessian — cubic in active point count, so worst-case BA hit **7.4 s** at ~800 points. `bundle_adjust_schur` already exists in `kornia-rs` and is the standard fix.

## Measured impact (EuRoC MH_01, 500 frames, single thread)

|                | Before (dense LU) | After (Schur) | Δ |
|---|---|---|---|
| LBA mean       | 951 ms            | 4.1 ms        | ~232× |
| LBA p95        | 3367 ms           | 10.4 ms       | ~324× |
| LBA max        | 7409 ms           | 13.7 ms       | ~540× |
| Total wall     | 110.3 s           | 8.1 s         | 13.5× |
| LBA share      | 89.7%             | 5.0%          | — |
| KFs / active MPs | 104 / 1599      | 99 / 1384     | ~95% |

End-to-end goes from clearly-not-realtime to mean 16 ms / frame (~60 fps single-threaded). Removes the immediate motivation for threading the mapping stage.

## Caveats to verify
- KF / active-MP counts dropped ~5% (104 → 99 KFs, 1599 → 1384 active MPs). Likely convergence-path differences between the two solvers on the same problem rather than a correctness bug — Schur is mathematically equivalent given identical inputs and convergence — but worth confirming against the parity reference.
- `bundle_adjust_schur` honors `fixed_pose` / `fixed_point` and robust kernels; the two call sites use Huber (init) and default L2 (local) which are both supported.

## Test plan
- [x] `cargo build -p orb_slam --release` (clean)
- [x] Run `orb_slam` on EuRoC MH_01 with `--max-frames 500`; verify the trajectory completes, KF count is in the same ballpark (99 vs 104), and active map size is healthy (1384 active MPs, mean obs/MP ≈ 17)
- [ ] Compare trajectory against the parity reference (next PR or follow-up)