### PR TITLE
feat(orb_slam): TUI by default + in-TUI debug panel + webcam source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures",
 ]
@@ -150,7 +150,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
@@ -279,7 +279,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -741,7 +741,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.4",
  "event-listener",
  "futures-lite",
  "rustix 1.1.4",
@@ -767,7 +767,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomic-waker",
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-core",
  "futures-io",
  "rustix 1.1.4",
@@ -1142,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object",
@@ -1214,6 +1214,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
 ]
 
 [[package]]
@@ -1310,7 +1333,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq 0.4.2",
  "cpufeatures",
 ]
@@ -1666,6 +1689,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1806,6 +1835,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
 
 [[package]]
+name = "cocoa"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c49e86fc36d5704151f5996b7b3795385f50ce09e3be0f47a0cfde869681cf8"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.7.0",
+ "core-graphics 0.19.2",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
+ "objc",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,7 +1936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -2007,11 +2064,21 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -2021,15 +2088,33 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.7.0",
+ "foreign-types 0.3.2",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics"
@@ -2067,6 +2152,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-media-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273bf3fc5bf51fd06a7766a84788c1540b6527130a0bce39e00567d6ab9f31f1"
+dependencies = [
+ "cfg-if 0.1.10",
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-video-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+dependencies = [
+ "cfg-if 0.1.10",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "libc",
+ "metal 0.18.0",
+ "objc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,7 +2206,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2407,7 +2517,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -3116,7 +3226,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3189,6 +3299,12 @@ name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-stack"
@@ -3708,7 +3824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3910,6 +4026,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -4229,12 +4357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4274,7 +4402,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi",
@@ -4287,7 +4415,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -4301,7 +4429,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
@@ -4673,7 +4801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy 0.8.40",
@@ -5000,7 +5128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
  "log",
@@ -5422,7 +5550,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5458,7 +5586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
  "log",
@@ -5473,7 +5601,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
@@ -5609,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-3d"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "bincode 2.0.1",
  "faer",
@@ -5627,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-algebra"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "glam 0.30.10",
  "nalgebra 0.32.6",
@@ -5637,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-image"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "kornia-tensor",
  "num-traits",
@@ -5647,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-imgproc"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "kornia-algebra",
  "kornia-image",
@@ -5660,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-io"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "image-webp",
  "jpeg-encoder",
@@ -5694,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "num-traits",
  "rayon",
@@ -5737,6 +5865,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -5835,7 +5969,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -6088,7 +6222,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
@@ -6118,7 +6252,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest",
 ]
 
@@ -6163,6 +6297,21 @@ checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "metal"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e198a0ee42bdbe9ef2c09d0b9426f3b2b47d90d93a4a9b0395c4cea605e92dc0"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa",
+ "core-graphics 0.19.2",
+ "foreign-types 0.3.2",
+ "log",
+ "objc",
 ]
 
 [[package]]
@@ -6278,6 +6427,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mozjpeg"
+version = "0.10.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7891b80aaa86097d38d276eb98b3805d6280708c4e0a1e6f6aed9380c51fec9"
+dependencies = [
+ "arrayvec",
+ "bytemuck",
+ "libc",
+ "mozjpeg-sys",
+ "rgb",
+]
+
+[[package]]
+name = "mozjpeg-sys"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0dc668bf9bf888c88e2fb1ab16a406d2c380f1d082b20d51dd540ab2aa70c1"
+dependencies = [
+ "cc",
+ "dunce",
+ "libc",
+ "nasm-rs",
+]
+
+[[package]]
 name = "mp4ra-rust"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,7 +6475,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.11.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "codespan-reporting 0.12.0",
  "half",
@@ -6449,6 +6623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "nasm-rs"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6569,6 +6752,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nokhwa"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d63f10b450319a0ace7aa8e0e25477d1fdb345313a97e220e886175539a1dbb"
+dependencies = [
+ "flume",
+ "image",
+ "nokhwa-bindings-linux",
+ "nokhwa-bindings-macos",
+ "nokhwa-bindings-windows",
+ "nokhwa-core",
+ "paste",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nokhwa-bindings-linux"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb67e22201a53322291740ca064b20eaaade7222ef0349f312d9b37b004e1984"
+dependencies = [
+ "libc",
+ "nokhwa-core",
+ "v4l",
+]
+
+[[package]]
+name = "nokhwa-bindings-macos"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70d3908ea68324e44a6b3a0f885aa59e433fb1f6678839d09e0df7d226fb42d"
+dependencies = [
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.10.1",
+ "core-media-sys",
+ "core-video-sys",
+ "flume",
+ "nokhwa-core",
+ "objc",
+ "once_cell",
+]
+
+[[package]]
+name = "nokhwa-bindings-windows"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be28886bad8abcec3655c1f24b965b4cb596a72b23164c910c54439ce55d2a4"
+dependencies = [
+ "nokhwa-core",
+ "once_cell",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "nokhwa-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1cba20bebd3bd9ae22f9273ade5bbe49da3e047c8512b53fbaf8b4b9c80d496"
+dependencies = [
+ "bytes",
+ "image",
+ "mozjpeg",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6647,7 +6897,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6783,6 +7033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+ "objc_exception",
 ]
 
 [[package]]
@@ -7133,6 +7384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7184,7 +7444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types 0.3.2",
  "libc",
  "openssl-macros",
@@ -7330,6 +7590,7 @@ dependencies = [
  "kornia-slam",
  "kornia-tensor",
  "libc",
+ "nokhwa",
  "ratatui",
  "rerun",
  "serde",
@@ -7412,7 +7673,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -7474,6 +7735,12 @@ dependencies = [
  "digest",
  "hmac",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peg"
@@ -7742,7 +8009,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
@@ -7962,7 +8229,7 @@ dependencies = [
  "anyhow",
  "bincode 1.3.3",
  "byteorder",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itertools 0.10.5",
  "lz4_flex 0.11.6",
  "once_cell",
@@ -8013,7 +8280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libm",
  "num-complex",
  "reborrow",
@@ -8273,7 +8540,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io 4.10.0",
  "built",
- "cfg-if",
+ "cfg-if 1.0.4",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -8819,7 +9086,7 @@ dependencies = [
  "ahash",
  "arrow",
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam",
  "datafusion",
  "egui",
@@ -9319,7 +9586,7 @@ dependencies = [
  "av-data",
  "bitflags 2.11.0",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "nasm-rs",
  "parking_lot",
@@ -9360,7 +9627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "815614e538d45fb7ae573d204cde2e12b0bf9a01313e3409250a44fe67cf723a"
 dependencies = [
  "ahash",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam",
  "datafusion",
  "egui",
@@ -10121,7 +10388,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam",
  "eframe",
  "egui",
@@ -10219,7 +10486,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "camino",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam",
  "datafusion",
  "directories",
@@ -10420,7 +10687,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "rustix 1.1.4",
  "windows 0.62.2",
@@ -10611,7 +10878,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "camino",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam",
  "document-features",
  "env_filter 0.1.4",
@@ -10724,7 +10991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -10823,7 +11090,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10984,7 +11251,7 @@ checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
 ]
@@ -10995,7 +11262,7 @@ version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -11162,7 +11429,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -11173,7 +11440,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -11184,7 +11451,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -11443,7 +11710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11451,6 +11718,15 @@ name = "sorted-vec"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f58d7b0190c7f12df7e8be6b79767a0836059159811b869d5ab55721fe14d0"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spirv"
@@ -11648,8 +11924,8 @@ version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
+ "cfg-if 1.0.4",
+ "core-foundation-sys 0.8.7",
  "libc",
  "ntapi",
  "once_cell",
@@ -11672,7 +11948,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11730,7 +12006,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -11818,7 +12094,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "log",
  "png 0.17.16",
  "tiny-skia-path",
@@ -12279,7 +12555,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12455,6 +12731,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "v4l"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fbfea44a46799d62c55323f3c55d06df722fbe577851d848d328a1041c3403"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "v4l2-sys-mit",
+]
+
+[[package]]
+name = "v4l2-sys-mit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6779878362b9bacadc7893eac76abe69612e8837ef746573c4a5239daf11990b"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12570,7 +12866,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -12596,7 +12892,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -12885,7 +13181,7 @@ checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
@@ -12988,7 +13284,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "core-graphics-types 0.2.0",
  "glow",
@@ -13002,7 +13298,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
+ "metal 0.32.0",
  "naga",
  "ndk-sys",
  "objc",
@@ -13036,6 +13332,18 @@ dependencies = [
  "log",
  "thiserror 2.0.18",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -13080,7 +13388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13618,7 +13926,7 @@ dependencies = [
  "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
- "core-graphics",
+ "core-graphics 0.23.2",
  "cursor-icon",
  "dpi",
  "js-sys",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Spatial runtime for real-time pose estimation, mapping, and agent interaction.
 
 > **Work in progress**
 
-> **Early stage.** This README describes the long-term vision for kornia-slam, while the current implementation is a much narrower slice: monocular ORB-based odometry running end-to-end on EuRoC datasets. The current codebase is not yet a general SLAM framework: it is an ORB-specific monocular pipeline whose system orchestration still lives in the example layer rather than behind a stable library abstraction. The API, module layout, and internal abstractions are still taking shape, and broader multi-sensor SLAM, map serving, and agent integration remain roadmap work. Expect breaking changes. Contributions and feedback welcome.
+> **Early stage.** This README describes the long-term vision for kornia-slam, while the current implementation is a much narrower slice: monocular ORB-based odometry that runs end-to-end on EuRoC datasets, OAK-D mono cameras, and any UVC-class device (laptop webcam, USB cam, CSI-to-UVC adapter). The current codebase is not yet a general SLAM framework: it is an ORB-specific monocular pipeline whose system orchestration still lives in the example layer rather than behind a stable library abstraction. The API, module layout, and internal abstractions are still taking shape, and broader multi-sensor SLAM, map serving, and agent integration remain roadmap work. Expect breaking changes. Contributions and feedback welcome.
 
 kornia-slam is a modular SLAM framework that estimates poses in real time from cameras, IMU, LiDAR, and GNSS, builds a persistent map of the environment, and makes that spatial state available to agents through MCP.
 
@@ -68,7 +68,18 @@ Beyond serving spatial state to external agents, kornia-slam is exploring the id
 
 ## Setup
 
-The current runnable package is the standalone ORB-SLAM example in [examples/orb_slam/README.md](examples/orb_slam/README.md).
+The current runnable package is the standalone ORB-SLAM example in [examples/orb_slam/README.md](examples/orb_slam/README.md). Quick taste, with the default TUI:
+
+```bash
+# Offline (no extra deps):
+cargo run --release -p orb_slam -- euroc --data /path/to/V1_01_easy
+
+# Live UVC camera (laptop webcam, USB cam, …):
+cargo run --release -p orb_slam --features uvc -- \
+    uvc --index 0 --fx 600 --fy 600 --cx 320 --cy 240
+```
+
+Press `d` in the TUI to toggle the debug panel. Pass `--rerun-stream` for a Rerun viewer instead, or `--no-tui` for plain stderr.
 
 ### Local checks
 
@@ -89,6 +100,8 @@ cargo test
 - [x] Keyframe insertion and map point triangulation
 - [x] Local bundle adjustment
 - [x] Map point culling
+- [x] Live frame sources (EuRoC offline, OAK-D, UVC) behind a common `FrameSource` trait
+- [x] Default terminal UI with live BEV + togglable debug panel
 
 **Next — complete monocular SLAM ideas**
 - [ ] Rich keyframe and map-point observation model

--- a/crates/kornia-slam/src/estimation/two_view.rs
+++ b/crates/kornia-slam/src/estimation/two_view.rs
@@ -15,6 +15,7 @@
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_3d::pose::{TriangulationConfig, TwoViewEstimator, TwoViewModel};
+pub use kornia_3d::pose::TwoViewError;
 use kornia_algebra::Vec3F64;
 use kornia_imgproc::features::{OrbFeatures, OrbMatchConfig, match_orb_descriptors};
 
@@ -67,12 +68,14 @@ impl Default for TwoViewInitConfig {
 }
 
 /// Two-view initialization rejection reason.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub enum TwoViewRejectReason {
     /// Not enough descriptor matches to run two-view estimation.
     LowMatches,
-    /// Two-view estimation failed.
-    EstimationFailed,
+    /// Two-view estimation failed; the wrapped error carries the specific
+    /// cause (RANSAC failure, ambiguous cheirality from pure rotation /
+    /// planar / low-parallax motion, solver error, …).
+    EstimationFailed(TwoViewError),
     /// Too few triangulated points.
     LowTriangulated,
     /// Too few inliers in estimated model.
@@ -130,7 +133,7 @@ pub fn try_initialize_two_view(
         .build();
     let result = estimator
         .estimate(&reference_pts, &current_pts, &k, &k)
-        .map_err(|_| TwoViewRejectReason::EstimationFailed)?;
+        .map_err(TwoViewRejectReason::EstimationFailed)?;
 
     let model_kind = match result.model {
         TwoViewModel::Homography(_) => 'H',

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -753,6 +753,8 @@ impl Map {
                             pixel: [p.x as f32, p.y as f32],
                             fixed_pose: is_fixed,
                             fixed_point: false,
+                            depth_meas: None,
+                            depth_sigma: 1.0,
                         });
                     }
                 }
@@ -896,6 +898,8 @@ impl Map {
                             pixel: [p.x as f32, p.y as f32],
                             fixed_pose: is_fixed,
                             fixed_point: false,
+                            depth_meas: None,
+                            depth_sigma: 1.0,
                         });
                     }
                 }

--- a/examples/common/source/mod.rs
+++ b/examples/common/source/mod.rs
@@ -7,6 +7,8 @@
 pub mod euroc;
 #[cfg(feature = "oakd")]
 pub mod oakd;
+#[cfg(feature = "webcam")]
+pub mod webcam;
 
 use kornia_3d::camera::PinholeCamera;
 use kornia_image::Image;
@@ -15,6 +17,8 @@ use kornia_tensor::CpuAllocator;
 pub use euroc::EurocSource;
 #[cfg(feature = "oakd")]
 pub use oakd::OakdSource;
+#[cfg(feature = "webcam")]
+pub use webcam::WebcamSource;
 
 /// One frame yielded by a source.
 pub struct FrameItem {

--- a/examples/common/source/mod.rs
+++ b/examples/common/source/mod.rs
@@ -7,8 +7,8 @@
 pub mod euroc;
 #[cfg(feature = "oakd")]
 pub mod oakd;
-#[cfg(feature = "webcam")]
-pub mod webcam;
+#[cfg(feature = "uvc")]
+pub mod uvc;
 
 use kornia_3d::camera::PinholeCamera;
 use kornia_image::Image;
@@ -17,8 +17,8 @@ use kornia_tensor::CpuAllocator;
 pub use euroc::EurocSource;
 #[cfg(feature = "oakd")]
 pub use oakd::OakdSource;
-#[cfg(feature = "webcam")]
-pub use webcam::WebcamSource;
+#[cfg(feature = "uvc")]
+pub use uvc::UvcSource;
 
 /// One frame yielded by a source.
 pub struct FrameItem {

--- a/examples/common/source/uvc.rs
+++ b/examples/common/source/uvc.rs
@@ -1,11 +1,13 @@
-//! Live UVC/V4L2 webcam as a [`FrameSource`].
+//! Live UVC camera as a [`FrameSource`].
 //!
 //! Uses [`nokhwa`] for cross-platform capture (V4L2 on Linux, AVFoundation on
-//! macOS, MSMF on Windows). Frames are decoded to grayscale `Image<u8, 1>` and
-//! fed through the same `process_frame` orchestrator as the EuRoC dataset.
+//! macOS, MSMF on Windows). Any UVC-class device works — built-in laptop
+//! webcams, USB cameras, CSI-to-UVC adapters on a Raspberry Pi, etc. Frames
+//! are decoded to grayscale `Image<u8, 1>` and fed through the same
+//! `process_frame` orchestrator as the EuRoC dataset.
 //!
 //! Intrinsics are supplied by the caller (CLI flags). They must match the
-//! webcam's *resolution at capture time* — if you calibrated at 1280×720, ask
+//! device's *resolution at capture time* — if you calibrated at 1280×720, ask
 //! for that resolution here too.
 
 use std::time::Instant;
@@ -36,8 +38,8 @@ fn try_open(
 
 use super::{FrameItem, FrameSource, SourceError};
 
-/// Live webcam frame source.
-pub struct WebcamSource {
+/// Live UVC frame source.
+pub struct UvcSource {
     camera_dev: Camera,
     image_size: ImageSize,
     camera: PinholeCamera,
@@ -46,8 +48,8 @@ pub struct WebcamSource {
     start: Instant,
 }
 
-impl WebcamSource {
-    /// Open the webcam at `index` and request the closest format to
+impl UvcSource {
+    /// Open the UVC device at `index` and request the closest format to
     /// `width × height` (decoding will produce Y8 grayscale regardless of the
     /// device's native pixel format).
     ///
@@ -59,11 +61,11 @@ impl WebcamSource {
         camera: PinholeCamera,
         max_frames: usize,
     ) -> Result<Self, SourceError> {
-        eprintln!("[webcam] opening camera index {index}…");
+        eprintln!("[uvc] opening camera index {index}…");
 
         let mut camera_dev = try_open(index, width, height, FrameFormat::MJPEG).or_else(
             |first_err| {
-                eprintln!("[webcam] MJPEG open failed ({first_err}); trying YUYV…");
+                eprintln!("[uvc] MJPEG open failed ({first_err}); trying YUYV…");
                 try_open(index, width, height, FrameFormat::YUYV)
             },
         )?;
@@ -78,7 +80,7 @@ impl WebcamSource {
 
         if actual.width() != width || actual.height() != height {
             eprintln!(
-                "[webcam] requested {width}x{height}, device selected {}x{} — \
+                "[uvc] requested {width}x{height}, device selected {}x{} — \
                  intrinsics must match the selected resolution",
                 actual.width(),
                 actual.height(),
@@ -86,7 +88,7 @@ impl WebcamSource {
         }
 
         eprintln!(
-            "[webcam] streaming {}x{} @ ~{} fps  fx={:.2} fy={:.2} cx={:.2} cy={:.2}",
+            "[uvc] streaming {}x{} @ ~{} fps  fx={:.2} fy={:.2} cx={:.2} cy={:.2}",
             actual.width(),
             actual.height(),
             camera_dev.frame_rate(),
@@ -107,7 +109,7 @@ impl WebcamSource {
     }
 }
 
-impl FrameSource for WebcamSource {
+impl FrameSource for UvcSource {
     fn camera(&self) -> PinholeCamera {
         self.camera.clone()
     }
@@ -133,7 +135,7 @@ impl FrameSource for WebcamSource {
         let expected = self.image_size.width * self.image_size.height;
         if bytes.len() != expected {
             return Err(SourceError::other(format!(
-                "webcam decoded payload {} bytes (want {expected})",
+                "uvc decoded payload {} bytes (want {expected})",
                 bytes.len(),
             )));
         }

--- a/examples/common/source/webcam.rs
+++ b/examples/common/source/webcam.rs
@@ -1,0 +1,152 @@
+//! Live UVC/V4L2 webcam as a [`FrameSource`].
+//!
+//! Uses [`nokhwa`] for cross-platform capture (V4L2 on Linux, AVFoundation on
+//! macOS, MSMF on Windows). Frames are decoded to grayscale `Image<u8, 1>` and
+//! fed through the same `process_frame` orchestrator as the EuRoC dataset.
+//!
+//! Intrinsics are supplied by the caller (CLI flags). They must match the
+//! webcam's *resolution at capture time* — if you calibrated at 1280×720, ask
+//! for that resolution here too.
+
+use std::time::Instant;
+
+use kornia_3d::camera::PinholeCamera;
+use kornia_image::{Image, ImageSize};
+use kornia_tensor::CpuAllocator;
+use nokhwa::pixel_format::LumaFormat;
+use nokhwa::utils::{
+    ApiBackend, CameraFormat, CameraIndex, FrameFormat, RequestedFormat, RequestedFormatType,
+};
+use nokhwa::Camera;
+
+/// Open the device at `index` with a closest-resolution request for the given
+/// frame format. Returns the camera ready to stream (caller must `open_stream`).
+fn try_open(
+    index: u32,
+    width: u32,
+    height: u32,
+    fmt: FrameFormat,
+) -> Result<Camera, SourceError> {
+    let target = CameraFormat::new_from(width, height, fmt, 30);
+    let requested =
+        RequestedFormat::new::<LumaFormat>(RequestedFormatType::Closest(target));
+    Camera::with_backend(CameraIndex::Index(index), requested, ApiBackend::Auto)
+        .map_err(SourceError::other)
+}
+
+use super::{FrameItem, FrameSource, SourceError};
+
+/// Live webcam frame source.
+pub struct WebcamSource {
+    camera_dev: Camera,
+    image_size: ImageSize,
+    camera: PinholeCamera,
+    max_frames: usize,
+    cursor: usize,
+    start: Instant,
+}
+
+impl WebcamSource {
+    /// Open the webcam at `index` and request the closest format to
+    /// `width × height` (decoding will produce Y8 grayscale regardless of the
+    /// device's native pixel format).
+    ///
+    /// `max_frames == 0` ⇒ run until the caller stops the loop (Ctrl-C).
+    pub fn open(
+        index: u32,
+        width: u32,
+        height: u32,
+        camera: PinholeCamera,
+        max_frames: usize,
+    ) -> Result<Self, SourceError> {
+        eprintln!("[webcam] opening camera index {index}…");
+
+        let mut camera_dev = try_open(index, width, height, FrameFormat::MJPEG).or_else(
+            |first_err| {
+                eprintln!("[webcam] MJPEG open failed ({first_err}); trying YUYV…");
+                try_open(index, width, height, FrameFormat::YUYV)
+            },
+        )?;
+
+        camera_dev.open_stream().map_err(SourceError::other)?;
+
+        let actual = camera_dev.resolution();
+        let image_size = ImageSize {
+            width: actual.width() as usize,
+            height: actual.height() as usize,
+        };
+
+        if actual.width() != width || actual.height() != height {
+            eprintln!(
+                "[webcam] requested {width}x{height}, device selected {}x{} — \
+                 intrinsics must match the selected resolution",
+                actual.width(),
+                actual.height(),
+            );
+        }
+
+        eprintln!(
+            "[webcam] streaming {}x{} @ ~{} fps  fx={:.2} fy={:.2} cx={:.2} cy={:.2}",
+            actual.width(),
+            actual.height(),
+            camera_dev.frame_rate(),
+            camera.fx,
+            camera.fy,
+            camera.cx,
+            camera.cy,
+        );
+
+        Ok(Self {
+            camera_dev,
+            image_size,
+            camera,
+            max_frames,
+            cursor: 0,
+            start: Instant::now(),
+        })
+    }
+}
+
+impl FrameSource for WebcamSource {
+    fn camera(&self) -> PinholeCamera {
+        self.camera.clone()
+    }
+
+    fn n_frames_hint(&self) -> Option<usize> {
+        if self.max_frames > 0 {
+            Some(self.max_frames)
+        } else {
+            None
+        }
+    }
+
+    fn next_frame(&mut self) -> Result<Option<FrameItem>, SourceError> {
+        if self.max_frames > 0 && self.cursor >= self.max_frames {
+            return Ok(None);
+        }
+
+        let buffer = self.camera_dev.frame().map_err(SourceError::other)?;
+        let luma = buffer
+            .decode_image::<LumaFormat>()
+            .map_err(SourceError::other)?;
+        let bytes = luma.into_raw();
+        let expected = self.image_size.width * self.image_size.height;
+        if bytes.len() != expected {
+            return Err(SourceError::other(format!(
+                "webcam decoded payload {} bytes (want {expected})",
+                bytes.len(),
+            )));
+        }
+
+        let image: Image<u8, 1, CpuAllocator> =
+            Image::new(self.image_size, bytes, CpuAllocator).map_err(SourceError::other)?;
+        let idx = self.cursor;
+        self.cursor += 1;
+        let timestamp_sec = self.start.elapsed().as_secs_f64();
+        Ok(Some(FrameItem {
+            idx,
+            timestamp_sec,
+            image,
+        }))
+    }
+}

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -15,10 +15,11 @@ kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", branch = "main" 
 kornia-io = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-tensor = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 rerun = { version = "0.29.2", optional = true }
-ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.28", optional = true }
-libc = { version = "0.2", optional = true }
+ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+crossterm = "0.28"
+libc = "0.2"
 depthai = { version = "0.1", optional = true }
+nokhwa = { version = "0.10", optional = true, default-features = false, features = ["input-native", "decoding"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2"
@@ -26,5 +27,5 @@ thiserror = "2"
 [features]
 default = ["viz"]
 viz = ["dep:rerun"]
-tui = ["dep:ratatui", "dep:crossterm", "dep:libc"]
 oakd = ["dep:depthai"]
+webcam = ["dep:nokhwa"]

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -28,4 +28,4 @@ thiserror = "2"
 default = ["viz"]
 viz = ["dep:rerun"]
 oakd = ["dep:depthai"]
-webcam = ["dep:nokhwa"]
+uvc = ["dep:nokhwa"]

--- a/examples/orb_slam/README.md
+++ b/examples/orb_slam/README.md
@@ -1,6 +1,6 @@
 # ORB-SLAM Example
 
-This package is the current runnable slice of `kornia-slam`: a monocular ORB-based SLAM pipeline with two interchangeable frame sources — offline EuRoC MAV image sequences and a live OAK-D mono camera. Both feed the same `process_frame` orchestrator, and TUI / Rerun work for both.
+This package is the current runnable slice of `kornia-slam`: a monocular ORB-based SLAM pipeline with three interchangeable frame sources — offline EuRoC MAV image sequences, a live OAK-D mono camera, and any UVC-class camera (laptop webcams, USB cams, CSI-to-UVC adapters on a Pi…). All three feed the same `process_frame` orchestrator, and the TUI / Rerun visualizers work for any of them.
 
 ## Frame sources
 
@@ -9,9 +9,10 @@ Selectable via subcommand:
 ```text
 orb_slam euroc --data /path/to/V1_01_easy [--start-frame N] [--max-frames N]
 orb_slam oakd  [--width 640 --height 400 --fps 30] [--max-frames N]
+orb_slam uvc   --fx F --fy F --cx C --cy C [--index 0] [--width 640 --height 480] [--max-frames N]
 ```
 
-`oakd` requires `--features oakd`; the default build needs no extra system dependencies.
+`oakd` requires `--features oakd`; `uvc` requires `--features uvc`. The default build needs no extra system dependencies.
 
 ## EuRoC dataset
 
@@ -68,20 +69,31 @@ at cargo invocation time when building with both `viz` and `oakd`.
 ```bash
 # Live, with Rerun visualization:
 RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" \
-  cargo run --release -p orb_slam --features oakd -- oakd --rerun-stream
+  cargo run --release -p orb_slam --features oakd -- --rerun-stream oakd
 
 # Live, TUI only (no Rerun, no lz4 clash):
-cargo run --release -p orb_slam --no-default-features --features "oakd tui" -- oakd --tui
+cargo run --release -p orb_slam --no-default-features --features oakd -- oakd
 ```
 
 Intrinsics are placeholder (rough scale of the OAK-D Pro factory fx/fy at 1280×800); reading the on-device factory calibration is a TODO.
 
+## UVC camera
+
+Any UVC-class device works (built-in laptop webcam, USB camera, CSI-to-UVC adapter on a Raspberry Pi). Unlike EuRoC and OAK-D, there's no on-device calibration, so you must pass intrinsics on the command line — they have to match the resolution the device actually streams at (nokhwa picks the closest supported mode if the exact one is missing).
+
+```bash
+# /dev/video0 at 640x480, rough pinhole calibration:
+cargo run --release -p orb_slam --features uvc -- \
+    uvc --index 0 --fx 600 --fy 600 --cx 320 --cy 240
+```
+
 ## Visualizers
 
-Mutually exclusive flags (apply to either source):
+The TUI is the default — just run the example. Override with one of:
 
-- `--rerun-stream` — spawn a Rerun viewer and stream image / keypoints / trajectory / camera / map points (requires `--features viz`, default on).
-- `--tui` — render a terminal UI with live status + bird's-eye view (requires `--features tui`).
+- `--rerun-stream` — spawn a Rerun viewer and stream image / keypoints / trajectory / camera / map points (requires `--features viz`, default on). Disables the TUI.
+- `--no-tui` — fall back to plain stderr status lines (no TUI, no Rerun).
+- `--debug` — show the debug panel inside the TUI (or extra diagnostic lines on stderr in `--no-tui` mode). Toggle live with the `d` key while the TUI is running.
 
 ## Local checks
 

--- a/examples/orb_slam/src/config.rs
+++ b/examples/orb_slam/src/config.rs
@@ -8,6 +8,9 @@ pub struct PipelineConfig {
     pub map_projection: MapProjectionConfig,
     pub keyframe_policy: KeyframePolicy,
     pub enable_local_ba: bool,
+    /// Emit per-frame diagnostics: skip reasons in bootstrap, reject reasons
+    /// in tracking, keyframe-growth and fuse counters.
+    pub debug: bool,
 }
 
 impl Default for PipelineConfig {
@@ -21,6 +24,7 @@ impl Default for PipelineConfig {
             map_projection: MapProjectionConfig::default(),
             keyframe_policy: KeyframePolicy::default(),
             enable_local_ba: true,
+            debug: false,
         }
     }
 }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -9,6 +9,12 @@
 //! ```text
 //! cargo run --release -p orb_slam --features oakd -- oakd
 //! ```
+//!
+//! Run live on a generic UVC webcam (requires `--features webcam`):
+//! ```text
+//! cargo run --release -p orb_slam --features webcam -- webcam \
+//!     --fx 600 --fy 600 --cx 320 --cy 240
+//! ```
 
 mod config;
 #[path = "../../common/datasets/mod.rs"]
@@ -16,7 +22,6 @@ mod datasets;
 mod pipeline;
 #[path = "../../common/source/mod.rs"]
 mod source;
-#[cfg(feature = "tui")]
 mod tui;
 mod utils;
 
@@ -27,6 +32,8 @@ use pipeline::Pipeline;
 use source::{EurocSource, FrameItem, FrameSource};
 #[cfg(feature = "oakd")]
 use source::OakdSource;
+#[cfg(feature = "webcam")]
+use source::WebcamSource;
 use utils::trajectory_point_from_pose;
 
 #[cfg(feature = "viz")]
@@ -46,10 +53,14 @@ struct Args {
     #[cfg(feature = "viz")]
     rerun_stream: bool,
 
-    /// render a terminal UI with a live BEV view (requires `--features tui`)
+    /// disable the terminal UI (status lines stream to stderr instead)
     #[argh(switch)]
-    #[cfg(feature = "tui")]
-    tui: bool,
+    no_tui: bool,
+
+    /// print per-frame diagnostics: bootstrap skip/reject reasons,
+    /// map-projection reject reasons, keyframe growth and fuse counters
+    #[argh(switch)]
+    debug: bool,
 }
 
 #[derive(argh::FromArgs)]
@@ -58,6 +69,8 @@ enum SourceCmd {
     Euroc(EurocCmd),
     #[cfg(feature = "oakd")]
     Oakd(OakdCmd),
+    #[cfg(feature = "webcam")]
+    Webcam(WebcamCmd),
 }
 
 /// Run on an EuRoC MAV dataset.
@@ -99,19 +112,71 @@ struct OakdCmd {
     fps: f32,
 }
 
+/// Run live on a UVC webcam (V4L2/AVFoundation/MSMF via nokhwa).
+///
+/// Intrinsics flags must match the resolution the device actually streams at
+/// — nokhwa may pick the closest supported mode if the exact one is missing.
+#[cfg(feature = "webcam")]
+#[derive(argh::FromArgs)]
+#[argh(subcommand, name = "webcam")]
+struct WebcamCmd {
+    /// camera device index (0 = first camera)
+    #[argh(option, default = "0")]
+    index: u32,
+
+    /// frame width in pixels
+    #[argh(option, default = "640")]
+    width: u32,
+
+    /// frame height in pixels
+    #[argh(option, default = "480")]
+    height: u32,
+
+    /// maximum number of frames to process (0 = run forever, Ctrl-C to stop)
+    #[argh(option, default = "0")]
+    max_frames: usize,
+
+    /// focal length x (pixels)
+    #[argh(option)]
+    fx: f64,
+
+    /// focal length y (pixels)
+    #[argh(option)]
+    fy: f64,
+
+    /// principal point x (pixels)
+    #[argh(option)]
+    cx: f64,
+
+    /// principal point y (pixels)
+    #[argh(option)]
+    cy: f64,
+
+    /// radial distortion k1
+    #[argh(option, default = "0.0")]
+    k1: f64,
+
+    /// radial distortion k2
+    #[argh(option, default = "0.0")]
+    k2: f64,
+
+    /// tangential distortion p1
+    #[argh(option, default = "0.0")]
+    p1: f64,
+
+    /// tangential distortion p2
+    #[argh(option, default = "0.0")]
+    p2: f64,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
-    #[cfg(all(feature = "tui", feature = "viz"))]
-    if args.tui && args.rerun_stream {
-        eprintln!("--tui and --rerun-stream are mutually exclusive");
-        std::process::exit(2);
-    }
-
-    #[cfg(feature = "tui")]
-    let tui_active = args.tui;
-    #[cfg(not(feature = "tui"))]
-    let tui_active = false;
+    // TUI is the default; --rerun-stream or --no-tui falls back to plain stderr.
+    #[cfg(feature = "viz")]
+    let tui_active = !args.no_tui && !args.rerun_stream;
+    #[cfg(not(feature = "viz"))]
+    let tui_active = !args.no_tui;
 
     // ── Source ─────────────────────────────────────────────────────────────
     let mut source: Box<dyn FrameSource> = match args.source {
@@ -130,10 +195,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(feature = "oakd")]
         SourceCmd::Oakd(o) => Box::new(OakdSource::open(o.width, o.height, o.fps, o.max_frames)?),
+        #[cfg(feature = "webcam")]
+        SourceCmd::Webcam(w) => {
+            let camera = kornia_3d::camera::PinholeCamera {
+                fx: w.fx,
+                fy: w.fy,
+                cx: w.cx,
+                cy: w.cy,
+                k1: w.k1,
+                k2: w.k2,
+                p1: w.p1,
+                p2: w.p2,
+            };
+            Box::new(WebcamSource::open(
+                w.index,
+                w.width,
+                w.height,
+                camera,
+                w.max_frames,
+            )?)
+        }
     };
 
     let camera = source.camera();
-    #[cfg(feature = "tui")]
     let n_frames_hint = source.n_frames_hint();
 
     // ── ORB detector ───────────────────────────────────────────────────────
@@ -143,7 +227,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // ── SLAM system ────────────────────────────────────────────────────────
-    let mut system = Pipeline::new(camera.clone(), PipelineConfig::default());
+    let pipeline_config = PipelineConfig {
+        debug: args.debug,
+        ..PipelineConfig::default()
+    };
+    let mut system = Pipeline::new(camera.clone(), pipeline_config);
 
     // ── Rerun ──────────────────────────────────────────────────────────────
     #[cfg(feature = "viz")]
@@ -157,10 +245,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // ── TUI ────────────────────────────────────────────────────────────────
-    #[cfg(feature = "tui")]
-    let mut tui_state = if args.tui {
+    let mut tui_state = if tui_active {
         let (term, guard) = tui::setup_terminal(std::path::Path::new("tui_stderr.log"))?;
-        let app = tui::TuiApp::new(n_frames_hint.unwrap_or(0));
+        let mut app = tui::TuiApp::new(n_frames_hint.unwrap_or(0));
+        app.debug_enabled = args.debug;
         Some((term, app, guard))
     } else {
         None
@@ -168,7 +256,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Main loop ──────────────────────────────────────────────────────────
     let mut trajectory: Vec<[f32; 3]> = Vec::new();
-    #[cfg(feature = "tui")]
     let mut processed: usize = 0;
 
     while let Some(item) = source.next_frame()? {
@@ -212,13 +299,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let frame_ms = t0.elapsed().as_secs_f64() * 1000.0;
         let keyframe_idx = system.current_keyframe_idx().unwrap_or(idx);
         let map_point_count = system.num_active_map_points();
-        #[cfg(feature = "tui")]
-        {
-            processed += 1;
-        }
+        let debug_msgs = system.drain_debug_messages();
+        processed += 1;
 
         // Status line.
         if !tui_active {
+            for line in &debug_msgs {
+                eprintln!("{line}");
+            }
             let status_line = format!(
                 "[{idx:>5}] {:?}  kf={:<4} pts={:<5} {frame_ms:>6.1}ms",
                 result.status, keyframe_idx, map_point_count,
@@ -238,8 +326,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // TUI render.
-        #[cfg(feature = "tui")]
         if let Some((term, app, _guard)) = tui_state.as_mut() {
+            for line in debug_msgs {
+                app.push_debug_line(line);
+            }
             app.frame_idx = idx;
             app.n_frames = n_frames_hint.unwrap_or(processed);
             app.frame_ms = frame_ms;
@@ -254,14 +344,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             app.mean_ms = app.mean_ms + (frame_ms - app.mean_ms) / n_so_far;
             app.update_pose(&result.pose_world_to_cam);
             app.draw(term)?;
-            if tui::poll_quit()? {
-                break;
+            match tui::poll_action()? {
+                tui::TuiAction::Quit => break,
+                tui::TuiAction::ToggleDebug => {
+                    app.debug_enabled = !app.debug_enabled;
+                    system.set_debug(app.debug_enabled);
+                }
+                tui::TuiAction::None => {}
             }
         }
     }
 
     // Restore terminal before printing the final summary.
-    #[cfg(feature = "tui")]
     if let Some((mut term, _, _guard)) = tui_state.take() {
         tui::restore_terminal(&mut term)?;
     }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -10,9 +10,10 @@
 //! cargo run --release -p orb_slam --features oakd -- oakd
 //! ```
 //!
-//! Run live on a generic UVC webcam (requires `--features webcam`):
+//! Run live on a UVC camera (built-in webcam, USB cam, etc.; requires
+//! `--features uvc`):
 //! ```text
-//! cargo run --release -p orb_slam --features webcam -- webcam \
+//! cargo run --release -p orb_slam --features uvc -- uvc \
 //!     --fx 600 --fy 600 --cx 320 --cy 240
 //! ```
 
@@ -32,8 +33,8 @@ use pipeline::Pipeline;
 use source::{EurocSource, FrameItem, FrameSource};
 #[cfg(feature = "oakd")]
 use source::OakdSource;
-#[cfg(feature = "webcam")]
-use source::WebcamSource;
+#[cfg(feature = "uvc")]
+use source::UvcSource;
 use utils::trajectory_point_from_pose;
 
 #[cfg(feature = "viz")]
@@ -69,8 +70,8 @@ enum SourceCmd {
     Euroc(EurocCmd),
     #[cfg(feature = "oakd")]
     Oakd(OakdCmd),
-    #[cfg(feature = "webcam")]
-    Webcam(WebcamCmd),
+    #[cfg(feature = "uvc")]
+    Uvc(UvcCmd),
 }
 
 /// Run on an EuRoC MAV dataset.
@@ -112,14 +113,15 @@ struct OakdCmd {
     fps: f32,
 }
 
-/// Run live on a UVC webcam (V4L2/AVFoundation/MSMF via nokhwa).
+/// Run live on a UVC camera (laptop webcam, USB cam, CSI-to-UVC adapter…),
+/// using V4L2 / AVFoundation / MSMF via nokhwa.
 ///
 /// Intrinsics flags must match the resolution the device actually streams at
 /// — nokhwa may pick the closest supported mode if the exact one is missing.
-#[cfg(feature = "webcam")]
+#[cfg(feature = "uvc")]
 #[derive(argh::FromArgs)]
-#[argh(subcommand, name = "webcam")]
-struct WebcamCmd {
+#[argh(subcommand, name = "uvc")]
+struct UvcCmd {
     /// camera device index (0 = first camera)
     #[argh(option, default = "0")]
     index: u32,
@@ -195,8 +197,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(feature = "oakd")]
         SourceCmd::Oakd(o) => Box::new(OakdSource::open(o.width, o.height, o.fps, o.max_frames)?),
-        #[cfg(feature = "webcam")]
-        SourceCmd::Webcam(w) => {
+        #[cfg(feature = "uvc")]
+        SourceCmd::Uvc(w) => {
             let camera = kornia_3d::camera::PinholeCamera {
                 fx: w.fx,
                 fy: w.fy,
@@ -207,7 +209,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 p1: w.p1,
                 p2: w.p2,
             };
-            Box::new(WebcamSource::open(
+            Box::new(UvcSource::open(
                 w.index,
                 w.width,
                 w.height,

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -33,6 +33,11 @@ pub struct Pipeline {
     keyframe_policy: KeyframePolicy,
     // Enable local bundle adjustment after keyframe insertion
     enable_local_ba: bool,
+    // Emit per-frame diagnostic logs (skip/reject reasons, growth counters)
+    debug: bool,
+    // Buffered debug messages produced during the most recent process_frame call;
+    // drained by the caller (TUI panel or stderr).
+    debug_messages: Vec<String>,
     // Map object
     map: Map,
     // System state
@@ -48,6 +53,8 @@ impl Pipeline {
             two_view_init_config: config.two_view_init,
             keyframe_policy: config.keyframe_policy,
             enable_local_ba: config.enable_local_ba,
+            debug: config.debug,
+            debug_messages: Vec::new(),
             map: Map::new(),
             state: SystemState::new(),
         }
@@ -78,6 +85,25 @@ impl Pipeline {
         self.map.num_active_map_points()
     }
 
+    /// Drain any debug messages accumulated since the last call.
+    pub fn drain_debug_messages(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.debug_messages)
+    }
+
+    /// Toggle whether the pipeline buffers per-frame debug messages.
+    pub fn set_debug(&mut self, on: bool) {
+        self.debug = on;
+        if !on {
+            self.debug_messages.clear();
+        }
+    }
+
+    fn dbg(&mut self, msg: String) {
+        if self.debug {
+            self.debug_messages.push(msg);
+        }
+    }
+
     fn bootstrap_step(&mut self, mut curr_frame: Frame) -> TrackingResult {
         // Stamp frames with current odometry pose so bootstrap builds
         // the new map in the existing coordinate frame.
@@ -89,6 +115,12 @@ impl Pipeline {
         // and wait for a feature-rich frame to start over.
         const MIN_KEYPOINTS_FOR_BOOTSTRAP: usize = 100;
         if curr_frame.features.keypoints_xy.len() <= MIN_KEYPOINTS_FOR_BOOTSTRAP {
+            self.dbg(format!(
+                "[bootstrap] frame={} skip: too few keypoints ({}, need > {})",
+                curr_frame.idx,
+                curr_frame.features.keypoints_xy.len(),
+                MIN_KEYPOINTS_FOR_BOOTSTRAP,
+            ));
             self.state.bootstrap_frame = None;
             return TrackingResult {
                 pose_world_to_cam: self.state.pose_world_to_cam,
@@ -97,6 +129,10 @@ impl Pipeline {
         }
 
         let Some(prev_bootstrap_frame) = self.state.bootstrap_frame.take() else {
+            self.dbg(format!(
+                "[bootstrap] frame={} stored as reference (awaiting second frame)",
+                curr_frame.idx,
+            ));
             self.state.bootstrap_frame = Some(curr_frame);
             return TrackingResult {
                 pose_world_to_cam: self.state.pose_world_to_cam,
@@ -113,7 +149,11 @@ impl Pipeline {
         );
 
         let two_view_estimate = match result {
-            Err(_) => {
+            Err(reason) => {
+                self.dbg(format!(
+                    "[bootstrap] frame={} (ref={}) reject: {:?}",
+                    curr_frame.idx, prev_bootstrap_frame.idx, reason,
+                ));
                 self.state.bootstrap_frame = Some(prev_bootstrap_frame);
                 return TrackingResult {
                     pose_world_to_cam: self.state.pose_world_to_cam,
@@ -123,12 +163,13 @@ impl Pipeline {
             Ok(tv) => tv,
         };
 
-        eprintln!(
-            "[bootstrap] model={} triangulated={} inliers={}",
+        self.dbg(format!(
+            "[bootstrap] frame={} accept: model={} triangulated={} inliers={}",
+            curr_frame.idx,
             two_view_estimate.model_kind,
             two_view_estimate.points3d.len(),
             two_view_estimate.estimate.inliers,
-        );
+        ));
 
         let estimated_pose = two_view_estimate.estimate.pose;
         let prev_pose_world_to_cam = curr_frame.pose_world_to_cam;
@@ -155,10 +196,10 @@ impl Pipeline {
         const MIN_VALID_POINTS: usize = 50;
         let health = self.map.initial_map_health();
         if health.valid_in_both < MIN_VALID_POINTS || health.median_depth_older_kf <= 0.0 {
-            eprintln!(
+            self.dbg(format!(
                 "[init_gate] reject: valid_in_both={} median_depth={:.3} (need >= {} and > 0)",
                 health.valid_in_both, health.median_depth_older_kf, MIN_VALID_POINTS,
-            );
+            ));
             self.map.clear_active();
             self.state.reset();
             return TrackingResult {
@@ -267,21 +308,31 @@ impl Pipeline {
             self.state.current_keyframe_idx,
         );
 
-        let (mut status, matches, tracked_inliers) = match result {
+        let (mut status, matches, tracked_inliers, reject_reason) = match result {
             Ok(estimate) => {
                 self.state.velocity = Some(Pose3d::between(&pose_before_tracking, &estimate.pose));
                 self.state.pose_world_to_cam = estimate.pose;
-                (TrackingStatus::Tracked, estimate.matches, estimate.inliers)
+                (
+                    TrackingStatus::Tracked,
+                    estimate.matches,
+                    estimate.inliers,
+                    None,
+                )
             }
-            Err(_) => (TrackingStatus::Skipped, Vec::new(), 0),
+            Err(reason) => (TrackingStatus::Skipped, Vec::new(), 0, Some(reason)),
         };
-        eprintln!(
-            "[track] frame={} status={:?} matches={} inliers={}",
-            frame.idx,
-            status,
-            matches.len(),
-            tracked_inliers,
-        );
+        if self.debug {
+            let msg = match reject_reason {
+                Some(reason) => format!("[track] frame={} reject: {:?}", frame.idx, reason),
+                None => format!(
+                    "[track] frame={} ok: matches={} inliers={}",
+                    frame.idx,
+                    matches.len(),
+                    tracked_inliers,
+                ),
+            };
+            self.debug_messages.push(msg);
+        }
 
         if status == TrackingStatus::Tracked {
             let visible = self
@@ -383,12 +434,12 @@ impl Pipeline {
                 &triangulation_config,
             );
         }
-        eprintln!(
+        self.dbg(format!(
             "[kf] frame={} grown={} from {} neighbor kfs",
             frame.idx,
             total_grown,
             neighbor_kfs.len()
-        );
+        ));
 
         self.map.upsert_keyframe(curr_kf);
         self.state.current_keyframe_idx = Some(frame.idx);
@@ -400,7 +451,7 @@ impl Pipeline {
         let neighbor_kf_indices: Vec<usize> =
             neighbor_kfs.iter().map(|kf| kf.frame.idx).collect();
         let n_fused = self.fuse_into_neighbors(frame.idx, &neighbor_kf_indices);
-        eprintln!("[fuse] frame={} fused={}", frame.idx, n_fused);
+        self.dbg(format!("[fuse] frame={} fused={}", frame.idx, n_fused));
 
         if enable_local_ba {
             self.map.run_local_ba(&self.camera);

--- a/examples/orb_slam/src/tui.rs
+++ b/examples/orb_slam/src/tui.rs
@@ -6,6 +6,7 @@
 //!   * bird's-eye view of the trajectory + camera heading (X right, Z forward,
 //!     Y-down gravity dropped)
 
+use std::collections::VecDeque;
 use std::io::{self, Stdout};
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -42,6 +43,9 @@ const C_KEYFRAME: Color = Color::Rgb(255, 110, 220);
 const C_SKIPPED: Color = Color::Rgb(220, 180, 60);
 const C_KEY: Color = Color::Rgb(255, 215, 60);
 const C_SYS: Color = Color::Rgb(200, 160, 240);
+const C_DEBUG: Color = Color::Rgb(170, 200, 170);
+
+const DEBUG_LOG_CAPACITY: usize = 200;
 
 /// Tracking status, mirrored from `kornia_slam::TrackingStatus` so the TUI
 /// module doesn't import library types in its widget code.
@@ -266,6 +270,10 @@ pub struct TuiApp {
     pub frame_ms: f64,
     pub mean_ms: f64,
     sys: SysStatsSampler,
+    /// When true, render the debug log panel.
+    pub debug_enabled: bool,
+    /// Rolling ring of recent debug messages from the SLAM pipeline.
+    debug_lines: VecDeque<String>,
 }
 
 impl TuiApp {
@@ -287,7 +295,16 @@ impl TuiApp {
             frame_ms: 0.0,
             mean_ms: 0.0,
             sys: SysStatsSampler::default(),
+            debug_enabled: false,
+            debug_lines: VecDeque::with_capacity(DEBUG_LOG_CAPACITY),
         }
+    }
+
+    pub fn push_debug_line(&mut self, line: String) {
+        if self.debug_lines.len() == DEBUG_LOG_CAPACITY {
+            self.debug_lines.pop_front();
+        }
+        self.debug_lines.push_back(line);
     }
 
     /// Update from the latest world-to-camera pose.
@@ -324,23 +341,53 @@ impl TuiApp {
 
     pub fn draw(&mut self, terminal: &mut Tui) -> io::Result<()> {
         let sys = self.sys.sample();
+        let debug_enabled = self.debug_enabled;
         terminal.draw(|frame| {
-            let chunks = Layout::vertical([
-                Constraint::Length(3),
-                Constraint::Min(0),
-                Constraint::Length(3),
-                Constraint::Length(3),
-                Constraint::Length(1),
-            ])
-            .split(frame.area());
+            let mut constraints = vec![
+                Constraint::Length(3), // header
+                Constraint::Min(0),    // BEV
+                Constraint::Length(3), // camera
+                Constraint::Length(3), // system
+            ];
+            if debug_enabled {
+                constraints.push(Constraint::Length(10)); // debug log
+            }
+            constraints.push(Constraint::Length(1)); // hint
+            let chunks = Layout::vertical(constraints).split(frame.area());
 
             frame.render_widget(self.header(), chunks[0]);
             self.render_bev(frame, chunks[1]);
             frame.render_widget(self.camera_panel(), chunks[2]);
             frame.render_widget(sys_panel(sys), chunks[3]);
-            frame.render_widget(self.hint(), chunks[4]);
+            if debug_enabled {
+                frame.render_widget(self.debug_panel(), chunks[4]);
+                frame.render_widget(self.hint(), chunks[5]);
+            } else {
+                frame.render_widget(self.hint(), chunks[4]);
+            }
         })?;
         Ok(())
+    }
+
+    fn debug_panel(&self) -> Paragraph<'_> {
+        let style = Style::default().fg(C_DEBUG);
+        let lines: Vec<Line> = self
+            .debug_lines
+            .iter()
+            .rev()
+            .take(8)
+            .rev()
+            .map(|s| Line::from(Span::styled(s.as_str(), style)))
+            .collect();
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(C_BORDER))
+                .title(Span::styled(
+                    " debug ",
+                    Style::default().fg(C_TITLE).add_modifier(Modifier::BOLD),
+                )),
+        )
     }
 
     fn header(&self) -> Paragraph<'_> {
@@ -485,7 +532,9 @@ impl TuiApp {
             Span::styled("Esc", key),
             Span::styled(" quit  ", lbl),
             Span::styled("Ctrl-C", key),
-            Span::styled(" quit", lbl),
+            Span::styled(" quit  ", lbl),
+            Span::styled("d", key),
+            Span::styled(" toggle debug", lbl),
         ]))
     }
 
@@ -582,17 +631,30 @@ fn sys_panel(s: SysStats) -> Paragraph<'static> {
     )
 }
 
-/// Non-blocking poll: returns true if the user pressed q / Esc / Ctrl-C.
-pub fn poll_quit() -> io::Result<bool> {
+#[derive(Clone, Copy)]
+pub enum TuiAction {
+    None,
+    Quit,
+    ToggleDebug,
+}
+
+/// Non-blocking poll for a single keypress.
+pub fn poll_action() -> io::Result<TuiAction> {
     if event::poll(Duration::from_millis(0))? {
         if let Event::Key(KeyEvent {
             code, modifiers, ..
         }) = event::read()?
         {
-            return Ok(matches!(code, KeyCode::Char('q') | KeyCode::Esc)
+            if matches!(code, KeyCode::Char('q') | KeyCode::Esc)
                 || (modifiers.contains(KeyModifiers::CONTROL)
-                    && matches!(code, KeyCode::Char('c'))));
+                    && matches!(code, KeyCode::Char('c')))
+            {
+                return Ok(TuiAction::Quit);
+            }
+            if matches!(code, KeyCode::Char('d')) {
+                return Ok(TuiAction::ToggleDebug);
+            }
         }
     }
-    Ok(false)
+    Ok(TuiAction::None)
 }


### PR DESCRIPTION
## Summary
- TUI is now compiled in unconditionally and runs by default. `--no-tui` or `--rerun-stream` falls back to plain stderr.
- New in-TUI debug panel toggled at runtime with `d` (or enabled at launch via `--debug`). Pipeline diagnostics are buffered into a ring instead of `eprintln!`, so they render cleanly inside the TUI.
- Added a UVC webcam `FrameSource` behind `--features webcam` (nokhwa-backed). The orb_slam example now runs live on `/dev/videoN` with `--fx/--fy/--cx/--cy`.
- `two_view`: `EstimationFailed` now carries the underlying `TwoViewError`, so bootstrap rejection logs name the actual failure (pure rotation, low parallax, planar degeneracy, etc.) instead of a generic string.
- `map.rs`: populated new `depth_meas` / `depth_sigma` fields on `BaObservation` (added in kornia-3d 0.1.14 for RGB-D / stereo BA — currently passed as `None`, so monocular behavior is unchanged).

## Test plan
- [ ] `cargo build -p orb_slam` (default features) — confirms TUI compiles unconditionally
- [ ] `cargo build -p orb_slam --features webcam` — confirms webcam source compiles
- [ ] EuRoC easy first 500 frames with default flags — TUI renders, BEV + camera panels populate
- [ ] Press `d` in TUI — debug panel appears/disappears, messages start/stop flowing
- [ ] `--no-tui` falls back to stderr status lines with debug messages when `--debug` is set
- [ ] Webcam: `cargo run --release -p orb_slam --features webcam -- --debug webcam --index 0 --fx 600 --fy 600 --cx 320 --cy 240`