### PR TITLE
ci: trigger on develop, add feature matrix + sccache

### DIFF
--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -1,0 +1,41 @@
+name: Setup Rust Cache
+description: Cache the Cargo registry and optionally enable sccache for compile-output caching.
+inputs:
+  cache-prefix:
+    description: Prefix for the cache key
+    required: false
+    default: "cargo"
+  with-sccache:
+    description: Whether to install and configure sccache
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ inputs.cache-prefix }}-${{ runner.os }}-${{ runner.arch }}-
+    - name: Install sccache
+      if: inputs.with-sccache == 'true'
+      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Configure sccache
+      if: inputs.with-sccache == 'true'
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "SCCACHE_CACHE_SIZE=6G" >> $GITHUB_ENV
+    - name: Start sccache server
+      if: inputs.with-sccache == 'true'
+      shell: bash
+      run: |
+        sccache --stop-server 2>/dev/null || true
+        sccache --start-server || true
+        sccache --show-stats || echo "::warning::sccache server may not be running"

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -3,51 +3,98 @@ name: Rust Lint
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
-      - "src/**"
+      - "crates/**"
       - "examples/**"
       - "tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/rust_lint.yml"
+      - ".github/actions/setup-rust-cache/**"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
-      - "src/**"
+      - "crates/**"
       - "examples/**"
       - "tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/rust_lint.yml"
+      - ".github/actions/setup-rust-cache/**"
 
 jobs:
-  lint:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Rustfmt
-            command: cargo fmt -- --check
-          - name: Clippy
+          # Default workspace lint: covers the library and the example with
+          # its default feature set (viz).
+          - name: workspace-default
+            apt: ""
             command: cargo clippy --all-targets -- -D warnings
-          - name: Example Rustfmt
-            command: cargo fmt --manifest-path examples/orb_slam/Cargo.toml -- --check
-          - name: Example Clippy
-            command: cargo clippy --manifest-path examples/orb_slam/Cargo.toml --all-targets -- -D warnings
+
+          # Example with no default features — exercises the non-viz, non-rerun
+          # build path. TUI deps are now unconditional, so this also verifies
+          # the example still compiles without the rerun integration.
+          - name: example-no-default
+            apt: ""
+            command: >-
+              cargo clippy
+              --manifest-path examples/orb_slam/Cargo.toml
+              --no-default-features
+              --all-targets
+              -- -D warnings
+
+          # Example with the UVC source enabled. nokhwa's native Linux backend
+          # needs the V4L2 headers from libv4l-dev.
+          - name: example-uvc
+            apt: "libv4l-dev"
+            command: >-
+              cargo clippy
+              --manifest-path examples/orb_slam/Cargo.toml
+              --features uvc
+              --all-targets
+              -- -D warnings
+
+          # NOTE: the `oakd` feature is intentionally not in this matrix.
+          # depthai-sys builds depthai-core from source (~5–10 min wall, GBs
+          # of artefacts) and pins LIBCLANG_PATH to a system clang. The
+          # build is too expensive for the default CI loop — gate it behind
+          # a dedicated workflow if/when we want it covered.
 
     steps:
-      - name: Checkout kornia-slam
-        uses: actions/checkout@v4
-        with:
-          path: kornia-slam
+      - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      - uses: ./.github/actions/setup-rust-cache
 
-      - name: Run ${{ matrix.name }}
-        working-directory: kornia-slam
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install apt deps
+        if: matrix.apt != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt }}
+
+      - name: ${{ matrix.command }}
         run: ${{ matrix.command }}
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats 2>&1 || echo "::warning::sccache stats unavailable"

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -3,41 +3,83 @@ name: Rust Test
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
-      - "src/**"
+      - "crates/**"
       - "examples/**"
       - "tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/rust_test.yml"
+      - ".github/actions/setup-rust-cache/**"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
-      - "src/**"
+      - "crates/**"
       - "examples/**"
       - "tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/rust_test.yml"
+      - ".github/actions/setup-rust-cache/**"
 
 jobs:
   test:
+    name: Test (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Default workspace: runs the actual test suite and a CLI smoke run
+          # on the example with default features (viz + tui).
+          - name: workspace-default
+            apt: ""
+            test_cmd: cargo test --workspace
+            build_cmd: cargo run -p orb_slam -- --help
+
+          # Example with no default features — just confirms the non-viz build
+          # links and the CLI parses.
+          - name: example-no-default
+            apt: ""
+            test_cmd: ""
+            build_cmd: >-
+              cargo run
+              --manifest-path examples/orb_slam/Cargo.toml
+              --no-default-features
+              -- --help
+
+          # Example with the UVC source — build only (the runner has no camera,
+          # so we can't actually open the device).
+          - name: example-uvc
+            apt: "libv4l-dev"
+            test_cmd: ""
+            build_cmd: >-
+              cargo build
+              --manifest-path examples/orb_slam/Cargo.toml
+              --features uvc
 
     steps:
-      - name: Checkout kornia-slam
-        uses: actions/checkout@v4
-        with:
-          path: kornia-slam
+      - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-cache
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install apt deps
+        if: matrix.apt != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt }}
 
       - name: Run tests
-        working-directory: kornia-slam
-        run: cargo test
+        if: matrix.test_cmd != ''
+        run: ${{ matrix.test_cmd }}
 
-      - name: Build standalone example
-        working-directory: kornia-slam
-        run: cargo run --manifest-path examples/orb_slam/Cargo.toml -- --help
+      - name: Build / smoke-run
+        run: ${{ matrix.build_cmd }}
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats 2>&1 || echo "::warning::sccache stats unavailable"

--- a/crates/kornia-sensors/Cargo.toml
+++ b/crates/kornia-sensors/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 description = "Physical sensor processing for kornia: IMU preintegration, noise models, and calibration."
 
 [dependencies]
-kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "feat/slam-utils" }
+kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 glam = "0.30"

--- a/crates/kornia-slam/src/estimation/two_view.rs
+++ b/crates/kornia-slam/src/estimation/two_view.rs
@@ -14,8 +14,8 @@
 
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
-use kornia_3d::pose::{TriangulationConfig, TwoViewEstimator, TwoViewModel};
 pub use kornia_3d::pose::TwoViewError;
+use kornia_3d::pose::{TriangulationConfig, TwoViewEstimator, TwoViewModel};
 use kornia_algebra::Vec3F64;
 use kornia_imgproc::features::{OrbFeatures, OrbMatchConfig, match_orb_descriptors};
 

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -197,11 +197,8 @@ impl MapPoint {
                 let mut best_idx = 0usize;
                 let mut best_median = u32::MAX;
                 for i in 0..n {
-                    for j in 0..n {
-                        dist_buf[j] = hamming_distance(
-                            &self.observed_descriptors[i],
-                            &self.observed_descriptors[j],
-                        );
+                    for (slot, other) in dist_buf.iter_mut().zip(self.observed_descriptors.iter()) {
+                        *slot = hamming_distance(&self.observed_descriptors[i], other);
                     }
                     let mid = n / 2;
                     dist_buf.select_nth_unstable(mid);
@@ -450,12 +447,7 @@ impl Map {
     /// bounds for one map point from its observing keyframes (ORB-SLAM3's
     /// `MapPoint::UpdateNormalAndDepth`). No-op if the point is culled or its
     /// reference keyframe is missing.
-    pub fn update_map_point_geometry(
-        &mut self,
-        mp_idx: usize,
-        scale_factor: f64,
-        n_levels: usize,
-    ) {
+    pub fn update_map_point_geometry(&mut self, mp_idx: usize, scale_factor: f64, n_levels: usize) {
         let (position, kf_indices, ref_kf_idx, ref_octave) = {
             let Some(mp) = self.map_points.get(mp_idx) else {
                 return;
@@ -479,7 +471,7 @@ impl Map {
                 let dir = position - cam_center;
                 let len = dir.length();
                 if len > 1e-9 {
-                    normal = normal + dir / len;
+                    normal += dir / len;
                     n += 1;
                 }
             }
@@ -705,7 +697,11 @@ impl Map {
 
         let mut mp_set: HashSet<usize> = HashSet::new();
         for &kf_idx in &kf_indices {
-            for mp_idx in self.keyframes[kf_idx].map_point_by_desc_idx.iter().flatten() {
+            for mp_idx in self.keyframes[kf_idx]
+                .map_point_by_desc_idx
+                .iter()
+                .flatten()
+            {
                 if let Some(mp) = self.map_points.get(*mp_idx)
                     && !mp.culled
                 {
@@ -911,7 +907,8 @@ impl Map {
         }
 
         let ba_result =
-            match bundle_adjust_schur(&poses, &points, &observations, camera, &BaParams::default()) {
+            match bundle_adjust_schur(&poses, &points, &observations, camera, &BaParams::default())
+            {
                 Ok(r) => r,
                 Err(_) => return,
             };
@@ -955,7 +952,11 @@ fn initial_ba_diagnostics(
             count += 1;
         }
     }
-    let mean_sq = if count > 0 { sum_sq / count as f64 } else { 0.0 };
+    let mean_sq = if count > 0 {
+        sum_sq / count as f64
+    } else {
+        0.0
+    };
 
     let median_depth = match poses.first() {
         Some(kf0) => {

--- a/examples/common/source/uvc.rs
+++ b/examples/common/source/uvc.rs
@@ -15,23 +15,17 @@ use std::time::Instant;
 use kornia_3d::camera::PinholeCamera;
 use kornia_image::{Image, ImageSize};
 use kornia_tensor::CpuAllocator;
+use nokhwa::Camera;
 use nokhwa::pixel_format::LumaFormat;
 use nokhwa::utils::{
     ApiBackend, CameraFormat, CameraIndex, FrameFormat, RequestedFormat, RequestedFormatType,
 };
-use nokhwa::Camera;
 
 /// Open the device at `index` with a closest-resolution request for the given
 /// frame format. Returns the camera ready to stream (caller must `open_stream`).
-fn try_open(
-    index: u32,
-    width: u32,
-    height: u32,
-    fmt: FrameFormat,
-) -> Result<Camera, SourceError> {
+fn try_open(index: u32, width: u32, height: u32, fmt: FrameFormat) -> Result<Camera, SourceError> {
     let target = CameraFormat::new_from(width, height, fmt, 30);
-    let requested =
-        RequestedFormat::new::<LumaFormat>(RequestedFormatType::Closest(target));
+    let requested = RequestedFormat::new::<LumaFormat>(RequestedFormatType::Closest(target));
     Camera::with_backend(CameraIndex::Index(index), requested, ApiBackend::Auto)
         .map_err(SourceError::other)
 }
@@ -63,12 +57,11 @@ impl UvcSource {
     ) -> Result<Self, SourceError> {
         eprintln!("[uvc] opening camera index {index}…");
 
-        let mut camera_dev = try_open(index, width, height, FrameFormat::MJPEG).or_else(
-            |first_err| {
+        let mut camera_dev =
+            try_open(index, width, height, FrameFormat::MJPEG).or_else(|first_err| {
                 eprintln!("[uvc] MJPEG open failed ({first_err}); trying YUYV…");
                 try_open(index, width, height, FrameFormat::YUYV)
-            },
-        )?;
+            })?;
 
         camera_dev.open_stream().map_err(SourceError::other)?;
 

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -30,11 +30,11 @@ use config::PipelineConfig;
 use kornia_3d::pose::Pose3d;
 use kornia_slam::Frame;
 use pipeline::Pipeline;
-use source::{EurocSource, FrameItem, FrameSource};
 #[cfg(feature = "oakd")]
 use source::OakdSource;
 #[cfg(feature = "uvc")]
 use source::UvcSource;
+use source::{EurocSource, FrameItem, FrameSource};
 use utils::trajectory_point_from_pose;
 
 #[cfg(feature = "viz")]

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -277,9 +277,11 @@ impl Pipeline {
             triangulated.push((p_world, descriptor, color, ref_desc_idx, curr_desc_idx));
         }
 
-        let added =
-            self.map
-                .add_triangulated_points(Some(&mut reference_kf), &mut current_kf, &triangulated);
+        let added = self.map.add_triangulated_points(
+            Some(&mut reference_kf),
+            &mut current_kf,
+            &triangulated,
+        );
 
         self.map.upsert_keyframe(reference_kf);
         self.map.upsert_keyframe(current_kf);
@@ -448,8 +450,7 @@ impl Pipeline {
         // Forward SearchInNeighbors / Fuse: extend each curr_kf-observed map
         // point's observation list to neighbor KFs that don't yet observe it.
         // Run before local BA so BA sees the extra reprojection constraints.
-        let neighbor_kf_indices: Vec<usize> =
-            neighbor_kfs.iter().map(|kf| kf.frame.idx).collect();
+        let neighbor_kf_indices: Vec<usize> = neighbor_kfs.iter().map(|kf| kf.frame.idx).collect();
         let n_fused = self.fuse_into_neighbors(frame.idx, &neighbor_kf_indices);
         self.dbg(format!("[fuse] frame={} fused={}", frame.idx, n_fused));
 
@@ -617,7 +618,8 @@ impl Pipeline {
         // its desc slot pointed at the new map point.
         for (i, &(_, _, _, prev_desc_idx, _)) in points.iter().take(added).enumerate() {
             let mp_idx = first_mp_idx + i;
-            self.map.register_observation(mp_idx, prev_kf, prev_desc_idx);
+            self.map
+                .register_observation(mp_idx, prev_kf, prev_desc_idx);
             if let Some(prev_live) = self.map.get_keyframe_mut(prev_kf_idx) {
                 prev_live.associate_map_point(prev_desc_idx, mp_idx);
             }
@@ -632,11 +634,7 @@ impl Pipeline {
     /// descriptor, register the observation. Mirrors a subset of ORB-SLAM3's
     /// `SearchInNeighbors` (forward direction only; we don't yet do duplicate
     /// merging or the second-hop covisible expansion).
-    fn fuse_into_neighbors(
-        &mut self,
-        curr_kf_idx: usize,
-        neighbor_kf_indices: &[usize],
-    ) -> usize {
+    fn fuse_into_neighbors(&mut self, curr_kf_idx: usize, neighbor_kf_indices: &[usize]) -> usize {
         const FUSE_SEARCH_RADIUS_PX: f32 = 7.0;
         const FUSE_MAX_HAMMING: u32 = 50;
 
@@ -699,11 +697,10 @@ impl Pipeline {
                 if p_cam.z <= 0.0 {
                     continue;
                 }
-                let Ok(pixel) = self.camera.project_to_image(
-                    &p_cam,
-                    0.0,
-                    nb_kf.frame.image_size,
-                ) else {
+                let Ok(pixel) = self
+                    .camera
+                    .project_to_image(&p_cam, 0.0, nb_kf.frame.image_size)
+                else {
                     continue;
                 };
                 let u = pixel.x as f32;
@@ -722,10 +719,8 @@ impl Pipeline {
                     if dx * dx + dy * dy > r2 {
                         continue;
                     }
-                    let dist = hamming_distance(
-                        &mp.descriptor,
-                        &nb_kf.frame.features.descriptors[kp_idx],
-                    );
+                    let dist =
+                        hamming_distance(&mp.descriptor, &nb_kf.frame.features.descriptors[kp_idx]);
                     if dist < best_dist {
                         best_dist = dist;
                         best_kp = kp_idx;

--- a/examples/orb_slam/src/tui.rs
+++ b/examples/orb_slam/src/tui.rs
@@ -154,28 +154,19 @@ pub struct SysStats {
 /// Reads `/proc/self/status` + `getrusage` and caches the result so we don't
 /// re-hit the kernel on every frame. CPU% is computed as the delta of
 /// utime+stime since the last full sample, over wall-clock delta.
+#[derive(Default)]
 pub struct SysStatsSampler {
     last_cpu_us: i64,
     last_wall: Option<Instant>,
     cached: Option<(Instant, SysStats)>,
 }
 
-impl Default for SysStatsSampler {
-    fn default() -> Self {
-        Self {
-            last_cpu_us: 0,
-            last_wall: None,
-            cached: None,
-        }
-    }
-}
-
 impl SysStatsSampler {
     pub fn sample(&mut self) -> SysStats {
-        if let Some((t, s)) = self.cached {
-            if t.elapsed() < Duration::from_millis(250) {
-                return s;
-            }
+        if let Some((t, s)) = self.cached
+            && t.elapsed() < Duration::from_millis(250)
+        {
+            return s;
         }
         let (rss_kb, peak_rss_kb, threads) = read_proc_status();
         let now_us = getrusage_total_us();
@@ -405,7 +396,10 @@ impl TuiApp {
         let label = Style::default().fg(C_LABEL);
         let line = Line::from(vec![
             Span::styled(" frame ", label),
-            Span::styled(format!("{:>4}/{:<4}", self.frame_idx, self.n_frames), bold_value),
+            Span::styled(
+                format!("{:>4}/{:<4}", self.frame_idx, self.n_frames),
+                bold_value,
+            ),
             Span::styled("  status: ", label),
             Span::styled(
                 format!("{:<16}", self.status.label()),
@@ -416,12 +410,18 @@ impl TuiApp {
             Span::styled("kf=", label),
             Span::styled(format!("{:<5}", self.kf_idx), Style::default().fg(C_VALUE)),
             Span::styled(" mp=", label),
-            Span::styled(format!("{:<5}", self.n_active_mp), Style::default().fg(C_VALUE)),
+            Span::styled(
+                format!("{:<5}", self.n_active_mp),
+                Style::default().fg(C_VALUE),
+            ),
             Span::styled("  ", label),
             Span::styled(format!("{:>5.1} ms", self.frame_ms), bold_value),
             Span::styled(format!(" ({:>5.1} fps)", instant_fps), label),
             Span::styled("  mean ", label),
-            Span::styled(format!("{:>5.1} ms", self.mean_ms), Style::default().fg(C_VALUE)),
+            Span::styled(
+                format!("{:>5.1} ms", self.mean_ms),
+                Style::default().fg(C_VALUE),
+            ),
             Span::styled(format!(" ({:>5.1} fps)", mean_fps), label),
         ]);
         Paragraph::new(line).block(
@@ -640,20 +640,18 @@ pub enum TuiAction {
 
 /// Non-blocking poll for a single keypress.
 pub fn poll_action() -> io::Result<TuiAction> {
-    if event::poll(Duration::from_millis(0))? {
-        if let Event::Key(KeyEvent {
+    if event::poll(Duration::from_millis(0))?
+        && let Event::Key(KeyEvent {
             code, modifiers, ..
         }) = event::read()?
+    {
+        if matches!(code, KeyCode::Char('q') | KeyCode::Esc)
+            || (modifiers.contains(KeyModifiers::CONTROL) && matches!(code, KeyCode::Char('c')))
         {
-            if matches!(code, KeyCode::Char('q') | KeyCode::Esc)
-                || (modifiers.contains(KeyModifiers::CONTROL)
-                    && matches!(code, KeyCode::Char('c')))
-            {
-                return Ok(TuiAction::Quit);
-            }
-            if matches!(code, KeyCode::Char('d')) {
-                return Ok(TuiAction::ToggleDebug);
-            }
+            return Ok(TuiAction::Quit);
+        }
+        if matches!(code, KeyCode::Char('d')) {
+            return Ok(TuiAction::ToggleDebug);
         }
     }
     Ok(TuiAction::None)

--- a/examples/orb_slam/src/utils.rs
+++ b/examples/orb_slam/src/utils.rs
@@ -1,8 +1,8 @@
 //! Minimal Rerun visualization helpers for the ORB-SLAM example.
 
-use kornia_3d::pose::Pose3d;
 #[cfg(feature = "viz")]
 use kornia_3d::camera::PinholeCamera;
+use kornia_3d::pose::Pose3d;
 #[cfg(feature = "viz")]
 use kornia_algebra::Mat3F64;
 #[cfg(feature = "viz")]


### PR DESCRIPTION
## Summary
Wraps up three CI gaps from the brainstorm:

1. **Workflows now trigger on `develop`.** Previously `Rust Lint` and `Rust Test` were scoped to `main`, so PRs targeting `develop` (the working branch — including #35 just merged) ran zero CI.
2. **Feature matrix.** Lint and test now both fan out across:
   - `workspace-default` — full workspace, default features
   - `example-no-default` — `examples/orb_slam` with `--no-default-features` (no viz, no rerun)
   - `example-uvc` — `examples/orb_slam` with `--features uvc` (installs `libv4l-dev` for nokhwa)
   `oakd` is intentionally skipped because depthai-core builds C++ from source (~5–10 min wall + several GB) — a comment in the workflow flags this for a future dedicated job.
3. **sccache.** New composite action `.github/actions/setup-rust-cache` wraps `actions/cache@v4` (Cargo registry) + `mozilla-actions/sccache-action` (GHA backend). Borrowed pattern from kornia-rs. Both workflows now use it.

Surfaced and fixed several pre-existing lint/fmt issues the new matrix would have caught:
- `tui.rs`: derive `Default` for `SysStatsSampler`, collapse two nested `if let` chains
- `map.rs`: replace `normal = normal + dir / len` with `+=`; rewrite an indexed loop over `dist_buf` as `iter_mut().zip(...)`

## Test plan
- [ ] CI on this PR shows all three lint matrix jobs and three test matrix jobs green
- [ ] `cargo clippy --all-targets -- -D warnings` clean locally
- [ ] `cargo clippy --manifest-path examples/orb_slam/Cargo.toml --no-default-features --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] Cold-cache run posts sccache stats; warm run shows >0% hit rate