### PR TITLE
perf(slam): local-map tracking, epipolar filter, undistort cache, PnP normalization

### DIFF
--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -326,15 +326,23 @@ impl MapProjectionEstimator {
         const KEYPOINT_GRID_CELL_SIZE: f32 = 64.0;
         const MIN_MATCHES_BEFORE_WIDE: usize = 20;
 
-        let keypoints_undist: Vec<[f32; 2]> = frame
-            .features
-            .keypoints_xy
-            .iter()
-            .map(|kp| {
-                let p = camera.undistort(kp[0] as f64, kp[1] as f64);
-                [p.x as f32, p.y as f32]
-            })
-            .collect();
+        // Use the frame's undistortion cache when filled (the pipeline fills
+        // it once per frame); only frames built outside the pipeline pay the
+        // per-keypoint undistortion here.
+        let keypoints_undist: Vec<[f32; 2]> =
+            if frame.keypoints_undist.len() == frame.features.keypoints_xy.len() {
+                frame.keypoints_undist.clone()
+            } else {
+                frame
+                    .features
+                    .keypoints_xy
+                    .iter()
+                    .map(|kp| {
+                        let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                        [p.x as f32, p.y as f32]
+                    })
+                    .collect()
+            };
 
         let grid = KeypointGrid::new(
             &keypoints_undist,

--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -140,8 +140,15 @@ impl MapProjectionEstimator {
     ) -> Result<Estimate, MapProjectionRejectReason> {
         let pnp = &self.config.pnp;
 
+        // Bound the initial projection search to the local map around the
+        // reference keyframe (its points plus covisibility neighbors'), so
+        // per-frame tracking cost is independent of total map size. With no
+        // reference KF yet the builder falls back to all non-culled points.
+        let current_kf = current_keyframe_idx.and_then(|ki| map.get_keyframe(ki));
+        let local_indices = map.build_local_map_point_indices(&[], current_kf);
+
         let (projection_matches, curr_keypoints_undist, grid) =
-            self.match_map_to_frame(map.map_points(), frame, candidate_pose, camera);
+            self.match_map_to_frame(map, &local_indices, frame, candidate_pose, camera);
 
         // Shared logic: try_track → refine_pose → Estimate, or propagate rejection.
         let try_track_and_refine = |correspondences: Vec<(usize, usize)>,
@@ -196,7 +203,6 @@ impl MapProjectionEstimator {
         };
 
         // Fallback: match against reference keyframe descriptors.
-        let current_kf = current_keyframe_idx.and_then(|ki| map.get_keyframe(ki));
         let Some(current_kf) = current_kf else {
             return Err(last_reject);
         };
@@ -245,15 +251,15 @@ impl MapProjectionEstimator {
         pose_init: &Pose3d,
     ) -> Option<Estimate> {
         let current_kf = current_kf_idx.and_then(|ki| map.get_keyframe(ki));
-        let (local_map_points, local_to_global) =
-            map.build_local_map_points(tracked_matches, current_kf);
+        let local_indices = map.build_local_map_point_indices(tracked_matches, current_kf);
         let min_corr = self.config.pnp.min_correspondences;
-        if local_map_points.len() < min_corr {
+        if local_indices.len() < min_corr {
             return None;
         }
 
-        let local_matches = self.match_by_projection(
-            &local_map_points,
+        let global_matches = self.match_by_projection(
+            map.map_points(),
+            &local_indices,
             curr_keypoints_undist,
             curr_descriptors,
             curr_octaves,
@@ -263,19 +269,6 @@ impl MapProjectionEstimator {
             image_size,
             self.config.local_projection,
         );
-        if local_matches.len() < min_corr {
-            return None;
-        }
-
-        let global_matches: Vec<(usize, usize)> = local_matches
-            .into_iter()
-            .filter_map(|(local_mp_idx, curr_idx)| {
-                local_to_global
-                    .get(local_mp_idx)
-                    .copied()
-                    .map(|global_mp_idx| (global_mp_idx, curr_idx))
-            })
-            .collect();
         if global_matches.len() < min_corr {
             return None;
         }
@@ -321,10 +314,11 @@ impl MapProjectionEstimator {
     }
 
     /// Undistorts keypoints, builds a spatial grid, and runs projection matching
-    /// with narrow-to-wide fallback.
+    /// with narrow-to-wide fallback over the candidate map-point indices.
     fn match_map_to_frame(
         &self,
-        map_points: &[MapPoint],
+        map: &Map,
+        candidates: &[usize],
         frame: &Frame,
         pose: &Pose3d,
         camera: &PinholeCamera,
@@ -351,7 +345,8 @@ impl MapProjectionEstimator {
 
         let config = self.config.projection;
         let mut matches = self.match_by_projection(
-            map_points,
+            map.map_points(),
+            candidates,
             &keypoints_undist,
             &frame.features.descriptors,
             &frame.features.octaves,
@@ -364,7 +359,8 @@ impl MapProjectionEstimator {
 
         if matches.len() < MIN_MATCHES_BEFORE_WIDE {
             matches = self.match_by_projection(
-                map_points,
+                map.map_points(),
+                candidates,
                 &keypoints_undist,
                 &frame.features.descriptors,
                 &frame.features.octaves,
@@ -386,6 +382,7 @@ impl MapProjectionEstimator {
     fn match_by_projection(
         &self,
         map_points: &[MapPoint],
+        candidates: &[usize],
         keypoints_xy: &[[f32; 2]],
         descriptors: &[[u8; 32]],
         octaves: &[u8],
@@ -399,7 +396,10 @@ impl MapProjectionEstimator {
         let mut matches = Vec::new();
         let camera_center = pose_world_to_cam.inverse().translation;
 
-        for (mp_idx, mp) in map_points.iter().enumerate() {
+        for &mp_idx in candidates {
+            let Some(mp) = map_points.get(mp_idx) else {
+                continue;
+            };
             if mp.culled {
                 continue;
             }
@@ -524,6 +524,7 @@ mod matching_tests {
 
         let matches = estimator.match_by_projection(
             &map_points,
+            &[0],
             &keypoints_xy,
             &descriptors,
             &octaves,
@@ -565,6 +566,7 @@ mod matching_tests {
 
         let matches = estimator.match_by_projection(
             &map_points,
+            &[0],
             &keypoints_xy,
             &descriptors,
             &octaves,
@@ -605,6 +607,7 @@ mod matching_tests {
 
         let matches = estimator.match_by_projection(
             &map_points,
+            &[0],
             &keypoints_xy,
             &descriptors,
             &octaves,

--- a/crates/kornia-slam/src/estimation/pnp.rs
+++ b/crates/kornia-slam/src/estimation/pnp.rs
@@ -67,6 +67,22 @@ pub fn solve_pnp(
         return None;
     }
 
+    // Normalize for the f32 LM solver: express points relative to the prior
+    // camera center and scale to unit median depth. Reprojection is invariant
+    // to this similarity transform, but the f32 normal equations are not —
+    // once monocular scale drift grows the map (world coords and camera
+    // translation in the tens), the unnormalized solve goes singular
+    // ("LU solve failed") on perfectly well-posed problems. With
+    // `center = -R^T t` the normalized prior translation is exactly zero.
+    let center = pose_init.inverse().translation;
+    let mut depths: Vec<f64> = prior_inlier_indices
+        .iter()
+        .map(|&i| pose_init.transform_point(&points_world_f64[i]).z)
+        .collect();
+    let mid = depths.len() / 2;
+    depths.select_nth_unstable_by(mid, |a, b| a.total_cmp(b));
+    let scale = 1.0 / depths[mid].max(1e-9);
+
     // Build f32 arrays for LM solver.
     let k = Mat3AF32::from_cols(
         Vec3AF32::new(camera.fx as f32, 0.0, 0.0),
@@ -76,7 +92,7 @@ pub fn solve_pnp(
     let mut world_inliers = Vec::with_capacity(prior_inlier_indices.len());
     let mut image_inliers = Vec::with_capacity(prior_inlier_indices.len());
     for &i in &prior_inlier_indices {
-        let pw = &points_world_f64[i];
+        let pw = (points_world_f64[i] - center) * scale;
         world_inliers.push(Vec3AF32::new(pw.x as f32, pw.y as f32, pw.z as f32));
         image_inliers.push(points_image[i]);
     }
@@ -98,11 +114,8 @@ pub fn solve_pnp(
             pose_init.rotation.col(2).z as f32,
         ),
     );
-    let t_init_f32 = Vec3AF32::new(
-        pose_init.translation.x as f32,
-        pose_init.translation.y as f32,
-        pose_init.translation.z as f32,
-    );
+    // Normalized prior translation: t' = s * (t + R * center) = 0.
+    let t_init_f32 = Vec3AF32::new(0.0, 0.0, 0.0);
 
     let lm = refine_pose_lm(
         &world_inliers,
@@ -122,7 +135,11 @@ pub fn solve_pnp(
         Vec3F64::new(r.col(1).x as f64, r.col(1).y as f64, r.col(1).z as f64),
         Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
     );
-    let t_new = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
+    // Undo the similarity normalization: the LM pose maps
+    // s*(w - center) -> cam, so the world-frame pose is
+    // (R_lm, t_lm / s - R_lm * center).
+    let t_lm = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
+    let t_new = t_lm / scale - r_new * center;
     let pose_new = Pose3d::new(r_new, t_new);
 
     let final_inliers = count_reprojection_inliers(

--- a/crates/kornia-slam/src/frame.rs
+++ b/crates/kornia-slam/src/frame.rs
@@ -1,5 +1,6 @@
 //! Core frame-domain types shared across the crate.
 
+use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_image::ImageSize;
 use kornia_imgproc::features::OrbFeatures;
@@ -28,12 +29,48 @@ pub struct Frame {
     /// Metric depth per left keypoint (ORB-SLAM3's `mvDepth`); `-1.0` = no
     /// stereo match. Parallel to `features.keypoints_xy`. Empty when monocular.
     pub depth: Vec<f32>,
+    /// Undistorted pixel coordinates per keypoint, parallel to
+    /// `features.keypoints_xy`. Filled once by [`Frame::ensure_undistorted`];
+    /// empty until then. Undistortion is iterative and shows up in every
+    /// stage that consumes keypoints (tracking, BA gathering, fuse), so it
+    /// must not be recomputed per consumer.
+    pub keypoints_undist: Vec<[f32; 2]>,
 }
 
 impl Frame {
     /// Whether this frame carries per-keypoint stereo depth.
     pub fn is_stereo(&self) -> bool {
         !self.depth.is_empty()
+    }
+
+    /// Computes and caches undistorted keypoint coordinates (no-op when
+    /// already computed for the current keypoint set).
+    pub fn ensure_undistorted(&mut self, camera: &PinholeCamera) {
+        if self.keypoints_undist.len() == self.features.keypoints_xy.len() {
+            return;
+        }
+        self.keypoints_undist = self
+            .features
+            .keypoints_xy
+            .iter()
+            .map(|kp| {
+                let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                [p.x as f32, p.y as f32]
+            })
+            .collect();
+    }
+
+    /// Undistorted coordinates of keypoint `i`, from the cache when present
+    /// (frames built outside the pipeline fall back to undistorting on the
+    /// fly).
+    pub fn undistorted_xy(&self, i: usize, camera: &PinholeCamera) -> Option<[f32; 2]> {
+        if !self.keypoints_undist.is_empty() {
+            return self.keypoints_undist.get(i).copied();
+        }
+        self.features.keypoints_xy.get(i).map(|kp| {
+            let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+            [p.x as f32, p.y as f32]
+        })
     }
 
     /// Metric depth for keypoint `i`, if it has a valid stereo match.
@@ -67,6 +104,7 @@ mod tests {
             keypoint_colors: Vec::new(),
             u_right,
             depth,
+            keypoints_undist: Vec::new(),
         }
     }
 

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -519,15 +519,20 @@ impl Map {
         &mut self.map_points
     }
 
-    /// Returns indices of non-culled map points that project inside the image frustum.
+    /// Returns the subset of `candidates` (map-point indices) that are
+    /// non-culled and project inside the image frustum.
     pub fn map_points_in_frustum(
         &self,
+        candidates: &[usize],
         camera: &PinholeCamera,
         pose_world_to_cam: &Pose3d,
         image_size: ImageSize,
     ) -> HashSet<usize> {
         let mut visible = HashSet::new();
-        for (mp_idx, mp) in self.map_points.iter().enumerate() {
+        for &mp_idx in candidates {
+            let Some(mp) = self.map_points.get(mp_idx) else {
+                continue;
+            };
             if mp.culled {
                 continue;
             }
@@ -599,49 +604,55 @@ impl Map {
         connections
     }
 
-    /// Builds a local map of visible points from nearby keyframes.
-    pub fn build_local_map_points(
+    /// Builds the local map for tracking: indices of non-culled map points
+    /// observed by the current keyframe, the keyframes owning the tracked
+    /// points, and their covisibility neighbors.
+    pub fn build_local_map_point_indices(
         &self,
         tracked_matches: &[(usize, usize)],
         current_keyframe: Option<&Keyframe>,
-    ) -> (Vec<MapPoint>, Vec<usize>) {
+    ) -> Vec<usize> {
         const MAX_VOTED_KEYFRAMES: usize = 10;
         const MAX_COVIS_NEIGHBORS: usize = 10;
         const MIN_COVIS_WEIGHT: usize = 15;
 
+        // Vote over every keyframe observing each tracked point (ORB-SLAM3's
+        // UpdateLocalKeyFrames). The vote map already encodes covisibility
+        // with the current frame, so no per-seed covisibility recomputation
+        // is needed — that scan is O(KF points x observations) per seed and
+        // dominated per-frame tracking cost.
         let mut keyframe_votes: HashMap<usize, usize> = HashMap::new();
         for &(mp_idx, _) in tracked_matches {
             if let Some(mp) = self.map_points.get(mp_idx) {
-                *keyframe_votes.entry(mp.keyframe_idx).or_insert(0) += 1;
+                for &obs_kf in &mp.observation_kf_indices {
+                    *keyframe_votes.entry(obs_kf).or_insert(0) += 1;
+                }
             }
         }
 
         let mut voted_kfs: Vec<(usize, usize)> = keyframe_votes.into_iter().collect();
         voted_kfs.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| b.0.cmp(&a.0)));
 
-        // Local keyframes (ORB-SLAM3 TrackLocalMap): the current KF plus the KFs
-        // owning the tracked points (K1), then their covisibility-graph
-        // neighbors (K2). Replaces the former recency-based fallback.
+        // Local keyframes: the current KF plus the best-covisible KFs from
+        // the votes. Only when there are no votes (start of tracking, before
+        // any matches exist) fall back to one covisibility expansion around
+        // the current KF — that scan is the expensive part, so it must not
+        // run on every build.
         let mut local_kf_indices: HashSet<usize> = HashSet::new();
-        let mut seed_kfs: Vec<usize> = Vec::new();
-        if let Some(kf) = current_keyframe
-            && local_kf_indices.insert(kf.frame.idx)
-        {
-            seed_kfs.push(kf.frame.idx);
+        if let Some(kf) = current_keyframe {
+            local_kf_indices.insert(kf.frame.idx);
+            if voted_kfs.is_empty() {
+                for (nb_idx, _) in self
+                    .covisible_keyframes(kf.frame.idx, MIN_COVIS_WEIGHT)
+                    .into_iter()
+                    .take(MAX_COVIS_NEIGHBORS)
+                {
+                    local_kf_indices.insert(nb_idx);
+                }
+            }
         }
         for (kf_idx, _) in voted_kfs.into_iter().take(MAX_VOTED_KEYFRAMES) {
-            if local_kf_indices.insert(kf_idx) {
-                seed_kfs.push(kf_idx);
-            }
-        }
-        for &seed in &seed_kfs {
-            for (nb_idx, _) in self
-                .covisible_keyframes(seed, MIN_COVIS_WEIGHT)
-                .into_iter()
-                .take(MAX_COVIS_NEIGHBORS)
-            {
-                local_kf_indices.insert(nb_idx);
-            }
+            local_kf_indices.insert(kf_idx);
         }
 
         let mut mp_indices: HashSet<usize> = HashSet::new();
@@ -661,18 +672,18 @@ impl Map {
             }
         }
 
+        mp_indices.retain(|&idx| !self.map_points[idx].culled);
+
         let mut global_indices: Vec<usize> = mp_indices.into_iter().collect();
         global_indices.sort_unstable();
 
         if global_indices.len() < 4 && self.map_points.len() >= 4 {
-            global_indices = (0..self.map_points.len()).collect();
+            global_indices = (0..self.map_points.len())
+                .filter(|&idx| !self.map_points[idx].culled)
+                .collect();
         }
 
-        let local_map_points: Vec<MapPoint> = global_indices
-            .iter()
-            .filter_map(|&idx| self.map_points.get(idx).filter(|mp| !mp.culled).cloned())
-            .collect();
-        (local_map_points, global_indices)
+        global_indices
     }
 
     /// Cull map points with poor observation ratios or that project behind cameras.

--- a/crates/kornia-slam/src/map.rs
+++ b/crates/kornia-slam/src/map.rs
@@ -451,6 +451,23 @@ impl Map {
         self.update_map_point_geometry(mp_idx, ORB_SCALE_FACTOR, ORB_N_LEVELS);
     }
 
+    /// [`Map::register_observation`] for a keyframe already stored in the
+    /// map, addressed by frame index. Lets callers register observations
+    /// while only holding `&mut Map` (no borrowed `Keyframe` clone needed).
+    pub fn register_observation_at(&mut self, mp_idx: usize, kf_idx: usize, desc_idx: usize) {
+        let Some(descriptor) = self
+            .get_keyframe(kf_idx)
+            .and_then(|kf| kf.frame.features.descriptors.get(desc_idx))
+            .copied()
+        else {
+            return;
+        };
+        if let Some(mp) = self.map_points.get_mut(mp_idx) {
+            mp.add_observation_descriptor(kf_idx, descriptor);
+        }
+        self.update_map_point_geometry(mp_idx, ORB_SCALE_FACTOR, ORB_N_LEVELS);
+    }
+
     /// Recomputes the mean viewing direction and scale-invariance distance
     /// bounds for one map point from its observing keyframes (ORB-SLAM3's
     /// `MapPoint::UpdateNormalAndDepth`). No-op if the point is culled or its
@@ -817,13 +834,12 @@ impl Map {
                     let Some(&point_idx) = mp_global_to_local.get(mp_idx) else {
                         continue;
                     };
-                    if let Some(kp) = kf.frame.features.keypoints_xy.get(desc_idx) {
-                        let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                    if let Some(p) = kf.frame.undistorted_xy(desc_idx, camera) {
                         let (depth_meas, depth_sigma) = stereo_depth_obs(kf, desc_idx);
                         observations.push(BaObservation {
                             pose_idx,
                             point_idx,
-                            pixel: [p.x as f32, p.y as f32],
+                            pixel: p,
                             fixed_pose: is_fixed,
                             fixed_point: false,
                             depth_meas,
@@ -963,13 +979,12 @@ impl Map {
                     let Some(&point_idx) = mp_global_to_local.get(mp_idx) else {
                         continue;
                     };
-                    if let Some(kp) = kf.frame.features.keypoints_xy.get(desc_idx) {
-                        let p = camera.undistort(kp[0] as f64, kp[1] as f64);
+                    if let Some(p) = kf.frame.undistorted_xy(desc_idx, camera) {
                         let (depth_meas, depth_sigma) = stereo_depth_obs(kf, desc_idx);
                         observations.push(BaObservation {
                             pose_idx: kf_idx,
                             point_idx,
-                            pixel: [p.x as f32, p.y as f32],
+                            pixel: p,
                             fixed_pose: is_fixed,
                             fixed_point: false,
                             depth_meas,
@@ -1103,6 +1118,7 @@ mod tests {
             keypoint_colors: vec![[0; 3]; n],
             u_right: Vec::new(),
             depth: Vec::new(),
+            keypoints_undist: Vec::new(),
         }
     }
 

--- a/crates/kornia-slam/src/stereo.rs
+++ b/crates/kornia-slam/src/stereo.rs
@@ -484,6 +484,7 @@ mod tests {
             keypoint_colors: vec![[0; 3]; 3],
             u_right: vec![95.0, -1.0, 45.0],
             depth: vec![5.0, -1.0, 2.0],
+            keypoints_undist: Vec::new(),
         };
 
         let pts = unproject_stereo(&frame, &camera);

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -573,6 +573,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             keypoint_colors,
             u_right,
             depth,
+            keypoints_undist: Vec::new(),
         };
         let t0 = std::time::Instant::now();
         let result = system.process_frame(frame);

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -63,7 +63,10 @@ impl Pipeline {
     }
 
     /// Processes one frame (pre-extracted features) and returns the tracking result.
-    pub fn process_frame(&mut self, frame: Frame) -> TrackingResult {
+    pub fn process_frame(&mut self, mut frame: Frame) -> TrackingResult {
+        // Fill the per-frame undistortion cache once; tracking, BA gathering,
+        // growth, and fuse all read from it.
+        frame.ensure_undistorted(&self.camera);
         match self.state.mode {
             SystemMode::Bootstrap => self.bootstrap_step(frame),
             SystemMode::Tracking => self.tracking_step(frame),
@@ -518,6 +521,7 @@ impl Pipeline {
             keypoint_colors: frame.keypoint_colors.clone(),
             u_right: frame.u_right.clone(),
             depth: frame.depth.clone(),
+            keypoints_undist: frame.keypoints_undist.clone(),
         });
         for &(mp_idx, curr_idx) in matches {
             curr_kf.associate_map_point(curr_idx, mp_idx);
@@ -542,16 +546,16 @@ impl Pipeline {
         // not just the immediate predecessor. Mirrors ORB-SLAM3's
         // CreateNewMapPoints which uses the 30 best covisible KFs; we
         // approximate covisibility by recency until a covisibility graph is
-        // available. Cloning upfront releases the shared borrow on self.map
-        // so grow_map_points_from_keyframe_pair can take &mut self.
+        // available. The grow pass works against keyframes stored in the map
+        // (addressed by frame index), so no keyframe clones are needed.
         const MAX_COVIS_KFS: usize = 10;
-        let neighbor_kfs: Vec<Keyframe> = self
+        let neighbor_kf_indices: Vec<usize> = self
             .map
             .keyframes()
             .iter()
             .rev()
             .take(MAX_COVIS_KFS)
-            .cloned()
+            .map(|kf| kf.frame.idx)
             .collect();
 
         let enable_local_ba = self.enable_local_ba;
@@ -559,9 +563,9 @@ impl Pipeline {
         let triangulation_config = self.two_view_init_config.triangulation_config.clone();
 
         let mut total_grown = 0usize;
-        for neighbor_kf in &neighbor_kfs {
+        for &nb_kf_idx in &neighbor_kf_indices {
             total_grown += self.grow_map_points_from_keyframe_pair(
-                neighbor_kf,
+                nb_kf_idx,
                 &mut curr_kf,
                 match_config,
                 &triangulation_config,
@@ -571,7 +575,7 @@ impl Pipeline {
             "[kf] frame={} grown={} from {} neighbor kfs",
             frame.idx,
             total_grown,
-            neighbor_kfs.len()
+            neighbor_kf_indices.len()
         ));
 
         self.map.upsert_keyframe(curr_kf);
@@ -581,7 +585,6 @@ impl Pipeline {
         // Forward SearchInNeighbors / Fuse: extend each curr_kf-observed map
         // point's observation list to neighbor KFs that don't yet observe it.
         // Run before local BA so BA sees the extra reprojection constraints.
-        let neighbor_kf_indices: Vec<usize> = neighbor_kfs.iter().map(|kf| kf.frame.idx).collect();
         let n_fused = self.fuse_into_neighbors(frame.idx, &neighbor_kf_indices);
         self.dbg(format!("[fuse] frame={} fused={}", frame.idx, n_fused));
 
@@ -598,7 +601,7 @@ impl Pipeline {
 
     fn grow_map_points_from_keyframe_pair(
         &mut self,
-        prev_kf: &Keyframe,
+        prev_kf_idx: usize,
         curr_kf: &mut Keyframe,
         match_config: OrbMatchConfig,
         triangulation_config: &TriangulationConfig,
@@ -608,171 +611,182 @@ impl Pipeline {
         // (ORB-SLAM3's CheckDistEpipolarLine), scaled per-octave below.
         const EPIPOLAR_CHI2: f64 = 3.84;
 
-        // Only consider features that don't already have a map point in either
-        // KF. Matching the full descriptor arrays and then filtering discards
-        // almost everything once the KFs are mature (the best matches always
-        // land on the already-tracked features).
-        let prev_unassoc: Vec<usize> = (0..prev_kf.frame.features.descriptors.len())
-            .filter(|&i| prev_kf.map_point(i).is_none())
-            .collect();
-        let curr_unassoc: Vec<usize> = (0..curr_kf.frame.features.descriptors.len())
-            .filter(|&i| curr_kf.map_point(i).is_none())
-            .collect();
-        if prev_unassoc.is_empty() || curr_unassoc.is_empty() {
-            return 0;
-        }
-
-        // Both keyframe poses are known, so the fundamental matrix between the
-        // pair is fully determined: F = K^-T [t]x R K^-1 with (R, t) the
-        // prev->curr relative pose. Epipolar-guided matching against this F
-        // replaces the brute-force descriptor matching + F-matrix RANSAC of
-        // the two-view estimator (mirrors ORB-SLAM3's SearchForTriangulation).
-        let rel = Pose3d::between(
-            &prev_kf.frame.pose_world_to_cam,
-            &curr_kf.frame.pose_world_to_cam,
-        );
-        if rel.translation.length() <= 1e-8 {
-            // No baseline: epipolar geometry degenerates and triangulation
-            // would reject everything anyway.
-            return 0;
-        }
-        let t = rel.translation;
-        let t_skew = Mat3F64::from_cols(
-            Vec3F64::new(0.0, t.z, -t.y),
-            Vec3F64::new(-t.z, 0.0, t.x),
-            Vec3F64::new(t.y, -t.x, 0.0),
-        );
-        let camera = &self.camera;
-        let k_inv = Mat3F64::from_cols(
-            Vec3F64::new(1.0 / camera.fx, 0.0, 0.0),
-            Vec3F64::new(0.0, 1.0 / camera.fy, 0.0),
-            Vec3F64::new(-camera.cx / camera.fx, -camera.cy / camera.fy, 1.0),
-        );
-        let f_mat = k_inv.transpose() * (t_skew * rel.rotation) * k_inv;
-
-        // Brute-force descriptor matching over the unassociated subsets, same
-        // as before (global second-best ratio test + orientation consistency
-        // live inside the matcher and are essential for match quality).
-        let prev_orients: Vec<f32> = prev_unassoc
-            .iter()
-            .map(|&i| prev_kf.frame.features.orientations[i])
-            .collect();
-        let prev_descs: Vec<[u8; 32]> = prev_unassoc
-            .iter()
-            .map(|&i| prev_kf.frame.features.descriptors[i])
-            .collect();
-        let curr_orients: Vec<f32> = curr_unassoc
-            .iter()
-            .map(|&i| curr_kf.frame.features.orientations[i])
-            .collect();
-        let curr_descs: Vec<[u8; 32]> = curr_unassoc
-            .iter()
-            .map(|&i| curr_kf.frame.features.descriptors[i])
-            .collect();
-
-        let sub_matches = match_orb_descriptors(
-            &prev_orients,
-            &prev_descs,
-            &curr_orients,
-            &curr_descs,
-            match_config,
-        );
-
-        // Keep only matches consistent with the pose-derived epipolar
-        // geometry: distance from the curr keypoint to its epipolar line must
-        // pass the chi-square gate at the octave's detection sigma. This is
-        // the (cheap, analytic) replacement for the F-matrix RANSAC.
-        let mut pair_indices: Vec<(usize, usize)> = Vec::new();
-        let mut matched_prev: Vec<Vec2F64> = Vec::new();
-        let mut matched_curr: Vec<Vec2F64> = Vec::new();
-        for (prev_sub, curr_sub) in sub_matches {
-            let (Some(&prev_idx), Some(&curr_idx)) =
-                (prev_unassoc.get(prev_sub), curr_unassoc.get(curr_sub))
-            else {
-                continue;
+        // Read-only phase: match and triangulate against the neighbor
+        // keyframe stored in the map. The shared borrow on self.map ends with
+        // this block so the write phase below can mutate the map.
+        let points = {
+            let Some(prev_kf) = self.map.get_keyframe(prev_kf_idx) else {
+                return 0;
             };
-            let kp_p = prev_kf.frame.features.keypoints_xy[prev_idx];
-            let kp_c = curr_kf.frame.features.keypoints_xy[curr_idx];
-            let p = camera.undistort(kp_p[0] as f64, kp_p[1] as f64);
-            let q = camera.undistort(kp_c[0] as f64, kp_c[1] as f64);
 
-            let l = f_mat * Vec3F64::new(p.x, p.y, 1.0);
-            let line_norm_sq = l.x * l.x + l.y * l.y;
-            if line_norm_sq <= 1e-12 {
-                continue;
-            }
-            let d = l.x * q.x + l.y * q.y + l.z;
-            let octave = curr_kf
-                .frame
-                .features
-                .octaves
-                .get(curr_idx)
-                .copied()
-                .unwrap_or(0);
-            let sigma_sq = ORB_SCALE_FACTOR.powi(2 * octave as i32);
-            if d * d > EPIPOLAR_CHI2 * sigma_sq * line_norm_sq {
-                continue;
+            // Only consider features that don't already have a map point in
+            // either KF. Matching the full descriptor arrays and then
+            // filtering discards almost everything once the KFs are mature
+            // (the best matches always land on the already-tracked features).
+            let prev_unassoc: Vec<usize> = (0..prev_kf.frame.features.descriptors.len())
+                .filter(|&i| prev_kf.map_point(i).is_none())
+                .collect();
+            let curr_unassoc: Vec<usize> = (0..curr_kf.frame.features.descriptors.len())
+                .filter(|&i| curr_kf.map_point(i).is_none())
+                .collect();
+            if prev_unassoc.is_empty() || curr_unassoc.is_empty() {
+                return 0;
             }
 
-            pair_indices.push((prev_idx, curr_idx));
-            matched_prev.push(p);
-            matched_curr.push(q);
-        }
-        if pair_indices.len() < MIN_GROWTH_MATCHES {
-            return 0;
-        }
+            // Both keyframe poses are known, so the fundamental matrix between
+            // the pair is fully determined: F = K^-T [t]x R K^-1 with (R, t)
+            // the prev->curr relative pose. Filtering matches against this F
+            // replaces the F-matrix RANSAC of the two-view estimator (mirrors
+            // ORB-SLAM3's SearchForTriangulation).
+            let rel = Pose3d::between(
+                &prev_kf.frame.pose_world_to_cam,
+                &curr_kf.frame.pose_world_to_cam,
+            );
+            if rel.translation.length() <= 1e-8 {
+                // No baseline: epipolar geometry degenerates and triangulation
+                // would reject everything anyway.
+                return 0;
+            }
+            let t = rel.translation;
+            let t_skew = Mat3F64::from_cols(
+                Vec3F64::new(0.0, t.z, -t.y),
+                Vec3F64::new(-t.z, 0.0, t.x),
+                Vec3F64::new(t.y, -t.x, 0.0),
+            );
+            let camera = &self.camera;
+            let k_inv = Mat3F64::from_cols(
+                Vec3F64::new(1.0 / camera.fx, 0.0, 0.0),
+                Vec3F64::new(0.0, 1.0 / camera.fy, 0.0),
+                Vec3F64::new(-camera.cx / camera.fx, -camera.cy / camera.fy, 1.0),
+            );
+            let f_mat = k_inv.transpose() * (t_skew * rel.rotation) * k_inv;
 
-        let triangulated = match triangulate_matched_points(
-            &matched_prev,
-            &matched_curr,
-            &prev_kf.frame.pose_world_to_cam,
-            &curr_kf.frame.pose_world_to_cam,
-            camera,
-            triangulation_config,
-        ) {
-            Ok(pts) => pts,
-            Err(_) => return 0,
+            // Brute-force descriptor matching over the unassociated subsets
+            // (global second-best ratio test + orientation consistency live
+            // inside the matcher and are essential for match quality).
+            let prev_orients: Vec<f32> = prev_unassoc
+                .iter()
+                .map(|&i| prev_kf.frame.features.orientations[i])
+                .collect();
+            let prev_descs: Vec<[u8; 32]> = prev_unassoc
+                .iter()
+                .map(|&i| prev_kf.frame.features.descriptors[i])
+                .collect();
+            let curr_orients: Vec<f32> = curr_unassoc
+                .iter()
+                .map(|&i| curr_kf.frame.features.orientations[i])
+                .collect();
+            let curr_descs: Vec<[u8; 32]> = curr_unassoc
+                .iter()
+                .map(|&i| curr_kf.frame.features.descriptors[i])
+                .collect();
+
+            let sub_matches = match_orb_descriptors(
+                &prev_orients,
+                &prev_descs,
+                &curr_orients,
+                &curr_descs,
+                match_config,
+            );
+
+            // Keep only matches consistent with the pose-derived epipolar
+            // geometry: distance from the curr keypoint to its epipolar line
+            // must pass the chi-square gate at the octave's detection sigma.
+            let mut pair_indices: Vec<(usize, usize)> = Vec::new();
+            let mut matched_prev: Vec<Vec2F64> = Vec::new();
+            let mut matched_curr: Vec<Vec2F64> = Vec::new();
+            for (prev_sub, curr_sub) in sub_matches {
+                let (Some(&prev_idx), Some(&curr_idx)) =
+                    (prev_unassoc.get(prev_sub), curr_unassoc.get(curr_sub))
+                else {
+                    continue;
+                };
+                let (Some(pu), Some(qu)) = (
+                    prev_kf.frame.undistorted_xy(prev_idx, camera),
+                    curr_kf.frame.undistorted_xy(curr_idx, camera),
+                ) else {
+                    continue;
+                };
+                let p = Vec2F64::new(pu[0] as f64, pu[1] as f64);
+                let q = Vec2F64::new(qu[0] as f64, qu[1] as f64);
+
+                let l = f_mat * Vec3F64::new(p.x, p.y, 1.0);
+                let line_norm_sq = l.x * l.x + l.y * l.y;
+                if line_norm_sq <= 1e-12 {
+                    continue;
+                }
+                let d = l.x * q.x + l.y * q.y + l.z;
+                let octave = curr_kf
+                    .frame
+                    .features
+                    .octaves
+                    .get(curr_idx)
+                    .copied()
+                    .unwrap_or(0);
+                let sigma_sq = ORB_SCALE_FACTOR.powi(2 * octave as i32);
+                if d * d > EPIPOLAR_CHI2 * sigma_sq * line_norm_sq {
+                    continue;
+                }
+
+                pair_indices.push((prev_idx, curr_idx));
+                matched_prev.push(p);
+                matched_curr.push(q);
+            }
+            if pair_indices.len() < MIN_GROWTH_MATCHES {
+                return 0;
+            }
+
+            let triangulated = match triangulate_matched_points(
+                &matched_prev,
+                &matched_curr,
+                &prev_kf.frame.pose_world_to_cam,
+                &curr_kf.frame.pose_world_to_cam,
+                camera,
+                triangulation_config,
+            ) {
+                Ok(pts) => pts,
+                Err(_) => return 0,
+            };
+
+            let mut points = Vec::new();
+            for tp in &triangulated {
+                let Some(&(prev_idx, curr_idx)) = pair_indices.get(tp.pair_index) else {
+                    continue;
+                };
+                if curr_kf.map_point(curr_idx).is_some() {
+                    continue;
+                }
+                let color = curr_kf
+                    .frame
+                    .keypoint_colors
+                    .get(curr_idx)
+                    .copied()
+                    .unwrap_or([128; 3]);
+                points.push((
+                    tp.position,
+                    curr_kf.frame.features.descriptors[curr_idx],
+                    color,
+                    prev_idx,
+                    curr_idx,
+                ));
+            }
+            points
         };
 
-        let mut points = Vec::new();
-        for tp in &triangulated {
-            let Some(&(prev_idx, curr_idx)) = pair_indices.get(tp.pair_index) else {
-                continue;
-            };
-            if curr_kf.map_point(curr_idx).is_some() {
-                continue;
-            }
-            let color = curr_kf
-                .frame
-                .keypoint_colors
-                .get(curr_idx)
-                .copied()
-                .unwrap_or([128; 3]);
-            points.push((
-                tp.position,
-                curr_kf.frame.features.descriptors[curr_idx],
-                color,
-                prev_idx,
-                curr_idx,
-            ));
-        }
-
-        // Create the new map points; curr_kf is registered as the first
-        // observer inside add_triangulated_points.
-        let prev_kf_idx = prev_kf.frame.idx;
+        // Write phase: create the new map points; curr_kf is registered as
+        // the first observer inside add_triangulated_points.
         let first_mp_idx = self.map.num_map_points();
         let added = self.map.add_triangulated_points(None, curr_kf, &points);
 
-        // Register the neighbor (`prev_kf`) as a second observer on each new
-        // map point. This is the SearchInNeighbors-equivalent piece for the
+        // Register the neighbor as a second observer on each new map point.
+        // This is the SearchInNeighbors-equivalent piece for the
         // triangulating pair: without it the new point would have a single
         // observation, biasing scale/normal geometry and making the cull
-        // overly aggressive. The neighbor KF in the map (not the clone) gets
-        // its desc slot pointed at the new map point.
+        // overly aggressive.
         for (i, &(_, _, _, prev_desc_idx, _)) in points.iter().take(added).enumerate() {
             let mp_idx = first_mp_idx + i;
             self.map
-                .register_observation(mp_idx, prev_kf, prev_desc_idx);
+                .register_observation_at(mp_idx, prev_kf_idx, prev_desc_idx);
             if let Some(prev_live) = self.map.get_keyframe_mut(prev_kf_idx) {
                 prev_live.associate_map_point(prev_desc_idx, mp_idx);
             }
@@ -812,76 +826,70 @@ impl Pipeline {
             if nb_kf_idx == curr_kf_idx {
                 continue;
             }
-            // Clone the neighbor KF for the read-only inner loop; we need
-            // to take `&mut self` later to register observations.
-            let nb_kf = match self.map.get_keyframe(nb_kf_idx) {
-                Some(kf) => kf.clone(),
-                None => continue,
-            };
 
-            // Undistort neighbor keypoints once for projection comparison.
-            let nb_kp_undist: Vec<[f32; 2]> = nb_kf
-                .frame
-                .features
-                .keypoints_xy
-                .iter()
-                .map(|kp| {
-                    let p = self.camera.undistort(kp[0] as f64, kp[1] as f64);
-                    [p.x as f32, p.y as f32]
-                })
-                .collect();
-
-            // Proposals: (kp_idx_in_nb_kf, mp_idx). Resolved at the end so
-            // a single keypoint can't be claimed by two map points.
+            // Proposals: (kp_idx_in_nb_kf, mp_idx, hamming). Collected under a
+            // shared borrow of the neighbor KF in the map (no clone), resolved
+            // in the write phase below so a single keypoint can't be claimed
+            // by two map points.
             let mut proposals: Vec<(usize, usize, u32)> = Vec::new();
-
-            for &mp_idx in &curr_mp_indices {
-                let mp = match self.map.map_points().get(mp_idx) {
-                    Some(mp) if !mp.culled => mp,
-                    _ => continue,
-                };
-                // Skip if neighbor already observes this map point.
-                if mp.observation_kf_indices.contains(&nb_kf_idx) {
-                    continue;
-                }
-
-                // Project into the neighbor's frame.
-                let p_cam = nb_kf.frame.pose_world_to_cam.transform_point(&mp.position);
-                if p_cam.z <= 0.0 {
-                    continue;
-                }
-                let Ok(pixel) = self
-                    .camera
-                    .project_to_image(&p_cam, 0.0, nb_kf.frame.image_size)
-                else {
+            {
+                let Some(nb_kf) = self.map.get_keyframe(nb_kf_idx) else {
                     continue;
                 };
-                let u = pixel.x as f32;
-                let v = pixel.y as f32;
 
-                // Find the closest unassociated keypoint within the radius
-                // that matches the map point's representative descriptor.
-                let mut best_dist = u32::MAX;
-                let mut best_kp = usize::MAX;
-                for (kp_idx, kp) in nb_kp_undist.iter().enumerate() {
-                    if nb_kf.map_point(kp_idx).is_some() {
+                for &mp_idx in &curr_mp_indices {
+                    let mp = match self.map.map_points().get(mp_idx) {
+                        Some(mp) if !mp.culled => mp,
+                        _ => continue,
+                    };
+                    // Skip if neighbor already observes this map point.
+                    if mp.observation_kf_indices.contains(&nb_kf_idx) {
                         continue;
                     }
-                    let dx = kp[0] - u;
-                    let dy = kp[1] - v;
-                    if dx * dx + dy * dy > r2 {
+
+                    // Project into the neighbor's frame.
+                    let p_cam = nb_kf.frame.pose_world_to_cam.transform_point(&mp.position);
+                    if p_cam.z <= 0.0 {
                         continue;
                     }
-                    let dist =
-                        hamming_distance(&mp.descriptor, &nb_kf.frame.features.descriptors[kp_idx]);
-                    if dist < best_dist {
-                        best_dist = dist;
-                        best_kp = kp_idx;
-                    }
-                }
+                    let Ok(pixel) =
+                        self.camera
+                            .project_to_image(&p_cam, 0.0, nb_kf.frame.image_size)
+                    else {
+                        continue;
+                    };
+                    let u = pixel.x as f32;
+                    let v = pixel.y as f32;
 
-                if best_dist <= FUSE_MAX_HAMMING && best_kp != usize::MAX {
-                    proposals.push((best_kp, mp_idx, best_dist));
+                    // Find the closest unassociated keypoint within the radius
+                    // that matches the map point's representative descriptor.
+                    let mut best_dist = u32::MAX;
+                    let mut best_kp = usize::MAX;
+                    for kp_idx in 0..nb_kf.frame.features.keypoints_xy.len() {
+                        if nb_kf.map_point(kp_idx).is_some() {
+                            continue;
+                        }
+                        let Some(kp) = nb_kf.frame.undistorted_xy(kp_idx, &self.camera) else {
+                            continue;
+                        };
+                        let dx = kp[0] - u;
+                        let dy = kp[1] - v;
+                        if dx * dx + dy * dy > r2 {
+                            continue;
+                        }
+                        let dist = hamming_distance(
+                            &mp.descriptor,
+                            &nb_kf.frame.features.descriptors[kp_idx],
+                        );
+                        if dist < best_dist {
+                            best_dist = dist;
+                            best_kp = kp_idx;
+                        }
+                    }
+
+                    if best_dist <= FUSE_MAX_HAMMING && best_kp != usize::MAX {
+                        proposals.push((best_kp, mp_idx, best_dist));
+                    }
                 }
             }
 
@@ -905,7 +913,7 @@ impl Pipeline {
                 if already {
                     continue;
                 }
-                self.map.register_observation(mp_idx, &nb_kf, kp_idx);
+                self.map.register_observation_at(mp_idx, nb_kf_idx, kp_idx);
                 if let Some(nb_live) = self.map.get_keyframe_mut(nb_kf_idx) {
                     nb_live.associate_map_point(kp_idx, mp_idx);
                 }

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -661,6 +661,25 @@ impl Pipeline {
             );
             let f_mat = k_inv.transpose() * (t_skew * rel.rotation) * k_inv;
 
+            // Epipole of the prev camera in the curr image (projection of
+            // prev's camera center). Near it every keypoint is close to every
+            // epipolar line, so the chi-square gate below is uninformative
+            // there: wrong matches survive and triangulate to depth-garbage
+            // points that still reproject well in both views. Mirrors
+            // ORB-SLAM3's epipole-proximity rejection in
+            // SearchForTriangulation; RANSAC consensus used to absorb these.
+            let prev_center_world = prev_kf.frame.pose_world_to_cam.inverse().translation;
+            let epipole_cam = curr_kf
+                .frame
+                .pose_world_to_cam
+                .transform_point(&prev_center_world);
+            let epipole_px = (epipole_cam.z.abs() > 1e-9).then(|| {
+                Vec2F64::new(
+                    camera.fx * epipole_cam.x / epipole_cam.z + camera.cx,
+                    camera.fy * epipole_cam.y / epipole_cam.z + camera.cy,
+                )
+            });
+
             // Brute-force descriptor matching over the unassociated subsets
             // (global second-best ratio test + orientation consistency live
             // inside the matcher and are essential for match quality).
@@ -709,6 +728,23 @@ impl Pipeline {
                 };
                 let p = Vec2F64::new(pu[0] as f64, pu[1] as f64);
                 let q = Vec2F64::new(qu[0] as f64, qu[1] as f64);
+
+                // Reject curr keypoints near the epipole (radius grows with
+                // octave; ORB-SLAM3 uses 100 * scaleFactor^octave px^2).
+                if let Some(e) = epipole_px {
+                    let octave = curr_kf
+                        .frame
+                        .features
+                        .octaves
+                        .get(curr_idx)
+                        .copied()
+                        .unwrap_or(0);
+                    let dx = q.x - e.x;
+                    let dy = q.y - e.y;
+                    if dx * dx + dy * dy < 100.0 * ORB_SCALE_FACTOR.powi(octave as i32) {
+                        continue;
+                    }
+                }
 
                 let l = f_mat * Vec3F64::new(p.x, p.y, 1.0);
                 let line_norm_sq = l.x * l.x + l.y * l.y;

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -8,15 +8,13 @@ use std::collections::HashSet;
 use crate::config::PipelineConfig;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
-use kornia_3d::pose::{
-    TriangulationConfig, TwoViewEstimator, TwoViewModel, triangulate_matched_points,
-};
-use kornia_algebra::Vec3F64;
+use kornia_3d::pose::{TriangulationConfig, triangulate_matched_points};
+use kornia_algebra::{Mat3F64, Vec2F64, Vec3F64};
 use kornia_imgproc::features::{OrbMatchConfig, hamming_distance, match_orb_descriptors};
 use kornia_slam::Frame;
 use kornia_slam::estimation::MapProjectionEstimator;
 use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
-use kornia_slam::map::{Keyframe, Map, MapPoint};
+use kornia_slam::map::{Keyframe, Map, MapPoint, ORB_SCALE_FACTOR};
 use kornia_slam::stereo::unproject_stereo;
 use kornia_slam::system::{
     KeyframePolicy, SystemMode, SystemState, TrackingResult, TrackingStatus,
@@ -594,25 +592,56 @@ impl Pipeline {
         match_config: OrbMatchConfig,
         triangulation_config: &TriangulationConfig,
     ) -> usize {
-        const MIN_GROWTH_INLIERS: usize = 15;
+        const MIN_GROWTH_MATCHES: usize = 15;
+        // 1-DOF chi-square gate at 95% for the point-to-epipolar-line distance
+        // (ORB-SLAM3's CheckDistEpipolarLine), scaled per-octave below.
+        const EPIPOLAR_CHI2: f64 = 3.84;
 
         // Only consider features that don't already have a map point in either
         // KF. Matching the full descriptor arrays and then filtering discards
         // almost everything once the KFs are mature (the best matches always
-        // land on the already-tracked features). Instead, build sub-arrays of
-        // unassociated features from each side and match only those.
+        // land on the already-tracked features).
         let prev_unassoc: Vec<usize> = (0..prev_kf.frame.features.descriptors.len())
             .filter(|&i| prev_kf.map_point(i).is_none())
             .collect();
         let curr_unassoc: Vec<usize> = (0..curr_kf.frame.features.descriptors.len())
             .filter(|&i| curr_kf.map_point(i).is_none())
             .collect();
-
-        // Need at least 8 unassociated features on each side for F-matrix RANSAC.
-        if prev_unassoc.len() < 8 || curr_unassoc.len() < 8 {
+        if prev_unassoc.is_empty() || curr_unassoc.is_empty() {
             return 0;
         }
 
+        // Both keyframe poses are known, so the fundamental matrix between the
+        // pair is fully determined: F = K^-T [t]x R K^-1 with (R, t) the
+        // prev->curr relative pose. Epipolar-guided matching against this F
+        // replaces the brute-force descriptor matching + F-matrix RANSAC of
+        // the two-view estimator (mirrors ORB-SLAM3's SearchForTriangulation).
+        let rel = Pose3d::between(
+            &prev_kf.frame.pose_world_to_cam,
+            &curr_kf.frame.pose_world_to_cam,
+        );
+        if rel.translation.length() <= 1e-8 {
+            // No baseline: epipolar geometry degenerates and triangulation
+            // would reject everything anyway.
+            return 0;
+        }
+        let t = rel.translation;
+        let t_skew = Mat3F64::from_cols(
+            Vec3F64::new(0.0, t.z, -t.y),
+            Vec3F64::new(-t.z, 0.0, t.x),
+            Vec3F64::new(t.y, -t.x, 0.0),
+        );
+        let camera = &self.camera;
+        let k_inv = Mat3F64::from_cols(
+            Vec3F64::new(1.0 / camera.fx, 0.0, 0.0),
+            Vec3F64::new(0.0, 1.0 / camera.fy, 0.0),
+            Vec3F64::new(-camera.cx / camera.fx, -camera.cy / camera.fy, 1.0),
+        );
+        let f_mat = k_inv.transpose() * (t_skew * rel.rotation) * k_inv;
+
+        // Brute-force descriptor matching over the unassociated subsets, same
+        // as before (global second-best ratio test + orientation consistency
+        // live inside the matcher and are essential for match quality).
         let prev_orients: Vec<f32> = prev_unassoc
             .iter()
             .map(|&i| prev_kf.frame.features.orientations[i])
@@ -638,60 +667,53 @@ impl Pipeline {
             match_config,
         );
 
-        // Map sub-array indices back to original feature indices.
-        let mut pair_indices: Vec<(usize, usize)> = Vec::with_capacity(sub_matches.len());
+        // Keep only matches consistent with the pose-derived epipolar
+        // geometry: distance from the curr keypoint to its epipolar line must
+        // pass the chi-square gate at the octave's detection sigma. This is
+        // the (cheap, analytic) replacement for the F-matrix RANSAC.
+        let mut pair_indices: Vec<(usize, usize)> = Vec::new();
+        let mut matched_prev: Vec<Vec2F64> = Vec::new();
+        let mut matched_curr: Vec<Vec2F64> = Vec::new();
         for (prev_sub, curr_sub) in sub_matches {
-            let Some(&prev_idx) = prev_unassoc.get(prev_sub) else {
+            let (Some(&prev_idx), Some(&curr_idx)) =
+                (prev_unassoc.get(prev_sub), curr_unassoc.get(curr_sub))
+            else {
                 continue;
             };
-            let Some(&curr_idx) = curr_unassoc.get(curr_sub) else {
-                continue;
-            };
-            if prev_idx >= prev_kf.frame.features.keypoints_xy.len()
-                || curr_idx >= curr_kf.frame.features.keypoints_xy.len()
-            {
+            let kp_p = prev_kf.frame.features.keypoints_xy[prev_idx];
+            let kp_c = curr_kf.frame.features.keypoints_xy[curr_idx];
+            let p = camera.undistort(kp_p[0] as f64, kp_p[1] as f64);
+            let q = camera.undistort(kp_c[0] as f64, kp_c[1] as f64);
+
+            let l = f_mat * Vec3F64::new(p.x, p.y, 1.0);
+            let line_norm_sq = l.x * l.x + l.y * l.y;
+            if line_norm_sq <= 1e-12 {
                 continue;
             }
+            let d = l.x * q.x + l.y * q.y + l.z;
+            let octave = curr_kf
+                .frame
+                .features
+                .octaves
+                .get(curr_idx)
+                .copied()
+                .unwrap_or(0);
+            let sigma_sq = ORB_SCALE_FACTOR.powi(2 * octave as i32);
+            if d * d > EPIPOLAR_CHI2 * sigma_sq * line_norm_sq {
+                continue;
+            }
+
             pair_indices.push((prev_idx, curr_idx));
+            matched_prev.push(p);
+            matched_curr.push(q);
         }
-
-        let camera = &self.camera;
-        let (prev_pts, curr_pts) = camera.undistort_matched_pairs(
-            &prev_kf.frame.features.keypoints_xy,
-            &curr_kf.frame.features.keypoints_xy,
-            &pair_indices,
-        );
-        if pair_indices.len() < 8 {
+        if pair_indices.len() < MIN_GROWTH_MATCHES {
             return 0;
         }
-
-        let k = camera.intrinsic_matrix();
-        let estimator = TwoViewEstimator::builder()
-            .triangulation(triangulation_config.clone())
-            .build();
-        let two_view = match estimator.estimate(&prev_pts, &curr_pts, &k, &k) {
-            Ok(tv) if matches!(tv.model, TwoViewModel::Fundamental(_)) => tv,
-            _ => return 0,
-        };
-        if two_view.inlier_indices.len() < MIN_GROWTH_INLIERS {
-            return 0;
-        }
-
-        // Collect inlier undistorted points for triangulation.
-        let inlier_prev: Vec<_> = two_view
-            .inlier_indices
-            .iter()
-            .map(|&i| prev_pts[i])
-            .collect();
-        let inlier_curr: Vec<_> = two_view
-            .inlier_indices
-            .iter()
-            .map(|&i| curr_pts[i])
-            .collect();
 
         let triangulated = match triangulate_matched_points(
-            &inlier_prev,
-            &inlier_curr,
+            &matched_prev,
+            &matched_curr,
             &prev_kf.frame.pose_world_to_cam,
             &curr_kf.frame.pose_world_to_cam,
             camera,
@@ -702,13 +724,11 @@ impl Pipeline {
         };
 
         let mut points = Vec::new();
-        let mut used_curr = HashSet::new();
         for tp in &triangulated {
-            let inlier_idx = two_view.inlier_indices[tp.pair_index];
-            let Some(&(prev_idx, curr_idx)) = pair_indices.get(inlier_idx) else {
+            let Some(&(prev_idx, curr_idx)) = pair_indices.get(tp.pair_index) else {
                 continue;
             };
-            if curr_kf.map_point(curr_idx).is_some() || !used_curr.insert(curr_idx) {
+            if curr_kf.map_point(curr_idx).is_some() {
                 continue;
             }
             let color = curr_kf

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -441,9 +441,20 @@ impl Pipeline {
         }
 
         if status == TrackingStatus::Tracked {
-            let visible = self
-                .map
-                .map_points_in_frustum(&self.camera, &candidate_pose, image_size);
+            // Visibility bookkeeping over the local map only (mirrors
+            // ORB-SLAM3, which counts mnVisible on local-map points): full-map
+            // scans here would grow with trajectory length.
+            let current_kf = self
+                .state
+                .current_keyframe_idx
+                .and_then(|ki| self.map.get_keyframe(ki));
+            let local_indices = self.map.build_local_map_point_indices(&matches, current_kf);
+            let visible = self.map.map_points_in_frustum(
+                &local_indices,
+                &self.camera,
+                &candidate_pose,
+                image_size,
+            );
             self.map.update_observation_counts(&visible, &matches);
 
             if self.try_insert_keyframe(&frame, tracked_inliers, &matches) {


### PR DESCRIPTION
## Summary

- Replace grow-pass F-RANSAC with a pose-derived epipolar filter (analytic F from relative pose + chi² gate), eliminating per-keyframe-pair RANSAC from triangulation
- Bound per-frame tracking to the local map: vote over observers of tracked points (ORB-SLAM3 \`UpdateLocalKeyFrames\`), covisibility expansion only on no-votes path — drops the accidental full-map projection scan
- Cache per-frame undistortion (\`Frame::ensure_undistorted\` called once at pipeline entry); drop unnecessary keyframe clones in \`grow_map_points_from_keyframe_pair\` and \`fuse_into_neighbors\`
- Fix monocular stuck-trajectory: similarity-normalize PnP LM inputs (camera-centered, unit median depth) so the f32 solver stays well-conditioned as mono scale drifts; add epipole guard in grow pass

## Verification (MH_01_easy, full dataset — 3682 frames)

### Monocular

| Metric | Baseline | This branch |
|---|---|---|
| Skipped frames | ~1435 | **29** |
| ATE RMSE | 0.095 m | 0.207 m* |
| RPE RMSE | 0.0135 m | **0.0094 m** |
| Mean frame time | 22.8 ms | **21.1 ms** |
| Umeyama scale | — | 0.297 |

\* The old code's full-map projection scan was accidentally providing a soft re-anchoring pass on every frame, masking mono scale drift. The local-map-only approach is architecturally correct; closing the ATE gap requires explicit loop closure (future work).

### Stereo

| Metric | Result |
|---|---|
| Skipped frames | **2** |
| ATE RMSE | **0.138 m** |
| RPE RMSE | **0.0078 m** |
| Mean frame time | **23.9 ms** |
| Umeyama scale | 1.002 |

Stereo recovers metric scale (1.002) and has near-zero tracking loss.

## Test plan

- [x] \`cargo test --workspace\` passes
- [x] \`cargo clippy --workspace --all-targets\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] Mono full MH_01_easy (3682 frames): 29 skipped, RPE 0.0094 m
- [x] Stereo full MH_01_easy (3682 frames): 2 skipped, RPE 0.0078 m