### PR TITLE
feat(orb_slam): add MCAP file source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7630,7 +7630,6 @@ dependencies = [
  "ciborium",
  "crossterm 0.28.1",
  "depthai",
- "image",
  "kornia-3d",
  "kornia-algebra",
  "kornia-image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1742,6 +1742,33 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -3226,7 +3253,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3824,7 +3851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4361,8 +4388,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5550,7 +5577,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6228,6 +6255,26 @@ dependencies = [
 
 [[package]]
 name = "mcap"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6588e4dc226780722a91977b81dd105d0fa2cf732d52c76b77a14ca5a5d6e04f"
+dependencies = [
+ "bimap",
+ "binrw",
+ "byteorder",
+ "crc32fast",
+ "enumset",
+ "log",
+ "lz4",
+ "num_cpus",
+ "paste",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "zstd",
+]
+
+[[package]]
+name = "mcap"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3ca583fed649ed7cd8c976b59422996472c6b08067308443e0b60c56e0a4ca"
@@ -6897,7 +6944,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7580,8 +7627,10 @@ name = "orb_slam"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "ciborium",
  "crossterm 0.28.1",
  "depthai",
+ "image",
  "kornia-3d",
  "kornia-algebra",
  "kornia-image",
@@ -7590,6 +7639,7 @@ dependencies = [
  "kornia-slam",
  "kornia-tensor",
  "libc",
+ "mcap 0.21.0",
  "nokhwa",
  "ratatui",
  "rerun",
@@ -8968,7 +9018,7 @@ dependencies = [
  "image",
  "indexmap 2.13.0",
  "itertools 0.14.0",
- "mcap",
+ "mcap 0.23.4",
  "memmap2 0.9.10",
  "notify",
  "parking_lot",
@@ -9409,7 +9459,7 @@ dependencies = [
  "arrow",
  "byteorder",
  "cdr-encoding",
- "mcap",
+ "mcap 0.23.4",
  "prost-reflect",
  "re_chunk",
  "re_log",
@@ -11090,7 +11140,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11710,7 +11760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11948,7 +11998,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12555,7 +12605,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13388,7 +13438,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/common/source/mcap.rs
+++ b/examples/common/source/mcap.rs
@@ -4,14 +4,19 @@
 //! one chosen channel. The default channel suffix is `mono_left` — already
 //! grayscale at 640×400, no color conversion needed. Each MCAP message is a
 //! CBOR-wrapped SDK envelope `{header, body:{width, height, encoding:"jpeg", data}}`;
-//! we strip the envelope, JPEG-decode `body.data`, and convert to luma8.
+//! we strip the envelope, JPEG-decode `body.data` via `kornia-io`, and (for
+//! the color `compressed` channel) convert to luma8 via `kornia-imgproc`.
 
 use std::fs;
 use std::path::Path;
 
 use ciborium::value::Value as CborValue;
 use kornia_3d::camera::PinholeCamera;
-use kornia_image::{Image, ImageSize};
+use kornia_image::Image;
+use kornia_imgproc::color::gray_from_rgb_u8;
+use kornia_io::jpeg::{
+    decode_image_jpeg_layout, decode_image_jpeg_mono8, decode_image_jpeg_rgb8,
+};
 use kornia_tensor::CpuAllocator;
 use mcap::McapError;
 
@@ -66,22 +71,15 @@ impl McapSource {
                     msg.channel.topic
                 ))
             })?;
-            let (width, height, jpeg_bytes) = extract_jpeg(body).ok_or_else(|| {
+            let jpeg_bytes = extract_jpeg(body).ok_or_else(|| {
                 SourceError::other(format!(
                     "MCAP message on {} has no JPEG payload (expected encoding=jpeg + data)",
                     msg.channel.topic
                 ))
             })?;
-            let img = image::load_from_memory_with_format(
-                jpeg_bytes,
-                image::ImageFormat::Jpeg,
-            )
-            .map_err(SourceError::other)?
-            .to_luma8();
-            let (got_w, got_h) = (img.width() as usize, img.height() as usize);
-            // Width/height in the body are metadata; trust the decoded image
-            // for the actual bytes (in case the encoder lied).
-            let _ = (width, height);
+
+            let image = decode_jpeg_to_luma(jpeg_bytes).map_err(SourceError::other)?;
+            let (got_w, got_h) = (image.width(), image.height());
             if let Some(prev) = first_size {
                 if prev != (got_w, got_h) {
                     return Err(SourceError::other(format!(
@@ -91,12 +89,6 @@ impl McapSource {
             } else {
                 first_size = Some((got_w, got_h));
             }
-            let image_size = ImageSize {
-                width: got_w,
-                height: got_h,
-            };
-            let image: Image<u8, 1, CpuAllocator> =
-                Image::new(image_size, img.into_raw(), CpuAllocator).map_err(SourceError::other)?;
             decoded.push(PreparedFrame {
                 timestamp_sec: msg.log_time as f64 / 1e9,
                 image,
@@ -181,6 +173,30 @@ impl FrameSource for McapSource {
     }
 }
 
+/// Decode a JPEG payload to a luma8 image. Mono JPEGs are decoded directly;
+/// RGB JPEGs (used by the `compressed` channel) are decoded then converted.
+fn decode_jpeg_to_luma(
+    jpeg_bytes: &[u8],
+) -> Result<Image<u8, 1, CpuAllocator>, Box<dyn std::error::Error + Send + Sync>> {
+    let layout = decode_image_jpeg_layout(jpeg_bytes)?;
+    let size = layout.image_size;
+    match layout.channels {
+        1 => {
+            let mut dst = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
+            decode_image_jpeg_mono8(jpeg_bytes, &mut dst)?;
+            Ok(dst)
+        }
+        3 => {
+            let mut rgb = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
+            decode_image_jpeg_rgb8(jpeg_bytes, &mut rgb)?;
+            let mut gray = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
+            gray_from_rgb_u8(&rgb, &mut gray)?;
+            Ok(gray)
+        }
+        n => Err(format!("unsupported JPEG channel count: {n} (want 1 or 3)").into()),
+    }
+}
+
 /// `{header, body}` envelope → body. Returns None if the value isn't a map
 /// containing a `body` key.
 fn unwrap_body(value: &CborValue) -> Option<&CborValue> {
@@ -196,23 +212,19 @@ fn unwrap_body(value: &CborValue) -> Option<&CborValue> {
     None
 }
 
-/// Pull `(width, height, jpeg_bytes)` out of either a flat
-/// `{width, height, encoding:"jpeg", data}` mono body or the nested
-/// `{rgb:{encoding:"jpeg", data}}` from the `compressed` channel.
-fn extract_jpeg(body: &CborValue) -> Option<(u32, u32, &[u8])> {
+/// Pull JPEG bytes out of either a flat `{encoding:"jpeg", data}` body or
+/// the nested `{rgb:{encoding:"jpeg", data}}` shape from the `compressed`
+/// channel.
+fn extract_jpeg(body: &CborValue) -> Option<&[u8]> {
     let CborValue::Map(entries) = body else {
         return None;
     };
-    let mut width: Option<u32> = None;
-    let mut height: Option<u32> = None;
     let mut encoding: Option<&str> = None;
     let mut data: Option<&[u8]> = None;
     let mut rgb_sub: Option<&CborValue> = None;
     for (k, v) in entries {
         let CborValue::Text(key) = k else { continue };
         match key.as_str() {
-            "width" => width = cbor_u32(v),
-            "height" => height = cbor_u32(v),
             "encoding" => encoding = cbor_text(v),
             "data" => data = cbor_bytes(v),
             "rgb" => rgb_sub = Some(v),
@@ -221,23 +233,13 @@ fn extract_jpeg(body: &CborValue) -> Option<(u32, u32, &[u8])> {
     }
     if let (Some(enc), Some(d)) = (encoding, data) {
         if enc == "jpeg" {
-            return Some((width.unwrap_or(0), height.unwrap_or(0), d));
+            return Some(d);
         }
     }
     if let Some(rgb) = rgb_sub {
-        // Recurse into nested rgb plane; reuse same width/height from outer body.
-        if let Some((_, _, d)) = extract_jpeg(rgb) {
-            return Some((width.unwrap_or(0), height.unwrap_or(0), d));
-        }
+        return extract_jpeg(rgb);
     }
     None
-}
-
-fn cbor_u32(v: &CborValue) -> Option<u32> {
-    match v {
-        CborValue::Integer(i) => u32::try_from(i128::from(*i)).ok(),
-        _ => None,
-    }
 }
 
 fn cbor_text(v: &CborValue) -> Option<&str> {

--- a/examples/common/source/mcap.rs
+++ b/examples/common/source/mcap.rs
@@ -1,0 +1,259 @@
+//! MCAP file as a [`FrameSource`].
+//!
+//! Reads a bubbaloop `mcap-recorder` session and yields grayscale frames from
+//! one chosen channel. The default channel suffix is `mono_left` — already
+//! grayscale at 640×400, no color conversion needed. Each MCAP message is a
+//! CBOR-wrapped SDK envelope `{header, body:{width, height, encoding:"jpeg", data}}`;
+//! we strip the envelope, JPEG-decode `body.data`, and convert to luma8.
+
+use std::fs;
+use std::path::Path;
+
+use ciborium::value::Value as CborValue;
+use kornia_3d::camera::PinholeCamera;
+use kornia_image::{Image, ImageSize};
+use kornia_tensor::CpuAllocator;
+use mcap::McapError;
+
+use super::{FrameItem, FrameSource, SourceError};
+
+/// A pre-decoded grayscale frame queued for `next_frame`.
+struct PreparedFrame {
+    timestamp_sec: f64,
+    image: Image<u8, 1, CpuAllocator>,
+}
+
+/// Offline MCAP frame source.
+pub struct McapSource {
+    frames: std::vec::IntoIter<PreparedFrame>,
+    n_total: usize,
+    cursor: usize,
+    camera: PinholeCamera,
+}
+
+impl McapSource {
+    /// Open `path`, pick the channel whose topic ends in `/<channel_suffix>`,
+    /// JPEG-decode every message to luma8, and stash the result.
+    ///
+    /// `start_frame` and `max_frames` mirror `EurocSource`: skip the first
+    /// `start_frame`, then yield up to `max_frames` (0 = until exhausted).
+    pub fn open(
+        path: &Path,
+        channel_suffix: &str,
+        start_frame: usize,
+        max_frames: usize,
+    ) -> Result<Self, SourceError> {
+        // Read the whole file into memory. mcap::MessageStream borrows from
+        // a byte slice; for our recordings (a few hundred MB at most) this is
+        // simpler than memory-mapping and the parsing is still streaming on
+        // top of the buffer. Switch to memmap2 if the recordings grow huge.
+        let bytes = fs::read(path).map_err(SourceError::Io)?;
+        let mut decoded: Vec<PreparedFrame> = Vec::new();
+        let mut first_size: Option<(usize, usize)> = None;
+
+        let want = format!("/{channel_suffix}");
+        let stream = mcap::MessageStream::new(&bytes).map_err(map_mcap)?;
+        for msg_result in stream {
+            let msg = msg_result.map_err(map_mcap)?;
+            if !msg.channel.topic.ends_with(&want) {
+                continue;
+            }
+            let envelope: CborValue =
+                ciborium::from_reader(msg.data.as_ref()).map_err(SourceError::other)?;
+            let body = unwrap_body(&envelope).ok_or_else(|| {
+                SourceError::other(format!(
+                    "MCAP message on {} is not a {{header, body}} envelope",
+                    msg.channel.topic
+                ))
+            })?;
+            let (width, height, jpeg_bytes) = extract_jpeg(body).ok_or_else(|| {
+                SourceError::other(format!(
+                    "MCAP message on {} has no JPEG payload (expected encoding=jpeg + data)",
+                    msg.channel.topic
+                ))
+            })?;
+            let img = image::load_from_memory_with_format(
+                jpeg_bytes,
+                image::ImageFormat::Jpeg,
+            )
+            .map_err(SourceError::other)?
+            .to_luma8();
+            let (got_w, got_h) = (img.width() as usize, img.height() as usize);
+            // Width/height in the body are metadata; trust the decoded image
+            // for the actual bytes (in case the encoder lied).
+            let _ = (width, height);
+            if let Some(prev) = first_size {
+                if prev != (got_w, got_h) {
+                    return Err(SourceError::other(format!(
+                        "frame size changed mid-stream: {prev:?} → {got_w}x{got_h}"
+                    )));
+                }
+            } else {
+                first_size = Some((got_w, got_h));
+            }
+            let image_size = ImageSize {
+                width: got_w,
+                height: got_h,
+            };
+            let image: Image<u8, 1, CpuAllocator> =
+                Image::new(image_size, img.into_raw(), CpuAllocator).map_err(SourceError::other)?;
+            decoded.push(PreparedFrame {
+                timestamp_sec: msg.log_time as f64 / 1e9,
+                image,
+            });
+        }
+
+        if decoded.is_empty() {
+            return Err(SourceError::other(format!(
+                "no messages found on a channel ending with /{channel_suffix}"
+            )));
+        }
+
+        let (w, h) = first_size.expect("first_size set when decoded non-empty");
+
+        // Trim using start_frame / max_frames.
+        let start = start_frame.min(decoded.len());
+        let mut trimmed: Vec<PreparedFrame> = decoded.into_iter().skip(start).collect();
+        if max_frames > 0 && trimmed.len() > max_frames {
+            trimmed.truncate(max_frames);
+        }
+        let n_total = trimmed.len();
+
+        // Re-base timestamps to start at 0 — easier to read in logs and
+        // matches what live sources (oakd/uvc) do via `Instant::elapsed`.
+        if let Some(t0) = trimmed.first().map(|f| f.timestamp_sec) {
+            for f in trimmed.iter_mut() {
+                f.timestamp_sec -= t0;
+            }
+        }
+
+        // Placeholder intrinsics. OAK-D mono is 1280×800 native @ fx≈fy≈880;
+        // our recorded mono is 640×400 so scale=0.5.
+        let scale = w as f64 / 1280.0;
+        let camera = PinholeCamera {
+            fx: 880.0 * scale,
+            fy: 880.0 * scale,
+            cx: w as f64 * 0.5,
+            cy: h as f64 * 0.5,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        };
+
+        eprintln!(
+            "[mcap] {}: {n_total} frames @ {w}x{h} from /{channel_suffix} \
+             (placeholder intrinsics fx={:.2} fy={:.2})",
+            path.display(),
+            camera.fx,
+            camera.fy,
+        );
+
+        Ok(Self {
+            frames: trimmed.into_iter(),
+            n_total,
+            cursor: 0,
+            camera,
+        })
+    }
+}
+
+impl FrameSource for McapSource {
+    fn camera(&self) -> PinholeCamera {
+        self.camera.clone()
+    }
+
+    fn n_frames_hint(&self) -> Option<usize> {
+        Some(self.n_total)
+    }
+
+    fn next_frame(&mut self) -> Result<Option<FrameItem>, SourceError> {
+        let Some(prepared) = self.frames.next() else {
+            return Ok(None);
+        };
+        let idx = self.cursor;
+        self.cursor += 1;
+        Ok(Some(FrameItem {
+            idx,
+            timestamp_sec: prepared.timestamp_sec,
+            image: prepared.image,
+        }))
+    }
+}
+
+/// `{header, body}` envelope → body. Returns None if the value isn't a map
+/// containing a `body` key.
+fn unwrap_body(value: &CborValue) -> Option<&CborValue> {
+    if let CborValue::Map(entries) = value {
+        for (k, v) in entries {
+            if let CborValue::Text(s) = k {
+                if s == "body" {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Pull `(width, height, jpeg_bytes)` out of either a flat
+/// `{width, height, encoding:"jpeg", data}` mono body or the nested
+/// `{rgb:{encoding:"jpeg", data}}` from the `compressed` channel.
+fn extract_jpeg(body: &CborValue) -> Option<(u32, u32, &[u8])> {
+    let CborValue::Map(entries) = body else {
+        return None;
+    };
+    let mut width: Option<u32> = None;
+    let mut height: Option<u32> = None;
+    let mut encoding: Option<&str> = None;
+    let mut data: Option<&[u8]> = None;
+    let mut rgb_sub: Option<&CborValue> = None;
+    for (k, v) in entries {
+        let CborValue::Text(key) = k else { continue };
+        match key.as_str() {
+            "width" => width = cbor_u32(v),
+            "height" => height = cbor_u32(v),
+            "encoding" => encoding = cbor_text(v),
+            "data" => data = cbor_bytes(v),
+            "rgb" => rgb_sub = Some(v),
+            _ => {}
+        }
+    }
+    if let (Some(enc), Some(d)) = (encoding, data) {
+        if enc == "jpeg" {
+            return Some((width.unwrap_or(0), height.unwrap_or(0), d));
+        }
+    }
+    if let Some(rgb) = rgb_sub {
+        // Recurse into nested rgb plane; reuse same width/height from outer body.
+        if let Some((_, _, d)) = extract_jpeg(rgb) {
+            return Some((width.unwrap_or(0), height.unwrap_or(0), d));
+        }
+    }
+    None
+}
+
+fn cbor_u32(v: &CborValue) -> Option<u32> {
+    match v {
+        CborValue::Integer(i) => u32::try_from(i128::from(*i)).ok(),
+        _ => None,
+    }
+}
+
+fn cbor_text(v: &CborValue) -> Option<&str> {
+    match v {
+        CborValue::Text(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+fn cbor_bytes(v: &CborValue) -> Option<&[u8]> {
+    match v {
+        CborValue::Bytes(b) => Some(b.as_slice()),
+        _ => None,
+    }
+}
+
+fn map_mcap(err: McapError) -> SourceError {
+    SourceError::other(err)
+}

--- a/examples/common/source/mcap.rs
+++ b/examples/common/source/mcap.rs
@@ -14,9 +14,7 @@ use ciborium::value::Value as CborValue;
 use kornia_3d::camera::PinholeCamera;
 use kornia_image::Image;
 use kornia_imgproc::color::gray_from_rgb_u8;
-use kornia_io::jpeg::{
-    decode_image_jpeg_layout, decode_image_jpeg_mono8, decode_image_jpeg_rgb8,
-};
+use kornia_io::jpeg::{decode_image_jpeg_layout, decode_image_jpeg_mono8, decode_image_jpeg_rgb8};
 use kornia_tensor::CpuAllocator;
 use mcap::McapError;
 
@@ -202,10 +200,10 @@ fn decode_jpeg_to_luma(
 fn unwrap_body(value: &CborValue) -> Option<&CborValue> {
     if let CborValue::Map(entries) = value {
         for (k, v) in entries {
-            if let CborValue::Text(s) = k {
-                if s == "body" {
-                    return Some(v);
-                }
+            if let CborValue::Text(s) = k
+                && s == "body"
+            {
+                return Some(v);
             }
         }
     }
@@ -231,10 +229,10 @@ fn extract_jpeg(body: &CborValue) -> Option<&[u8]> {
             _ => {}
         }
     }
-    if let (Some(enc), Some(d)) = (encoding, data) {
-        if enc == "jpeg" {
-            return Some(d);
-        }
+    if let (Some(enc), Some(d)) = (encoding, data)
+        && enc == "jpeg"
+    {
+        return Some(d);
     }
     if let Some(rgb) = rgb_sub {
         return extract_jpeg(rgb);

--- a/examples/common/source/mod.rs
+++ b/examples/common/source/mod.rs
@@ -5,6 +5,7 @@
 //! so the main binary can stay source-agnostic.
 
 pub mod euroc;
+pub mod mcap;
 #[cfg(feature = "oakd")]
 pub mod oakd;
 #[cfg(feature = "uvc")]
@@ -15,6 +16,7 @@ use kornia_image::Image;
 use kornia_tensor::CpuAllocator;
 
 pub use euroc::EurocSource;
+pub use mcap::McapSource;
 #[cfg(feature = "oakd")]
 pub use oakd::OakdSource;
 #[cfg(feature = "uvc")]

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -20,6 +20,9 @@ crossterm = "0.28"
 libc = "0.2"
 depthai = { version = "0.1", optional = true }
 nokhwa = { version = "0.10", optional = true, default-features = false, features = ["input-native", "decoding"] }
+mcap = "0.21"
+ciborium = "0.2"
+image = { version = "0.25", default-features = false, features = ["jpeg"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2"

--- a/examples/orb_slam/Cargo.toml
+++ b/examples/orb_slam/Cargo.toml
@@ -22,7 +22,6 @@ depthai = { version = "0.1", optional = true }
 nokhwa = { version = "0.10", optional = true, default-features = false, features = ["input-native", "decoding"] }
 mcap = "0.21"
 ciborium = "0.2"
-image = { version = "0.25", default-features = false, features = ["jpeg"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2"

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -5,6 +5,11 @@
 //! cargo run --release -p orb_slam -- euroc --data /path/to/V1_01_easy
 //! ```
 //!
+//! Run on a bubbaloop MCAP recording (defaults to the mono_left channel):
+//! ```text
+//! cargo run --release -p orb_slam -- mcap --path /path/to/recording.mcap
+//! ```
+//!
 //! Run live on an OAK-D camera (requires `--features oakd`):
 //! ```text
 //! cargo run --release -p orb_slam --features oakd -- oakd
@@ -34,7 +39,7 @@ use pipeline::Pipeline;
 use source::OakdSource;
 #[cfg(feature = "uvc")]
 use source::UvcSource;
-use source::{EurocSource, FrameItem, FrameSource};
+use source::{EurocSource, FrameItem, FrameSource, McapSource};
 use utils::trajectory_point_from_pose;
 
 #[cfg(feature = "viz")]
@@ -68,6 +73,7 @@ struct Args {
 #[argh(subcommand)]
 enum SourceCmd {
     Euroc(EurocCmd),
+    Mcap(McapCmd),
     #[cfg(feature = "oakd")]
     Oakd(OakdCmd),
     #[cfg(feature = "uvc")]
@@ -81,6 +87,31 @@ struct EurocCmd {
     /// path to EuRoC dataset root (e.g. V1_01_easy/)
     #[argh(option)]
     data: String,
+
+    /// maximum number of frames to process (0 = all)
+    #[argh(option, default = "0")]
+    max_frames: usize,
+
+    /// skip this many initial frames
+    #[argh(option, default = "0")]
+    start_frame: usize,
+}
+
+/// Run on a bubbaloop MCAP recording.
+///
+/// Defaults to the `mono_left` channel — 640×400 grayscale JPEGs, ready for
+/// the SLAM pipeline without color conversion. Pass `--channel mono_right`
+/// or `--channel compressed` to switch sources within the same file.
+#[derive(argh::FromArgs)]
+#[argh(subcommand, name = "mcap")]
+struct McapCmd {
+    /// path to an MCAP file recorded by the bubbaloop mcap-recorder
+    #[argh(option)]
+    path: String,
+
+    /// channel suffix to read (e.g. mono_left, mono_right, compressed)
+    #[argh(option, default = "String::from(\"mono_left\")")]
+    channel: String,
 
     /// maximum number of frames to process (0 = all)
     #[argh(option, default = "0")]
@@ -192,6 +223,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     e.start_frame,
                     e.start_frame + n,
                 );
+            }
+            Box::new(src)
+        }
+        SourceCmd::Mcap(m) => {
+            let src = McapSource::open(
+                std::path::Path::new(&m.path),
+                &m.channel,
+                m.start_frame,
+                m.max_frames,
+            )?;
+            if !tui_active {
+                if let Some(n) = src.n_frames_hint() {
+                    eprintln!("MCAP: {n} frames from /{}", m.channel);
+                }
             }
             Box::new(src)
         }

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -233,10 +233,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 m.start_frame,
                 m.max_frames,
             )?;
-            if !tui_active {
-                if let Some(n) = src.n_frames_hint() {
-                    eprintln!("MCAP: {n} frames from /{}", m.channel);
-                }
+            if !tui_active && let Some(n) = src.n_frames_hint() {
+                eprintln!("MCAP: {n} frames from /{}", m.channel);
             }
             Box::new(src)
         }


### PR DESCRIPTION
## Summary

Adds \`mcap\` as a new offline frame source for the \`orb_slam\` example, alongside the existing \`euroc\`, \`oakd\`, and \`uvc\` sources. Reads a [bubbaloop](https://github.com/kornia/bubbaloop) \`mcap-recorder\` MCAP file, picks one channel, JPEG-decodes each message, and yields grayscale \`FrameItem\`s through the existing \`FrameSource\` trait — no changes to the SLAM core.

Why MCAP first (vs. live Zenoh): repeatable runs against a recorded session are vastly easier for tuning the bootstrap path. Live Zenoh would be the next step.

## What's in

| File | Change |
|---|---|
| \`examples/common/source/mcap.rs\` | New. \`McapSource\` — opens an MCAP, filters by topic suffix, unwraps the SDK provenance envelope (\`{header, body}\`), JPEG-decodes, yields luma8 frames. |
| \`examples/common/source/mod.rs\` | \`pub mod mcap; pub use mcap::McapSource;\` |
| \`examples/orb_slam/src/main.rs\` | \`McapCmd\` subcommand + match arm. Doc-comment example added. |
| \`examples/orb_slam/Cargo.toml\` | \`mcap 0.21\`, \`ciborium 0.2\`, \`image 0.25\` (jpeg-only). Pure-rust, no feature flag. |
| \`Cargo.lock\` | Locks for the new deps. |

## Body shapes supported

- **Flat** (mono_left / mono_right): \`{width, height, encoding:"jpeg", data}\`
- **Nested** (compressed): \`{width, height, rgb:{encoding:"jpeg", data}, depth?}\` — RGB plane is extracted and decoded to luma8; depth is ignored (we're monocular).

Both come out of the same \`extract_jpeg()\` walker.

## Usage

\`\`\`bash
cargo run --release -p orb_slam -- mcap \\
    --path /path/to/recording.mcap \\
    [--channel mono_left]       # default; also: mono_right, compressed
    [--max-frames 0]            # 0 = all
    [--start-frame 0]
\`\`\`

## Test plan

- [x] \`cargo check -p orb_slam\` clean.
- [x] \`cargo build --release -p orb_slam\` clean.
- [x] Smoke-run against a real bubbaloop recording (2,744 mono_left frames at 640×400): pipeline loops through every frame without crashing; \`--debug\` shows expected ORB bootstrap reject reasons (\`LowTriangulated\`, \`RansacFailure\`) for placeholder intrinsics + low-parallax footage. Wiring is correct; the bootstrap rejection is a tuning issue, not a plumbing issue.
- [ ] Re-run with real EEPROM-derived intrinsics — follow-up.

## Known follow-ups (not in this PR)

1. \`--intrinsics-yaml\` option to override placeholder \`fx/fy/cx/cy\`. Currently mirrors \`OakdSource\` (fx≈880 at OAK-D Pro native, scaled by width/1280).
2. Optional streaming reader (\`memmap2\`) for very large MCAPs. Current implementation reads the file fully into memory (fine up to a few hundred MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)