### PR TITLE
imu init: keep the accel-bias prior at VIBA2

### DIFF
--- a/crates/kornia-slam/src/estimation/imu_init.rs
+++ b/crates/kornia-slam/src/estimation/imu_init.rs
@@ -416,6 +416,26 @@ impl ImuInitializer {
             println!("[imu_init] rejected: non-finite bias");
             return None;
         }
+        // Physical plausibility floor on the accel bias. ORB-SLAM3 has no such
+        // gate (see the note above about the |bg|>0.05 gate that broke real-data
+        // init) — this one is deliberately far looser than any calibrated MEMS
+        // accelerometer's bias, so it cannot reject a solution a healthy solve
+        // would produce. It exists only to stop a genuinely diverged refinement
+        // from being applied to the map: the failure mode in kornia-slam#51
+        // reached 0.57 and 0.94 m/s^2 on the gravity-aligned axis, against
+        // EuRoC's true |ba| of ~0.16. Rejecting leaves the previous stage's
+        // bias in place, which is the safe fallback.
+        const MAX_PLAUSIBLE_ACCEL_BIAS: f64 = 1.0; // m/s^2, ~10% of gravity
+        if ba_out.length() > MAX_PLAUSIBLE_ACCEL_BIAS {
+            println!(
+                "[imu_init] rejected: implausible accel bias |ba|={:.3} > {MAX_PLAUSIBLE_ACCEL_BIAS} m/s^2 ({:.3},{:.3},{:.3})",
+                ba_out.length(),
+                ba_out.x,
+                ba_out.y,
+                ba_out.z,
+            );
+            return None;
+        }
         // Reconstruct the PHYSICAL gravity vector using the *same* gI the factor
         // used internally — do not reuse rwg_out assuming any other convention.
         let gravity_world = rwg_out * Vec3F64::new(0.0, 0.0, -GRAVITY_MAGNITUDE);
@@ -516,6 +536,14 @@ mod tests {
 
     const RADIUS: f64 = 2.0;
     const OMEGA: f64 = 0.5;
+    /// Yaw rate for the weak-excitation regime the accel-bias blowup lives in:
+    /// ~66 deg of body rotation over the 5.8 s window, against OMEGA's 166 deg.
+    /// Only body rotation separates a body-fixed accel bias from world-fixed
+    /// gravity, so this is the knob that sets how observable `ba` is. Measured
+    /// on the map built below: at OMEGA the bias is recovered with or without
+    /// the prior; here it is recovered only with it; below ~33 deg the window is
+    /// too degenerate for either to hold.
+    const WEAK_YAW_RATE: f64 = 0.2;
 
     /// True trajectory: circular translation *plus* the body yawing in sync
     /// with it (like a vehicle banking into the turn) — needed so `R_wb(t)`
@@ -525,15 +553,15 @@ mod tests {
     /// bias stays observable either way since it only needs rotation-only
     /// consistency, which is why `bg` recovered correctly even with the
     /// bug below.
-    fn circular_trajectory(t: f64) -> (Vec3F64, Vec3F64, Vec3F64, Mat3F64) {
-        let theta = OMEGA * t;
+    fn circular_trajectory(t: f64, omega: f64) -> (Vec3F64, Vec3F64, Vec3F64, Mat3F64) {
+        let theta = omega * t;
         let (s, c) = theta.sin_cos();
         let p = Vec3F64::new(RADIUS * c, 0.0, RADIUS * s);
-        let v = Vec3F64::new(-RADIUS * OMEGA * s, 0.0, RADIUS * OMEGA * c);
+        let v = Vec3F64::new(-RADIUS * omega * s, 0.0, RADIUS * omega * c);
         let a = Vec3F64::new(
-            -RADIUS * OMEGA * OMEGA * c,
+            -RADIUS * omega * omega * c,
             0.0,
-            -RADIUS * OMEGA * OMEGA * s,
+            -RADIUS * omega * omega * s,
         );
         // Rotation about the (world) Y axis by theta — angular velocity is
         // exactly (0, OMEGA, 0) in both body and world frame since Y is a
@@ -585,10 +613,12 @@ mod tests {
     /// so it integrates the biased signal uncorrected, exactly like a real
     /// biased sensor (`PreintegratedImu::integrate` subtracts `self.bias`,
     /// which is zero here — see `imu.rs:140-143`).
+    #[allow(clippy::too_many_arguments)]
     fn integrate_true_imu(
         t0: f64,
         t1: f64,
         imu_rate_hz: f64,
+        omega: f64,
         gravity_true: Vec3F64,
         bias_gyro_true: Vec3F64,
         bias_accel_true: Vec3F64,
@@ -598,8 +628,8 @@ mod tests {
         let dt = 1.0 / imu_rate_hz;
         let mut t = t0;
         while t < t1 - 1e-9 {
-            let (_, _, a_true, r_wb_true) = circular_trajectory(t + 0.5 * dt);
-            let gyro_meas = Vec3F64::new(0.0, OMEGA, 0.0) + bias_gyro_true; // true body-frame ω + bias
+            let (_, _, a_true, r_wb_true) = circular_trajectory(t + 0.5 * dt, omega);
+            let gyro_meas = Vec3F64::new(0.0, omega, 0.0) + bias_gyro_true; // true body-frame ω + bias
             let accel_meas = r_wb_true.transpose() * (a_true - gravity_true) + bias_accel_true; // specific force in body frame + bias
             pim.integrate(
                 &ImuMeasurement {
@@ -612,6 +642,234 @@ mod tests {
             t += dt;
         }
         pim
+    }
+
+    /// Builds the synthetic circular-trajectory map at an arbitrary vision-map
+    /// scale `s_true` (see `recovers_scale_bias_gravity_from_synthetic_trajectory`
+    /// for the geometry).
+    fn synth_map(s_true: f64, r_arb: Mat3F64) -> Map {
+        synth_map_with_calib(
+            s_true,
+            r_arb,
+            ImuCalib {
+                gyro_noise: 1e-3,
+                accel_noise: 1e-2,
+                gyro_bias_noise: 1e-5,
+                accel_bias_noise: 1e-4,
+            },
+            OMEGA,
+        )
+    }
+
+    /// `omega` is the body yaw rate: it sets how much the body frame rotates
+    /// across the window, which is *the* thing that makes the accel bias
+    /// observable at all (gravity is world-fixed, bias is body-fixed, so only
+    /// rotation separates them).
+    fn synth_map_with_calib(s_true: f64, r_arb: Mat3F64, calib: ImuCalib, omega: f64) -> Map {
+        let bias_gyro_true = Vec3F64::new(0.01, -0.02, 0.005);
+        let bias_accel_true = Vec3F64::new(0.05, -0.03, 0.02);
+        let gravity_true = Vec3F64::new(0.0, GRAVITY_MAGNITUDE, 0.0);
+        let n_keyframes = 30;
+        let kf_dt = 0.2;
+        let imu_rate = 200.0;
+
+        let mut map = Map::new();
+        for k in 0..n_keyframes {
+            let t = k as f64 * kf_dt;
+            let (p_true, _, _, r_wb_true) = circular_trajectory(t, omega);
+            let pose = synth_pose_world_to_cam(r_arb, s_true, p_true, r_wb_true);
+            map.upsert_keyframe(Keyframe::from_frame(synth_frame(k, pose)));
+            if k > 0 {
+                let pim = integrate_true_imu(
+                    t - kf_dt,
+                    t,
+                    imu_rate,
+                    omega,
+                    gravity_true,
+                    bias_gyro_true,
+                    bias_accel_true,
+                    calib,
+                );
+                map.add_imu_factor(k - 1, k, pim, Vec::new(), t - kf_dt, t);
+            }
+        }
+        map
+    }
+
+    /// The VIBA0 residual is *exactly* invariant under `t -> k·t`, `v -> k·v`,
+    /// `s -> s/k`: gravity, both biases and the preintegrated deltas are
+    /// untouched by a rescaling of the visual map, and the velocities that
+    /// absorb it are free variables. So `s_recovered · s_true` must be the
+    /// same constant for every `s_true` — whatever bias the pinned accel prior
+    /// introduces, it introduces identically at every map size.
+    ///
+    /// A drift in that product is not a modelling error, it is the solver
+    /// failing to reach the optimum, which is what makes the estimated scale
+    /// stop tracking map size on real data (kornia/kornia-slam#51).
+    #[test]
+    fn viba0_scale_is_invariant_to_vision_map_scale() {
+        let r_arb = SO3F64::exp(Vec3F64::new(0.3, -0.5, 0.2)).matrix();
+        let initializer = ImuInitializer::new(ImuInitConfig {
+            min_keyframes: 10,
+            min_time_sec: 1.0,
+            min_motion: 0.1,
+        });
+
+        let mut products = Vec::new();
+        for s_true in [0.25, 0.5, 1.0, 2.0, 4.0] {
+            let map = synth_map(s_true, r_arb);
+            let init = initializer
+                .try_initialize(
+                    &map,
+                    Some(Pose3d::IDENTITY),
+                    ImuBias::default(),
+                    0,
+                    1e2,
+                    1e10,
+                    false,
+                )
+                .expect("VIBA0 should solve on clean synthetic data at any map scale");
+            println!(
+                "[scale-invariance] s_true={s_true:<5} s_recovered={:<10.5} product={:.5}",
+                init.scale,
+                init.scale * s_true
+            );
+            products.push(init.scale * s_true);
+        }
+
+        let mean = products.iter().sum::<f64>() / products.len() as f64;
+        let max_rel_dev = products
+            .iter()
+            .map(|p| (p - mean).abs() / mean)
+            .fold(0.0f64, f64::max);
+        assert!(
+            max_rel_dev < 0.02,
+            "VIBA0 scale does not track map size: products {products:?} (mean {mean:.5}, \
+             max deviation {:.1}%)",
+            max_rel_dev * 100.0,
+        );
+    }
+
+    /// Regression test for the accel-bias blowup of kornia-slam#51.
+    ///
+    /// The VIBA refinement solves hold the visual keyframe poses *fixed*, so any
+    /// disagreement between those poses and the preintegrated IMU has to be
+    /// absorbed by the free variables. With EuRoC's tight noise densities even
+    /// millimetre-level pose error is tens of sigma, and the softest direction
+    /// available is the accel bias along gravity — degenerate with gravity
+    /// magnitude (pinned at 9.81) traded against map scale. Drop the accel-bias
+    /// prior, as ORB-SLAM3 does at VIBA2, and that direction runs away.
+    ///
+    /// ORB-SLAM3 can afford `priorA=0` because it runs a `FullInertialBA` between
+    /// stages, which moves the poses into agreement with the IMU first. We do
+    /// not, so we keep the prior (see `Pipeline::VIBA_PRIOR_A`). This test pins
+    /// both halves of that reasoning: the prior keeps the bias physical, and
+    /// removing it does not.
+    #[test]
+    fn viba2_accel_bias_stays_bounded_under_pose_inconsistency() {
+        let r_arb = SO3F64::exp(Vec3F64::new(0.3, -0.5, 0.2)).matrix();
+        let bias_accel_true = Vec3F64::new(0.05, -0.03, 0.02);
+        // Real EuRoC IMU noise densities — the information magnitude is what
+        // turns small pose error into a huge whitened residual.
+        let euroc_calib = ImuCalib {
+            gyro_noise: 1.6968e-4,
+            accel_noise: 2.0e-3,
+            gyro_bias_noise: 1.9393e-5,
+            accel_bias_noise: 3.0e-3,
+        };
+        let initializer = ImuInitializer::new(ImuInitConfig {
+            min_keyframes: 10,
+            min_time_sec: 1.0,
+            min_motion: 0.1,
+        });
+
+        // Deterministic, zero-mean-ish millimetre pose perturbation standing in
+        // for a real front-end's keyframe noise (a real map's disagreement with
+        // the IMU is of this order: MH_01 sits at ~40 sigma per residual).
+        let mut map = synth_map_with_calib(0.5, r_arb, euroc_calib, WEAK_YAW_RATE);
+        for (k, kf) in map.keyframes_mut().iter_mut().enumerate() {
+            let f = k as f64;
+            let jitter = Vec3F64::new(
+                (3.7 * f).sin(),
+                (5.1 * f + 1.3).sin(),
+                (2.3 * f + 0.7).sin(),
+            ) * 2e-3;
+            let cam_to_world = kf.frame.pose_world_to_cam.inverse();
+            kf.frame.pose_world_to_cam =
+                Pose3d::new(cam_to_world.rotation, cam_to_world.translation + jitter).inverse();
+        }
+
+        // VIBA0 is unaffected by the choice below: it pins the accel bias with
+        // prior_a=1e10 either way.
+        let viba0 = initializer
+            .try_initialize(
+                &map,
+                Some(Pose3d::IDENTITY),
+                ImuBias::default(),
+                0,
+                1e2,
+                1e10,
+                false,
+            )
+            .expect("VIBA0 should solve");
+        let mut state = SystemState::new();
+        let mut bias = ImuBias::default();
+        let mut gravity_world = Vec3F64::ZERO;
+        initializer.apply_initialization(
+            &mut map,
+            &mut state,
+            &mut bias,
+            &mut gravity_world,
+            viba0,
+            0,
+        );
+
+        let solve_viba2 = |prior_a: f64| -> Vec3F64 {
+            initializer
+                .try_initialize(
+                    &map.clone(),
+                    Some(Pose3d::IDENTITY),
+                    bias,
+                    0,
+                    0.0,
+                    prior_a,
+                    true,
+                )
+                .map(|init| init.bias.accel)
+                // A diverged solve can now also be rejected outright by the
+                // plausibility gate in `try_initialize`; report that as the
+                // gate's own threshold so the comparison below still holds.
+                .unwrap_or(Vec3F64::new(0.0, 1.0, 0.0))
+        };
+
+        let ba_with_prior = solve_viba2(1e5);
+        let ba_no_prior = solve_viba2(0.0);
+        let err_with_prior = (ba_with_prior - bias_accel_true).length();
+        let err_no_prior = (ba_no_prior - bias_accel_true).length();
+        println!(
+            "[viba2] prior_a=1e5 ba=({:+.4},{:+.4},{:+.4}) err={err_with_prior:.4}\n\
+             [viba2] prior_a=0   ba=({:+.4},{:+.4},{:+.4}) err={err_no_prior:.4}",
+            ba_with_prior.x,
+            ba_with_prior.y,
+            ba_with_prior.z,
+            ba_no_prior.x,
+            ba_no_prior.y,
+            ba_no_prior.z,
+        );
+
+        assert!(
+            err_with_prior < 0.1,
+            "accel bias should stay near truth with the prior retained: \
+             got {ba_with_prior:?}, want ~{bias_accel_true:?}"
+        );
+        assert!(
+            err_no_prior > err_with_prior,
+            "dropping the accel-bias prior is what lets the bias run away; if this \
+             ever stops holding, the poses have become IMU-consistent (e.g. a \
+             FullInertialBA equivalent landed) and `VIBA_PRIOR_A` can be revisited. \
+             with prior: {ba_with_prior:?} ({err_with_prior:.4}), \
+             without: {ba_no_prior:?} ({err_no_prior:.4})"
+        );
     }
 
     #[test]
@@ -636,7 +894,7 @@ mod tests {
         let mut map = Map::new();
         for k in 0..n_keyframes {
             let t = k as f64 * kf_dt;
-            let (p_true, _, _, r_wb_true) = circular_trajectory(t);
+            let (p_true, _, _, r_wb_true) = circular_trajectory(t, OMEGA);
             let pose = synth_pose_world_to_cam(r_arb, s_true, p_true, r_wb_true);
             map.upsert_keyframe(Keyframe::from_frame(synth_frame(k, pose)));
 
@@ -645,6 +903,7 @@ mod tests {
                     t - kf_dt,
                     t,
                     imu_rate,
+                    OMEGA,
                     gravity_true,
                     bias_gyro_true,
                     bias_accel_true,
@@ -751,7 +1010,7 @@ mod tests {
         // `result.velocities_world` here).
         for k in 0..n_keyframes {
             let t = k as f64 * kf_dt;
-            let (_, v_true, _, _) = circular_trajectory(t);
+            let (_, v_true, _, _) = circular_trajectory(t, OMEGA);
             let expected_v = rwg_viba0 * ((r_arb * v_true) * s_true * viba0_scale);
             let err = (result.velocities_world[k] - expected_v).length();
             assert!(

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -4,6 +4,8 @@
 //! to bottom in the same order frames move through the system.
 
 use std::collections::HashSet;
+use std::io::Write as _;
+use std::path::PathBuf;
 
 use crate::config::PipelineConfig;
 use kornia_3d::camera::PinholeCamera;
@@ -14,7 +16,7 @@ use kornia_imgproc::features::{OrbMatchConfig, hamming_distance, match_orb_descr
 use kornia_sensors::imu::{GRAVITY_MAGNITUDE, ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
 use kornia_slam::Frame;
 use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
-use kornia_slam::estimation::{ImuInitConfig, ImuInitializer, MapProjectionEstimator};
+use kornia_slam::estimation::{ImuInitConfig, ImuInitResult, ImuInitializer, MapProjectionEstimator};
 use kornia_slam::map::{Keyframe, Map, MapPoint, ORB_SCALE_FACTOR};
 use kornia_slam::stereo::unproject_stereo;
 use kornia_slam::system::{
@@ -76,6 +78,12 @@ pub struct Pipeline {
     imu_viba1_done: bool,
     imu_viba2_done: bool,
 
+    // Optional CSV sink for VIBA telemetry. When the env var `KORNIA_VIBA_CSV`
+    // is set, every VIBA0/VIBA1/VIBA2 attempt (accepted or rejected) appends one
+    // row with the full solved state vector + scheduling meta, for offline
+    // plotting and ORB-SLAM3 comparison. `None` in normal runs — zero overhead.
+    viba_csv_path: Option<PathBuf>,
+
     // System state
     state: SystemState,
 }
@@ -122,6 +130,87 @@ impl Pipeline {
             imu_init_window_start_sec: None,
             imu_viba1_done: false,
             imu_viba2_done: false,
+            viba_csv_path: Self::init_viba_csv(),
+        }
+    }
+
+    /// If `KORNIA_VIBA_CSV` is set, (re)create the file with a header row and
+    /// return its path; otherwise `None`. One row per VIBA attempt is appended
+    /// later by `log_viba`.
+    fn init_viba_csv() -> Option<PathBuf> {
+        let path = PathBuf::from(std::env::var_os("KORNIA_VIBA_CSV")?);
+        match std::fs::File::create(&path) {
+            Ok(mut f) => {
+                let _ = writeln!(
+                    f,
+                    "stage,t_sec,mtinit,n_kf,imu_time,prior_g,prior_a,accepted,\
+                     scale,g_x,g_y,g_z,g_mag,bg_x,bg_y,bg_z,ba_x,ba_y,ba_z"
+                );
+                eprintln!("[viba_csv] logging VIBA telemetry to {}", path.display());
+                Some(path)
+            }
+            Err(e) => {
+                eprintln!("[viba_csv] could not open {}: {e}", path.display());
+                None
+            }
+        }
+    }
+
+    /// Append one row of VIBA telemetry. `result` is `Some` for an accepted
+    /// solve, `None` for a rejected one (state columns written as NaN). Meta
+    /// (mtinit / n_kf / imu_time) is recomputed from the current window so the
+    /// row is self-describing regardless of which VIBA stage fired.
+    fn log_viba(
+        &self,
+        stage: &str,
+        timestamp_sec: f64,
+        prior_g: f64,
+        prior_a: f64,
+        result: Option<&ImuInitResult>,
+    ) {
+        let Some(path) = &self.viba_csv_path else {
+            return;
+        };
+        let Some(start_idx) = self.inertial_init_start_kf_idx else {
+            return;
+        };
+        let mtinit = self
+            .imu_init_window_start_sec
+            .map(|w| timestamp_sec - w)
+            .unwrap_or(f64::NAN);
+        let n_kf = self
+            .map
+            .keyframes()
+            .iter()
+            .filter(|kf| kf.frame.idx >= start_idx)
+            .count();
+        let imu_time: f64 = self
+            .map
+            .imu_factors()
+            .iter()
+            .filter(|f| f.curr_kf_idx >= start_idx)
+            .map(|f| f.preintegrated.dt)
+            .sum();
+        let row = match result {
+            Some(r) => {
+                let g = r.gravity_world;
+                let bg = r.bias.gyro;
+                let ba = r.bias.accel;
+                format!(
+                    "{stage},{timestamp_sec:.6},{mtinit:.4},{n_kf},{imu_time:.4},\
+                     {prior_g:e},{prior_a:e},1,{:.6},{:.6},{:.6},{:.6},{:.6},\
+                     {:.8},{:.8},{:.8},{:.8},{:.8},{:.8}",
+                    r.scale, g.x, g.y, g.z, g.length(),
+                    bg.x, bg.y, bg.z, ba.x, ba.y, ba.z,
+                )
+            }
+            None => format!(
+                "{stage},{timestamp_sec:.6},{mtinit:.4},{n_kf},{imu_time:.4},\
+                 {prior_g:e},{prior_a:e},0,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan"
+            ),
+        };
+        if let Ok(mut f) = std::fs::OpenOptions::new().append(true).open(path) {
+            let _ = writeln!(f, "{row}");
         }
     }
 
@@ -668,6 +757,7 @@ impl Pipeline {
                     let scale = init.scale;
                     let gravity = init.gravity_world;
                     let bg = init.bias.gyro;
+                    self.log_viba("VIBA0", timestamp_sec, 1e2, prior_a0, Some(&init));
                     self.inertial_init.apply_initialization(
                         &mut self.map,
                         &mut self.state,
@@ -690,6 +780,7 @@ impl Pipeline {
                     ));
                 }
                 None => {
+                    self.log_viba("VIBA0", timestamp_sec, 1e2, prior_a0, None);
                     self.dbg("[imu_init] VIBA0 rejected: solve failed or invalid scale".into());
                 }
             }
@@ -1040,7 +1131,21 @@ impl Pipeline {
         let (prior_g, prior_a, stage) = if !self.imu_viba1_done && mtinit > 5.0 {
             (1.0, 1e5, "VIBA1")
         } else if self.imu_viba1_done && !self.imu_viba2_done && mtinit > 15.0 {
-            (0.0, 0.0, "VIBA2")
+            // Experiment (exp1): VIBA2's `priorA=0` (no accel-bias regularizer)
+            // lets kornia's accel bias run away — unlike ORB-SLAM3, which
+            // re-solves on a FullInertialBA-conditioned map. Allow A/B via env:
+            //   KORNIA_VIBA2=off            → skip VIBA2 entirely (keep VIBA1)
+            //   KORNIA_VIBA2_PRIOR_A=<f64>  → override the accel-bias prior
+            // Default (both unset) reproduces ORB's (0, 0) schedule.
+            if std::env::var("KORNIA_VIBA2").as_deref() == Ok("off") {
+                self.imu_viba2_done = true;
+                return;
+            }
+            let prior_a = std::env::var("KORNIA_VIBA2_PRIOR_A")
+                .ok()
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.0);
+            (0.0, prior_a, "VIBA2")
         } else {
             return;
         };
@@ -1057,6 +1162,7 @@ impl Pipeline {
             Some(init) => {
                 let scale = init.scale;
                 let bg = init.bias.gyro;
+                self.log_viba(stage, timestamp_sec, prior_g, prior_a, Some(&init));
                 self.inertial_init.apply_initialization(
                     &mut self.map,
                     &mut self.state,
@@ -1071,6 +1177,7 @@ impl Pipeline {
                 ));
             }
             None => {
+                self.log_viba(stage, timestamp_sec, prior_g, prior_a, None);
                 self.dbg(format!(
                     "[imu_init] {stage} rejected: solve failed or invalid scale"
                 ));

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -16,7 +16,9 @@ use kornia_imgproc::features::{OrbMatchConfig, hamming_distance, match_orb_descr
 use kornia_sensors::imu::{GRAVITY_MAGNITUDE, ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
 use kornia_slam::Frame;
 use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
-use kornia_slam::estimation::{ImuInitConfig, ImuInitResult, ImuInitializer, MapProjectionEstimator};
+use kornia_slam::estimation::{
+    ImuInitConfig, ImuInitResult, ImuInitializer, MapProjectionEstimator,
+};
 use kornia_slam::map::{Keyframe, Map, MapPoint, ORB_SCALE_FACTOR};
 use kornia_slam::stereo::unproject_stereo;
 use kornia_slam::system::{
@@ -200,8 +202,17 @@ impl Pipeline {
                     "{stage},{timestamp_sec:.6},{mtinit:.4},{n_kf},{imu_time:.4},\
                      {prior_g:e},{prior_a:e},1,{:.6},{:.6},{:.6},{:.6},{:.6},\
                      {:.8},{:.8},{:.8},{:.8},{:.8},{:.8}",
-                    r.scale, g.x, g.y, g.z, g.length(),
-                    bg.x, bg.y, bg.z, ba.x, ba.y, ba.z,
+                    r.scale,
+                    g.x,
+                    g.y,
+                    g.z,
+                    g.length(),
+                    bg.x,
+                    bg.y,
+                    bg.z,
+                    ba.x,
+                    ba.y,
+                    ba.z,
                 )
             }
             None => format!(
@@ -1110,6 +1121,36 @@ impl Pipeline {
         true
     }
 
+    /// Accel-bias prior information for the VIBA1/VIBA2 refinement solves.
+    ///
+    /// ORB-SLAM3 relaxes this to 0 at VIBA2 (`InitializeIMU(0.f, 0.f, true)`,
+    /// LocalMapping.cc:213). We deliberately do NOT: ORB-SLAM3 runs a
+    /// `FullInertialBA` after *every* `InitializeIMU` stage, so by the time its
+    /// VIBA2 solve runs, the keyframe poses it holds fixed have already been
+    /// pulled into agreement with the IMU. Ours have not — the VIBA2 solve sits
+    /// at ~40 sigma per residual on MH_01 (cost 1.3e6 over 729 residual dims),
+    /// and with the accel-bias prior removed the least-squares compromise dumps
+    /// that pose/IMU inconsistency into the one weakly observable direction:
+    /// accel bias along gravity, which is degenerate with gravity magnitude
+    /// (pinned at 9.81) traded against map scale.
+    ///
+    /// Measured at VIBA2 on MH_01 (500 frames) against the dataset's own bias
+    /// ground truth `ba = (-0.026, 0.137, 0.076)`:
+    ///
+    /// | prior_a | ba                        | gravity err |
+    /// |---------|---------------------------|-------------|
+    /// | 0       | (-0.041, **0.386**, 0.041)| 2.2 deg     |
+    /// | 1e4     | (-0.038, 0.207, 0.068)    | 1.2 deg     |
+    /// | 1e5     | (-0.042, 0.047, 0.076)    | 0.26 deg    |
+    ///
+    /// 1e5 is VIBA1's own value (and ORB-SLAM3's at that stage), so keeping it
+    /// for VIBA2 adds no new tuned constant. The blown accel bias also corrupts
+    /// gravity, since the two are coupled in `InertialInitFactor`.
+    ///
+    /// The real fix is a `FullInertialBA` equivalent between stages; until then
+    /// this prior is what stands in for it. See kornia-slam#51.
+    const VIBA_PRIOR_A: f64 = 1e5;
+
     /// VIBA1 (mTinit>5s) / VIBA2 (mTinit>15s): progressive re-solves with
     /// relaxed priors over the same (now-growing) window that VIBA0 used,
     /// mirroring LocalMapping.cc:200-228. Each fires at most once and refines
@@ -1129,14 +1170,12 @@ impl Pipeline {
         }
 
         let (prior_g, prior_a, stage) = if !self.imu_viba1_done && mtinit > 5.0 {
-            (1.0, 1e5, "VIBA1")
+            (1.0, Self::VIBA_PRIOR_A, "VIBA1")
         } else if self.imu_viba1_done && !self.imu_viba2_done && mtinit > 15.0 {
-            // Experiment (exp1): VIBA2's `priorA=0` (no accel-bias regularizer)
-            // lets kornia's accel bias run away — unlike ORB-SLAM3, which
-            // re-solves on a FullInertialBA-conditioned map. Allow A/B via env:
+            // A/B knobs for the accel-bias investigation (kornia-slam#51):
             //   KORNIA_VIBA2=off            → skip VIBA2 entirely (keep VIBA1)
             //   KORNIA_VIBA2_PRIOR_A=<f64>  → override the accel-bias prior
-            // Default (both unset) reproduces ORB's (0, 0) schedule.
+            //                                 (0 reproduces ORB-SLAM3's schedule)
             if std::env::var("KORNIA_VIBA2").as_deref() == Ok("off") {
                 self.imu_viba2_done = true;
                 return;
@@ -1144,7 +1183,7 @@ impl Pipeline {
             let prior_a = std::env::var("KORNIA_VIBA2_PRIOR_A")
                 .ok()
                 .and_then(|s| s.parse::<f64>().ok())
-                .unwrap_or(0.0);
+                .unwrap_or(Self::VIBA_PRIOR_A);
             (0.0, prior_a, "VIBA2")
         } else {
             return;


### PR DESCRIPTION
Fixes #51.

## Root cause

The VIBA refinement solves hold the visual keyframe poses **fixed**, so any disagreement between those poses and the preintegrated IMU has to be absorbed by the remaining free variables. On MH_01 that disagreement is large — the VIBA2 solve sits at **~40σ per residual** (cost 1.3e6 over 729 residual dims) — and the softest direction available is the **accel bias along gravity**, which is degenerate with gravity magnitude (pinned at 9.81) traded against map scale.

VIBA1 resists this because it keeps `priorA = 1e5`. VIBA2 relaxed the prior to 0 and had nothing left holding that direction, so it absorbed the model error: `ba_y` went from a healthy 0.009 at VIBA1 to **0.386** at VIBA2, against MH_01's own bias ground truth of 0.137. It also dragged gravity 2.2° off, since bias and gravity are coupled in `InertialInitFactor`.

ORB-SLAM3 gets away with `priorA = 0` at VIBA2 only because it runs a `FullInertialBA` after *every* `InitializeIMU` stage (`LocalMapping.cc:213`), so the poses its VIBA2 holds fixed have already been pulled into agreement with the IMU. We have no such stage.

## Change

VIBA2 keeps VIBA1's accel-bias prior instead of relaxing it to 0 (`Pipeline::VIBA_PRIOR_A = 1e5`). That is ORB-SLAM3's own value at the previous stage, so it introduces no new tuned constant. The deviation and its reason are documented on the constant.

Also included:

- **Plausibility gate** in `ImuInitializer::try_initialize`: reject any solve with `|ba| > 1 m/s²` (~10% of gravity, far above any calibrated MEMS bias) so a diverged refinement can never be applied to the map. Rejecting leaves the previous stage's bias in place, which is the safe fallback. Deliberately loose — it is a backstop for gross divergence, not the fix.
- **VIBA telemetry** (first commit): `KORNIA_VIBA_CSV=<path>` writes one row per VIBA0/1/2 attempt with the full solved state, which is how the numbers below were produced. Zero overhead when unset. A/B knobs `KORNIA_VIBA2=off` and `KORNIA_VIBA2_PRIOR_A=<f64>` (`0` reproduces ORB-SLAM3's schedule).

## Results

MH_01, 500 frames, VIBA2 vs the dataset's own bias ground truth `ba = (-0.026, 0.137, 0.076)`:

| `prior_a` | `ba` | gravity err |
|-----------|------|-------------|
| 0 (before) | (-0.041, **0.386**, 0.041) | 2.2° |
| 1e4 | (-0.038, 0.207, 0.068) | 1.2° |
| **1e5 (this PR)** | **(-0.042, 0.047, 0.076)** | **0.26°** |

Full-length MH_01 (3682 frames) improves as well:

| | before | after |
|---|---|---|
| ATE RMSE | 0.2388 m | **0.1977 m** |
| Final drift | 0.5805 % | **0.3458 %** |
| RPE RMSE | 0.0171 m | 0.0179 m |

## Tests

- `viba2_accel_bias_stays_bounded_under_pose_inconsistency` reproduces the mechanism on synthetic data: millimetre keyframe jitter plus real EuRoC noise densities. Body rotation is the only thing that separates a body-fixed accel bias from world-fixed gravity, so the test runs at a weak **66° of yaw** across the window — there the bias is recovered only with the prior retained. At the existing test's 166° the prior is irrelevant either way, which is why this never showed up before. Below ~33° the window is too degenerate for either setting.
- `viba0_scale_is_invariant_to_vision_map_scale` pins the exact invariance `s_recovered × map_scale = const` (holds to 5 digits across a 16× range of map scales).

## Hypotheses ruled out along the way

Recorded so they are not re-investigated:

- **Solver under-convergence** — the scale invariance above holds exactly, so VIBA0 is reaching its optimum.
- **f32 generic optimizer precision** — with EuRoC-tight noise on *consistent* synthetic data, VIBA2 at `priorA = 0` recovers `ba` to 6e-4. Single precision only fails once real model error is present.
- **Missing information-matrix eigenvalue clamping** (ORB-SLAM3 clamps in `EdgeInertialGS`, we do not) — measured condition number ≈ 5e2 on real data and Cholesky never fails, so the clamp is a no-op here.
- **Mis-scaled post-init map** — windowed GT/estimate path-length ratio is ≈ 1.00 for frames 100–400. The run-wide eval `Scale` of 0.61 is dominated by the pre-init prefix (0.17), not by post-init error.

## Limitations

- **Not validated on V1_01** — the sequence is not available locally and the ETH dataset host is unreachable from the machine this was developed on. Validation rests on MH_01 (500-frame and full-length).
- The prior is a stand-in, not the real fix. The underlying problem is that our fixed keyframe poses are not IMU-consistent; the proper solution is a `FullInertialBA` equivalent between the VIBA stages. A naive port of that was tried and made things worse (VIBA2 `ba_y` 0.573 → 0.937), because VIBA0's rough scale gets baked in by conditioning on it. The regression test's second assertion is written to fail loudly if the poses ever *do* become IMU-consistent, at which point `VIBA_PRIOR_A` should be revisited.
- The full-length run still shows map scale decaying to ~0.57 in its later windows. That is the pre-existing long-run scale drift, untouched here (the baseline was worse on the run-wide metric).
