### PR TITLE
chore: drop unused dep and dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,6 @@ dependencies = [
  "kornia-algebra",
  "kornia-image",
  "kornia-imgproc",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/kornia-slam/Cargo.toml
+++ b/crates/kornia-slam/Cargo.toml
@@ -9,4 +9,3 @@ kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
-thiserror = "2"

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -519,11 +519,6 @@ impl Map {
         &mut self.map_points
     }
 
-    /// Returns a mutable reference to all keyframes.
-    pub fn keyframes_mut(&mut self) -> &mut Vec<Keyframe> {
-        &mut self.keyframes
-    }
-
     /// Returns indices of non-culled map points that project inside the image frustum.
     pub fn map_points_in_frustum(
         &self,

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -73,11 +73,6 @@ impl Pipeline {
             .and_then(|ki| self.map.get_keyframe(ki).map(|kf| kf.frame.idx))
     }
 
-    /// Returns the total number of persistent map points (including culled).
-    pub fn num_map_points(&self) -> usize {
-        self.map.map_points().len()
-    }
-
     /// Returns the number of active (non-culled) map points.
     pub fn num_active_map_points(&self) -> usize {
         self.map.num_active_map_points()


### PR DESCRIPTION
## Summary
- Drop unused `thiserror` dep from `kornia-slam` (no `thiserror::` or `derive(Error)` in the crate)
- Remove dead `Pipeline::num_map_points` (compiler-flagged `dead_code`; `main.rs` uses `num_active_map_points` / `map_points().len()`)
- Remove unused `Map::keyframes_mut` (no callers in tracked code)

Net: -12 lines, no behavior change.

## Test plan
- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` passes