### PR TITLE
feat(orb_slam): make rerun optional, add tui with live BEV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1329,6 +1329,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,7 +1506,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1528,9 +1543,23 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1572,7 +1601,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1807,6 +1836,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -1889,8 +1934,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1907,12 +1962,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -2571,7 +2650,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3034,7 +3113,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3150,7 +3229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3981,6 +4060,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4433,9 +4514,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.3",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -4471,6 +4561,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4512,6 +4615,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4539,7 +4651,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5019,6 +5131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8a05e3879b317b1b6dbf353e5bba7062bedcc59815267bb23eaa0c576cebf0"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5569,7 +5690,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6205,6 +6326,7 @@ name = "orb_slam"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "crossterm 0.28.1",
  "kornia-3d",
  "kornia-algebra",
  "kornia-image",
@@ -6212,6 +6334,8 @@ dependencies = [
  "kornia-io",
  "kornia-slam",
  "kornia-tensor",
+ "libc",
+ "ratatui",
  "rerun",
  "serde",
  "serde_yaml",
@@ -7044,6 +7168,27 @@ name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -9457,7 +9602,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9815,6 +9960,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10010,7 +10176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10233,7 +10399,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10814,7 +10980,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10836,6 +11002,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10843,9 +11020,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -11030,7 +11207,7 @@ dependencies = [
  "http-cache-reqwest",
  "image",
  "log",
- "lru",
+ "lru 0.16.3",
  "reqwest",
  "reqwest-middleware",
  "thiserror 2.0.18",
@@ -11587,7 +11764,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -14,7 +14,15 @@ kornia-image = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-io = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-tensor = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
-rerun = "0.29.2"
+rerun = { version = "0.29.2", optional = true }
+ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.28", optional = true }
+libc = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2"
+
+[features]
+default = ["viz"]
+viz = ["dep:rerun"]
+tui = ["dep:ratatui", "dep:crossterm", "dep:libc"]

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -11,6 +11,8 @@ mod config;
 #[path = "../../common/datasets/mod.rs"]
 mod datasets;
 mod pipeline;
+#[cfg(feature = "tui")]
+mod tui;
 mod utils;
 
 use config::PipelineConfig;
@@ -22,10 +24,11 @@ use pipeline::Pipeline;
 
 use datasets::EurocDataset;
 
+#[cfg(feature = "viz")]
 use utils::{
     log_camera_to_rerun, log_frame_to_rerun, log_map_points_to_rerun, log_trajectory_to_rerun,
-    trajectory_point_from_pose,
 };
+use utils::trajectory_point_from_pose;
 
 /// CLI arguments.
 #[derive(argh::FromArgs)]
@@ -39,9 +42,15 @@ struct Args {
     #[argh(option, default = "0")]
     max_frames: usize,
 
-    /// spawn a Rerun viewer and stream to it
+    /// spawn a Rerun viewer and stream to it (requires `--features viz`)
     #[argh(switch)]
+    #[cfg(feature = "viz")]
     rerun_stream: bool,
+
+    /// render a terminal UI with a live BEV view (requires `--features tui`)
+    #[argh(switch)]
+    #[cfg(feature = "tui")]
+    tui: bool,
 
     /// skip this many initial frames
     #[argh(option, default = "0")]
@@ -50,6 +59,17 @@ struct Args {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
+
+    #[cfg(all(feature = "tui", feature = "viz"))]
+    if args.tui && args.rerun_stream {
+        eprintln!("--tui and --rerun-stream are mutually exclusive");
+        std::process::exit(2);
+    }
+
+    #[cfg(feature = "tui")]
+    let tui_active = args.tui;
+    #[cfg(not(feature = "tui"))]
+    let tui_active = false;
 
     // ── Dataset ────────────────────────────────────────────────────────────
     let dataset = EurocDataset::open(&args.data)?;
@@ -60,12 +80,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         samples.len() - args.start_frame
     };
-    eprintln!(
-        "Dataset: {} frames (processing {}..{})",
-        samples.len(),
-        args.start_frame,
-        args.start_frame + n_frames
-    );
+    if !tui_active {
+        eprintln!(
+            "Dataset: {} frames (processing {}..{})",
+            samples.len(),
+            args.start_frame,
+            args.start_frame + n_frames
+        );
+    }
 
     // ── Camera (from EuRoC cam0 sensor.yaml) ───────────────────────────────
     let camera = dataset.camera();
@@ -80,11 +102,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut system = Pipeline::new(camera.clone(), PipelineConfig::default());
 
     // ── Rerun ──────────────────────────────────────────────────────────────
+    #[cfg(feature = "viz")]
     let rec = if args.rerun_stream {
         let r = rerun::RecordingStreamBuilder::new("orb_slam").spawn()?;
         r.log("/", &rerun::ViewCoordinates::RIGHT_HAND_Y_DOWN())?;
         r.log("world/camera", &rerun::ViewCoordinates::RDF())?;
         Some(r)
+    } else {
+        None
+    };
+
+    // ── TUI ────────────────────────────────────────────────────────────────
+    #[cfg(feature = "tui")]
+    let mut tui_state = if args.tui {
+        let (term, guard) =
+            tui::setup_terminal(std::path::Path::new("tui_stderr.log"))?;
+        let app = tui::TuiApp::new(n_frames);
+        Some((term, app, guard))
     } else {
         None
     };
@@ -106,6 +140,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Extract ORB features.
         let features = detector.detect_and_extract_u8(&gray_u8)?;
+        #[cfg(feature = "viz")]
         if let Some(ref rec) = rec {
             log_frame_to_rerun(rec, &gray_u8, &features.keypoints_xy);
         }
@@ -137,21 +172,55 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let map_point_count = system.num_active_map_points();
 
         // Status line.
-        let status_line = format!(
-            "[{idx:>5}] {:?}  kf={:<4} pts={:<5} {frame_ms:>6.1}ms",
-            result.status, keyframe_idx, map_point_count,
-        );
-        eprintln!("{status_line}");
+        if !tui_active {
+            let status_line = format!(
+                "[{idx:>5}] {:?}  kf={:<4} pts={:<5} {frame_ms:>6.1}ms",
+                result.status, keyframe_idx, map_point_count,
+            );
+            eprintln!("{status_line}");
+        }
 
         // Collect trajectory.
         trajectory.push(trajectory_point_from_pose(&result.pose_world_to_cam));
 
         // Rerun logging.
+        #[cfg(feature = "viz")]
         if let Some(ref rec) = rec {
             log_trajectory_to_rerun(rec, &trajectory);
             log_camera_to_rerun(rec, &result.pose_world_to_cam, &camera, image_size);
             log_map_points_to_rerun(rec, system.map_points());
         }
+
+        // TUI render.
+        #[cfg(feature = "tui")]
+        if let Some((term, app, _guard)) = tui_state.as_mut() {
+            app.frame_idx = idx;
+            app.n_frames = n_frames;
+            app.frame_ms = frame_ms;
+            app.status = match result.status {
+                kornia_slam::TrackingStatus::Tracked => tui::TuiStatus::Tracked,
+                kornia_slam::TrackingStatus::KeyframeAccepted => {
+                    tui::TuiStatus::KeyframeAccepted
+                }
+                kornia_slam::TrackingStatus::Skipped => tui::TuiStatus::Skipped,
+            };
+            app.kf_idx = keyframe_idx;
+            app.n_active_mp = map_point_count;
+            let n_so_far = (i + 1) as f64;
+            app.mean_ms = app.mean_ms + (frame_ms - app.mean_ms) / n_so_far;
+            app.update_pose(&result.pose_world_to_cam);
+            app.draw(term)?;
+            if tui::poll_quit()? {
+                break;
+            }
+        }
+    }
+
+    // Restore terminal before printing the final summary.
+    // The StderrGuard's Drop restores stderr after the alternate screen leaves.
+    #[cfg(feature = "tui")]
+    if let Some((mut term, _, _guard)) = tui_state.take() {
+        tui::restore_terminal(&mut term)?;
     }
 
     let total_pts = system.map_points().len();

--- a/examples/orb_slam/src/tui.rs
+++ b/examples/orb_slam/src/tui.rs
@@ -1,0 +1,598 @@
+//! Ratatui TUI for the ORB-SLAM example.
+//!
+//! Three panels:
+//!   * top status bar (frame counters, status, FPS)
+//!   * camera image (grayscale half-block render of the latest frame)
+//!   * bird's-eye view of the trajectory + camera heading (X right, Z forward,
+//!     Y-down gravity dropped)
+
+use std::io::{self, Stdout};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crossterm::ExecutableCommand;
+use crossterm::cursor;
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use kornia_3d::pose::Pose3d;
+use kornia_algebra::Vec3F64;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::Marker;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::canvas::{Canvas, Line as CanvasLine};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+pub type Tui = Terminal<CrosstermBackend<Stdout>>;
+
+// ── Color palette ────────────────────────────────────────────────────────
+
+const C_BORDER: Color = Color::Rgb(80, 120, 180);
+const C_TITLE: Color = Color::Rgb(140, 220, 255);
+const C_LABEL: Color = Color::Rgb(170, 170, 180);
+const C_VALUE: Color = Color::Rgb(240, 240, 240);
+const C_TRAJ: Color = Color::Rgb(80, 200, 255);
+const C_CAMERA: Color = Color::Rgb(255, 215, 60);
+const C_TRACKED: Color = Color::Rgb(120, 220, 100);
+const C_KEYFRAME: Color = Color::Rgb(255, 110, 220);
+const C_SKIPPED: Color = Color::Rgb(220, 180, 60);
+const C_KEY: Color = Color::Rgb(255, 215, 60);
+const C_SYS: Color = Color::Rgb(200, 160, 240);
+
+/// Tracking status, mirrored from `kornia_slam::TrackingStatus` so the TUI
+/// module doesn't import library types in its widget code.
+#[derive(Clone, Copy)]
+pub enum TuiStatus {
+    Tracked,
+    KeyframeAccepted,
+    Skipped,
+}
+
+impl TuiStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Tracked => "Tracked",
+            Self::KeyframeAccepted => "KeyframeAccepted",
+            Self::Skipped => "Skipped",
+        }
+    }
+    fn color(self) -> Color {
+        match self {
+            Self::Tracked => C_TRACKED,
+            Self::KeyframeAccepted => C_KEYFRAME,
+            Self::Skipped => C_SKIPPED,
+        }
+    }
+}
+
+// ── Stderr redirect ──────────────────────────────────────────────────────
+
+/// RAII guard that redirects process stderr to a file via `dup2` while the
+/// TUI is active, and restores the original on drop.
+///
+/// The SLAM pipeline emits diagnostic `eprintln!` lines that would otherwise
+/// corrupt the alternate-screen canvas.
+pub struct StderrGuard {
+    saved_fd: libc::c_int,
+}
+
+impl StderrGuard {
+    pub fn redirect_to(path: &Path) -> io::Result<Self> {
+        use std::os::unix::io::AsRawFd;
+        let saved_fd = unsafe { libc::dup(libc::STDERR_FILENO) };
+        if saved_fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let file = match std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                unsafe { libc::close(saved_fd) };
+                return Err(e);
+            }
+        };
+        let ret = unsafe { libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(saved_fd) };
+            return Err(err);
+        }
+        Ok(Self { saved_fd })
+    }
+}
+
+impl Drop for StderrGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::dup2(self.saved_fd, libc::STDERR_FILENO);
+            libc::close(self.saved_fd);
+        }
+    }
+}
+
+pub fn setup_terminal(stderr_log: &Path) -> io::Result<(Tui, StderrGuard)> {
+    let guard = StderrGuard::redirect_to(stderr_log)?;
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    stdout.execute(EnterAlternateScreen)?;
+    stdout.execute(cursor::Hide)?;
+    let terminal = Terminal::new(CrosstermBackend::new(stdout))?;
+    Ok((terminal, guard))
+}
+
+pub fn restore_terminal(terminal: &mut Tui) -> io::Result<()> {
+    disable_raw_mode()?;
+    let backend = terminal.backend_mut();
+    backend.execute(LeaveAlternateScreen)?;
+    backend.execute(cursor::Show)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+// ── System stats sampler ─────────────────────────────────────────────────
+
+#[derive(Default, Clone, Copy)]
+pub struct SysStats {
+    pub rss_mb: f64,
+    pub peak_rss_mb: f64,
+    pub threads: u32,
+    pub cpu_pct: f64,
+}
+
+/// Reads `/proc/self/status` + `getrusage` and caches the result so we don't
+/// re-hit the kernel on every frame. CPU% is computed as the delta of
+/// utime+stime since the last full sample, over wall-clock delta.
+pub struct SysStatsSampler {
+    last_cpu_us: i64,
+    last_wall: Option<Instant>,
+    cached: Option<(Instant, SysStats)>,
+}
+
+impl Default for SysStatsSampler {
+    fn default() -> Self {
+        Self {
+            last_cpu_us: 0,
+            last_wall: None,
+            cached: None,
+        }
+    }
+}
+
+impl SysStatsSampler {
+    pub fn sample(&mut self) -> SysStats {
+        if let Some((t, s)) = self.cached {
+            if t.elapsed() < Duration::from_millis(250) {
+                return s;
+            }
+        }
+        let (rss_kb, peak_rss_kb, threads) = read_proc_status();
+        let now_us = getrusage_total_us();
+        let now_wall = Instant::now();
+        let cpu_pct = match (self.last_wall, self.last_cpu_us) {
+            (Some(prev_wall), prev_cpu) if prev_cpu > 0 => {
+                let wall_us = now_wall.duration_since(prev_wall).as_micros() as i64;
+                if wall_us > 0 {
+                    let cpu_us = now_us - prev_cpu;
+                    (100.0 * cpu_us as f64 / wall_us as f64).max(0.0)
+                } else {
+                    0.0
+                }
+            }
+            _ => 0.0,
+        };
+        self.last_cpu_us = now_us;
+        self.last_wall = Some(now_wall);
+        let stats = SysStats {
+            rss_mb: rss_kb as f64 / 1024.0,
+            peak_rss_mb: peak_rss_kb as f64 / 1024.0,
+            threads,
+            cpu_pct,
+        };
+        self.cached = Some((now_wall, stats));
+        stats
+    }
+}
+
+fn read_proc_status() -> (u64, u64, u32) {
+    let s = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    let mut rss = 0u64;
+    let mut peak = 0u64;
+    let mut threads = 0u32;
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            rss = parse_kb_field(rest);
+        } else if let Some(rest) = line.strip_prefix("VmHWM:") {
+            peak = parse_kb_field(rest);
+        } else if let Some(rest) = line.strip_prefix("Threads:") {
+            threads = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    (rss, peak, threads)
+}
+
+fn parse_kb_field(rest: &str) -> u64 {
+    rest.split_whitespace()
+        .next()
+        .and_then(|t| t.parse().ok())
+        .unwrap_or(0)
+}
+
+fn getrusage_total_us() -> i64 {
+    unsafe {
+        let mut ru: libc::rusage = std::mem::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, &mut ru) == 0 {
+            let u = ru.ru_utime.tv_sec as i64 * 1_000_000 + ru.ru_utime.tv_usec as i64;
+            let s = ru.ru_stime.tv_sec as i64 * 1_000_000 + ru.ru_stime.tv_usec as i64;
+            u + s
+        } else {
+            0
+        }
+    }
+}
+
+// ── App state ────────────────────────────────────────────────────────────
+
+/// Live view state shared between the SLAM loop and the renderer.
+pub struct TuiApp {
+    /// BEV trajectory (world X, Z).
+    trajectory: Vec<[f64; 2]>,
+    /// Current camera position in BEV.
+    current: Option<[f64; 2]>,
+    /// Current camera forward direction in BEV (unit vector).
+    forward: Option<[f64; 2]>,
+    /// Full 3D camera-in-world position (most recent frame).
+    pos_world: Option<Vec3F64>,
+    /// Full 3D camera-in-world forward axis (most recent frame).
+    fwd_world: Option<Vec3F64>,
+    /// Previous-frame 3D position, used to compute per-frame displacement.
+    prev_pos_world: Option<Vec3F64>,
+    /// Magnitude of the last frame-to-frame displacement (metres / frame).
+    last_step_m: f64,
+    /// Cumulative path length (sum of per-frame displacements).
+    path_length_m: f64,
+    pub frame_idx: usize,
+    pub n_frames: usize,
+    pub status: TuiStatus,
+    pub kf_idx: usize,
+    pub n_active_mp: usize,
+    pub frame_ms: f64,
+    pub mean_ms: f64,
+    sys: SysStatsSampler,
+}
+
+impl TuiApp {
+    pub fn new(n_frames: usize) -> Self {
+        Self {
+            trajectory: Vec::with_capacity(n_frames),
+            current: None,
+            forward: None,
+            pos_world: None,
+            fwd_world: None,
+            prev_pos_world: None,
+            last_step_m: 0.0,
+            path_length_m: 0.0,
+            frame_idx: 0,
+            n_frames,
+            status: TuiStatus::Skipped,
+            kf_idx: 0,
+            n_active_mp: 0,
+            frame_ms: 0.0,
+            mean_ms: 0.0,
+            sys: SysStatsSampler::default(),
+        }
+    }
+
+    /// Update from the latest world-to-camera pose.
+    ///
+    /// Camera-in-world is `pose.inverse()`; its translation is the camera
+    /// position, and `R^T * [0,0,1]` is the camera forward axis in world
+    /// coordinates. We drop Y (gravity) to get the BEV.
+    pub fn update_pose(&mut self, pose_world_to_cam: &Pose3d) {
+        let cam_to_world = pose_world_to_cam.inverse();
+        let t = cam_to_world.translation;
+        let f_world = cam_to_world.rotation * Vec3F64::new(0.0, 0.0, 1.0);
+
+        // BEV projection (drop Y).
+        let pos_bev = [t.x, t.z];
+        self.trajectory.push(pos_bev);
+        self.current = Some(pos_bev);
+        let len_xz = (f_world.x * f_world.x + f_world.z * f_world.z).sqrt();
+        if len_xz > 1e-9 {
+            self.forward = Some([f_world.x / len_xz, f_world.z / len_xz]);
+        }
+
+        // Per-frame displacement + cumulative path length.
+        if let Some(prev) = self.prev_pos_world {
+            let dx = t.x - prev.x;
+            let dy = t.y - prev.y;
+            let dz = t.z - prev.z;
+            self.last_step_m = (dx * dx + dy * dy + dz * dz).sqrt();
+            self.path_length_m += self.last_step_m;
+        }
+        self.prev_pos_world = Some(t);
+        self.pos_world = Some(t);
+        self.fwd_world = Some(f_world);
+    }
+
+    pub fn draw(&mut self, terminal: &mut Tui) -> io::Result<()> {
+        let sys = self.sys.sample();
+        terminal.draw(|frame| {
+            let chunks = Layout::vertical([
+                Constraint::Length(3),
+                Constraint::Min(0),
+                Constraint::Length(3),
+                Constraint::Length(3),
+                Constraint::Length(1),
+            ])
+            .split(frame.area());
+
+            frame.render_widget(self.header(), chunks[0]);
+            self.render_bev(frame, chunks[1]);
+            frame.render_widget(self.camera_panel(), chunks[2]);
+            frame.render_widget(sys_panel(sys), chunks[3]);
+            frame.render_widget(self.hint(), chunks[4]);
+        })?;
+        Ok(())
+    }
+
+    fn header(&self) -> Paragraph<'_> {
+        let instant_fps = if self.frame_ms > 0.0 {
+            1000.0 / self.frame_ms
+        } else {
+            0.0
+        };
+        let mean_fps = if self.mean_ms > 0.0 {
+            1000.0 / self.mean_ms
+        } else {
+            0.0
+        };
+        let bold_value = Style::default().fg(C_VALUE).add_modifier(Modifier::BOLD);
+        let label = Style::default().fg(C_LABEL);
+        let line = Line::from(vec![
+            Span::styled(" frame ", label),
+            Span::styled(format!("{:>4}/{:<4}", self.frame_idx, self.n_frames), bold_value),
+            Span::styled("  status: ", label),
+            Span::styled(
+                format!("{:<16}", self.status.label()),
+                Style::default()
+                    .fg(self.status.color())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("kf=", label),
+            Span::styled(format!("{:<5}", self.kf_idx), Style::default().fg(C_VALUE)),
+            Span::styled(" mp=", label),
+            Span::styled(format!("{:<5}", self.n_active_mp), Style::default().fg(C_VALUE)),
+            Span::styled("  ", label),
+            Span::styled(format!("{:>5.1} ms", self.frame_ms), bold_value),
+            Span::styled(format!(" ({:>5.1} fps)", instant_fps), label),
+            Span::styled("  mean ", label),
+            Span::styled(format!("{:>5.1} ms", self.mean_ms), Style::default().fg(C_VALUE)),
+            Span::styled(format!(" ({:>5.1} fps)", mean_fps), label),
+        ]);
+        Paragraph::new(line).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(C_BORDER))
+                .title(Span::styled(
+                    " orb_slam ",
+                    Style::default().fg(C_TITLE).add_modifier(Modifier::BOLD),
+                )),
+        )
+    }
+
+    fn render_bev(&self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        let inner_w = area.width.saturating_sub(2);
+        let inner_h = area.height.saturating_sub(2);
+        let (xmin, xmax, zmin, zmax) = self.viewport_bounds(inner_w, inner_h);
+        let traj = self.trajectory.clone();
+        let camera = self.camera_triangle(xmax - xmin, zmax - zmin);
+
+        let canvas = Canvas::default()
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(C_BORDER))
+                    .title(Span::styled(
+                        " BEV (X right / Z forward) ",
+                        Style::default().fg(C_TITLE).add_modifier(Modifier::BOLD),
+                    )),
+            )
+            .marker(Marker::Braille)
+            .x_bounds([xmin, xmax])
+            .y_bounds([zmin, zmax])
+            .paint(move |ctx| {
+                for w in traj.windows(2) {
+                    ctx.draw(&CanvasLine {
+                        x1: w[0][0],
+                        y1: w[0][1],
+                        x2: w[1][0],
+                        y2: w[1][1],
+                        color: C_TRAJ,
+                    });
+                }
+                if let Some([apex, left, right]) = camera {
+                    for (p, q) in [(apex, left), (apex, right), (left, right)] {
+                        ctx.draw(&CanvasLine {
+                            x1: p[0],
+                            y1: p[1],
+                            x2: q[0],
+                            y2: q[1],
+                            color: C_CAMERA,
+                        });
+                    }
+                }
+            });
+        frame.render_widget(canvas, area);
+    }
+
+    fn camera_panel(&self) -> Paragraph<'_> {
+        let lbl = Style::default().fg(C_LABEL);
+        let val = Style::default().fg(C_CAMERA).add_modifier(Modifier::BOLD);
+        let (pos_str, heading_str, elev_str) = match (self.pos_world, self.fwd_world) {
+            (Some(p), Some(f)) => {
+                // Heading: angle of the forward axis in the world X/Z plane,
+                // measured from +Z (forward) toward +X (right). Range (-180°, 180°].
+                let heading = f.x.atan2(f.z).to_degrees();
+                // Elevation: angle of the forward axis above the horizontal
+                // plane. Y is down, so "up" is -Y. Range [-90°, 90°].
+                let horiz = (f.x * f.x + f.z * f.z).sqrt();
+                let elevation = (-f.y).atan2(horiz).to_degrees();
+                (
+                    format!("[{:>6.2}, {:>6.2}, {:>6.2}] m", p.x, p.y, p.z),
+                    format!("{:>+7.1}°", heading),
+                    format!("{:>+5.1}°", elevation),
+                )
+            }
+            _ => ("—".into(), "—".into(), "—".into()),
+        };
+        let line = Line::from(vec![
+            Span::styled(" pos ", lbl),
+            Span::styled(pos_str, val),
+            Span::styled("   heading ", lbl),
+            Span::styled(heading_str, val),
+            Span::styled("   elev ", lbl),
+            Span::styled(elev_str, val),
+            Span::styled("   step ", lbl),
+            Span::styled(format!("{:>5.3} m", self.last_step_m), val),
+            Span::styled("   path ", lbl),
+            Span::styled(format!("{:>6.2} m", self.path_length_m), val),
+        ]);
+        Paragraph::new(line).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(C_BORDER))
+                .title(Span::styled(
+                    " camera ",
+                    Style::default().fg(C_TITLE).add_modifier(Modifier::BOLD),
+                )),
+        )
+    }
+
+    fn hint(&self) -> Paragraph<'static> {
+        let key = Style::default().fg(C_KEY).add_modifier(Modifier::BOLD);
+        let lbl = Style::default().fg(C_LABEL);
+        Paragraph::new(Line::from(vec![
+            Span::styled(" q", key),
+            Span::styled(" quit  ", lbl),
+            Span::styled("Esc", key),
+            Span::styled(" quit  ", lbl),
+            Span::styled("Ctrl-C", key),
+            Span::styled(" quit", lbl),
+        ]))
+    }
+
+    /// Auto-fit bounds with padding + aspect correction.
+    ///
+    /// Braille gives 2×4 sub-pixels per char, and terminal cells are roughly
+    /// 1:2 (W:H), so per-sub-pixel both axes are ≈square. Effective resolution
+    /// of the BEV panel is therefore `(cells_w * 2) × (cells_h * 4)` square
+    /// pixels — we match the world-span aspect to this so circles look round.
+    fn viewport_bounds(&self, cells_w: u16, cells_h: u16) -> (f64, f64, f64, f64) {
+        let (mut xmin, mut xmax, mut zmin, mut zmax) = if self.trajectory.is_empty() {
+            (-1.0, 1.0, -1.0, 1.0)
+        } else {
+            let (mut a, mut b, mut c, mut d) = (
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+            );
+            for p in &self.trajectory {
+                a = a.min(p[0]);
+                b = b.max(p[0]);
+                c = c.min(p[1]);
+                d = d.max(p[1]);
+            }
+            (a, b, c, d)
+        };
+
+        let pad_x = ((xmax - xmin) * 0.15).max(0.5);
+        let pad_z = ((zmax - zmin) * 0.15).max(0.5);
+        xmin -= pad_x;
+        xmax += pad_x;
+        zmin -= pad_z;
+        zmax += pad_z;
+
+        let pixel_w = (cells_w as f64) * 2.0;
+        let pixel_h = (cells_h as f64) * 4.0;
+        if pixel_w > 0.0 && pixel_h > 0.0 {
+            let span_x = xmax - xmin;
+            let span_z = zmax - zmin;
+            let aspect_data = span_x / span_z;
+            let aspect_pixels = pixel_w / pixel_h;
+            if aspect_data > aspect_pixels {
+                let new_span_z = span_x / aspect_pixels;
+                let cz = 0.5 * (zmin + zmax);
+                zmin = cz - 0.5 * new_span_z;
+                zmax = cz + 0.5 * new_span_z;
+            } else {
+                let new_span_x = span_z * aspect_pixels;
+                let cx = 0.5 * (xmin + xmax);
+                xmin = cx - 0.5 * new_span_x;
+                xmax = cx + 0.5 * new_span_x;
+            }
+        }
+
+        (xmin, xmax, zmin, zmax)
+    }
+
+    /// Isoceles triangle with apex along the camera forward axis.
+    fn camera_triangle(&self, span_x: f64, span_z: f64) -> Option<[[f64; 2]; 3]> {
+        let pos = self.current?;
+        let fwd = self.forward?;
+        let l = span_x.max(span_z) * 0.03;
+        let w = l * 0.5;
+        let perp = [-fwd[1], fwd[0]];
+        let apex = [pos[0] + fwd[0] * l, pos[1] + fwd[1] * l];
+        let left = [pos[0] + perp[0] * w, pos[1] + perp[1] * w];
+        let right = [pos[0] - perp[0] * w, pos[1] - perp[1] * w];
+        Some([apex, left, right])
+    }
+}
+
+fn sys_panel(s: SysStats) -> Paragraph<'static> {
+    let label = Style::default().fg(C_LABEL);
+    let value = Style::default().fg(C_SYS).add_modifier(Modifier::BOLD);
+    let line = Line::from(vec![
+        Span::styled(" ram ", label),
+        Span::styled(format!("{:>6.1} MB", s.rss_mb), value),
+        Span::styled("   peak ", label),
+        Span::styled(format!("{:>6.1} MB", s.peak_rss_mb), value),
+        Span::styled("   threads ", label),
+        Span::styled(format!("{}", s.threads), value),
+        Span::styled("   cpu ", label),
+        Span::styled(format!("{:>5.1}%", s.cpu_pct), value),
+    ]);
+    Paragraph::new(line).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(C_BORDER))
+            .title(Span::styled(
+                " system ",
+                Style::default().fg(C_TITLE).add_modifier(Modifier::BOLD),
+            )),
+    )
+}
+
+/// Non-blocking poll: returns true if the user pressed q / Esc / Ctrl-C.
+pub fn poll_quit() -> io::Result<bool> {
+    if event::poll(Duration::from_millis(0))? {
+        if let Event::Key(KeyEvent {
+            code, modifiers, ..
+        }) = event::read()?
+        {
+            return Ok(matches!(code, KeyCode::Char('q') | KeyCode::Esc)
+                || (modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(code, KeyCode::Char('c'))));
+        }
+    }
+    Ok(false)
+}

--- a/examples/orb_slam/src/utils.rs
+++ b/examples/orb_slam/src/utils.rs
@@ -1,14 +1,21 @@
 //! Minimal Rerun visualization helpers for the ORB-SLAM example.
 
-use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
+#[cfg(feature = "viz")]
+use kornia_3d::camera::PinholeCamera;
+#[cfg(feature = "viz")]
 use kornia_algebra::Mat3F64;
+#[cfg(feature = "viz")]
 use kornia_image::{Image, ImageSize};
+#[cfg(feature = "viz")]
 use kornia_slam::map::MapPoint;
+#[cfg(feature = "viz")]
 use kornia_tensor::CpuAllocator;
 
+#[cfg(feature = "viz")]
 const CAMERA_IMAGE_PLANE_DISTANCE: f32 = 0.15;
 
+#[cfg(feature = "viz")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct CameraVisualizationSpec {
     translation: [f32; 3],
@@ -19,6 +26,7 @@ struct CameraVisualizationSpec {
     image_plane_distance: f32,
 }
 
+#[cfg(feature = "viz")]
 pub fn log_frame_to_rerun(
     rec: &rerun::RecordingStream,
     image: &Image<u8, 1, CpuAllocator>,
@@ -37,11 +45,13 @@ pub fn log_frame_to_rerun(
 }
 
 /// Convert feature keypoints to the point format expected by Rerun.
+#[cfg(feature = "viz")]
 pub fn keypoints_xy_to_rerun_points(keypoints_xy: &[[f32; 2]]) -> Vec<[f32; 2]> {
     keypoints_xy.to_vec()
 }
 
 /// Log the estimated trajectory as a growing 3D line strip.
+#[cfg(feature = "viz")]
 pub fn log_trajectory_to_rerun(rec: &rerun::RecordingStream, trajectory: &[[f32; 3]]) {
     if trajectory.len() >= 2 {
         rec.log("world/trajectory", &rerun::LineStrips3D::new([trajectory]))
@@ -50,6 +60,7 @@ pub fn log_trajectory_to_rerun(rec: &rerun::RecordingStream, trajectory: &[[f32;
 }
 
 /// Log the current camera frustum in world coordinates.
+#[cfg(feature = "viz")]
 pub fn log_camera_to_rerun(
     rec: &rerun::RecordingStream,
     pose_world_to_cam: &Pose3d,
@@ -76,6 +87,7 @@ pub fn log_camera_to_rerun(
 }
 
 /// Log active map points as a 3D point cloud.
+#[cfg(feature = "viz")]
 pub fn log_map_points_to_rerun(rec: &rerun::RecordingStream, map_points: &[MapPoint]) {
     let (positions, colors): (Vec<_>, Vec<_>) = map_points
         .iter()
@@ -112,6 +124,7 @@ pub fn trajectory_point_from_pose(pose_world_to_cam: &Pose3d) -> [f32; 3] {
     ]
 }
 
+#[cfg(feature = "viz")]
 fn camera_visualization_spec(
     pose_world_to_cam: &Pose3d,
     camera: &PinholeCamera,
@@ -131,6 +144,7 @@ fn camera_visualization_spec(
     }
 }
 
+#[cfg(feature = "viz")]
 fn quat_xyzw_from_matrix(r: &Mat3F64) -> (f64, f64, f64, f64) {
     let trace = r.x_axis.x + r.y_axis.y + r.z_axis.z;
 
@@ -168,8 +182,9 @@ fn quat_xyzw_from_matrix(r: &Mat3F64) -> (f64, f64, f64, f64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_algebra::Vec3F64;
+    use kornia_algebra::{Mat3F64, Vec3F64};
 
+    #[cfg(feature = "viz")]
     #[test]
     fn keypoints_xy_to_rerun_points_preserves_xy_order() {
         let rerun_points = keypoints_xy_to_rerun_points(&[[10.0, 20.0], [30.5, 40.5]]);
@@ -185,6 +200,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "viz")]
     #[test]
     fn camera_visualization_spec_uses_camera_to_world_pose() {
         let pose_world_to_cam = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(1.0, -2.0, 3.0));


### PR DESCRIPTION
## Summary
Two cargo features on the `orb_slam` example, both behind the example so the library crate is untouched.

### `viz` (default on) — gates rerun
`rerun` is now optional; the default-on `viz` feature pulls it in. Builds with `--no-default-features` skip the rerun → datafusion / arrow / sqlparser / chrono-tz chain entirely.

| Build | Wall (clean release) | Binary |
|---|---|---|
| `--no-default-features` (lean) | 37 s | 3.1 MB |
| default (`viz`, rerun on) | 5m 42s | 20.6 MB |

### `tui` (new) — live Ratatui terminal UI
`cargo run --release -p orb_slam --no-default-features --features tui -- --data <euroc> --tui` launches an interactive view with:

- **Status header** — frame X/Y, tracking status (colored by kind), kf/mp counts, current ms + fps, mean ms + fps
- **BEV panel** — cyan trajectory polyline + gold camera triangle showing heading; Braille marker, aspect-corrected viewport (drops world Y per EuRoC's Y-down convention)
- **Camera panel** — 3D position `[x, y, z]`, heading (yaw around world Y), elevation (pitch above horizontal), per-frame step magnitude, cumulative path length
- **System panel** — RSS, peak RSS, threads, process CPU% via `/proc/self/status` + `getrusage` (250 ms sample throttle)
- `q` / `Esc` / `Ctrl-C` quit

Pipeline `eprintln!` diagnostics get redirected to `tui_stderr.log` via `dup2` while the TUI owns the terminal, restored on exit by an RAII guard. `--tui` and `--rerun-stream` are mutually exclusive.

Build cost of `tui` on top of the lean baseline: ~6 s wall, ~500 KB binary.

## Test plan
- [x] `cargo build --workspace --all-targets` clean (default)
- [x] `cargo build -p orb_slam --no-default-features` clean (lean)
- [x] `cargo build -p orb_slam --no-default-features --features tui` clean (tui only)
- [x] `cargo build -p orb_slam --features tui` clean (viz + tui)
- [x] `cargo test -p orb_slam` and `cargo test -p orb_slam --no-default-features` pass
- [ ] Run interactively on EuRoC MH_01_easy: verify trajectory + camera heading + stats panels render and `q` cleanly restores the terminal