### PR TITLE
feat(sim): measurement-level simulator with perturbation-recovery tests

### DIFF
--- a/crates/kornia-sensors/src/imu.rs
+++ b/crates/kornia-sensors/src/imu.rs
@@ -14,6 +14,50 @@ pub struct ImuMeasurement {
     pub accel: Vec3F64,
 }
 
+impl ImuMeasurement {
+    /// The reading an ideal IMU produces for a known kinematic state.
+    ///
+    /// This is the **forward sensor model** — the inverse of what
+    /// [`PreintegratedImu`] does, which is why it belongs here rather than in a
+    /// consumer. Integrating a stream produced by this function must reproduce
+    /// the motion it was generated from; that round trip is the sharpest
+    /// available check on [`PreintegratedImu::integrate`], and
+    /// `preintegration_inverts_the_forward_model` below runs it.
+    ///
+    /// ```text
+    /// gyro  = ω_body            + b_g
+    /// accel = R_wbᵀ · (a − g)   + b_a
+    /// ```
+    ///
+    /// The accelerometer measures **specific force**, not acceleration: a body
+    /// in free fall (`a == g`) reads zero, and one at rest reads `−R_wbᵀ·g`.
+    ///
+    /// # Arguments
+    ///
+    /// - `rotation_wb` — body-to-world rotation at `timestamp`.
+    /// - `accel_world` — world-frame acceleration, **excluding** gravity.
+    /// - `angular_velocity_body` — body-frame angular velocity.
+    /// - `gravity` — world-frame gravity vector (e.g. `[0, 9.81, 0]` with
+    ///   OpenCV Y-down axes).
+    /// - `bias` — bias to add. Noise, if wanted, is the caller's business:
+    ///   this function stays deterministic so it can be used in exact tests.
+    pub fn simulate(
+        timestamp: f64,
+        rotation_wb: &Mat3F64,
+        accel_world: Vec3F64,
+        angular_velocity_body: Vec3F64,
+        gravity: Vec3F64,
+        bias: &ImuBias,
+    ) -> Self {
+        let r_bw = Mat3F64(*rotation_wb.transpose());
+        Self {
+            timestamp,
+            gyro: angular_velocity_body + bias.gyro,
+            accel: r_bw * (accel_world - gravity) + bias.accel,
+        }
+    }
+}
+
 /// Accelerometer and gyroscope biases.
 #[derive(Debug, Clone, Copy)]
 pub struct ImuBias {
@@ -679,5 +723,214 @@ mod tests {
                 "diagonal {i} should not decrease"
             );
         }
+    }
+
+    /// Preintegration must invert the forward sensor model **exactly** on a
+    /// closed-form trajectory: constant body-frame angular velocity and constant
+    /// world-frame acceleration.
+    ///
+    /// ```text
+    /// R_wb(t) = R0·Exp(ω·t)    v(t) = v0 + a·t    p(t) = p0 + v0·t + ½a·t²
+    /// ⇒  ΔR = Exp(ω·Δt)   Δv = R_bw0·(a−g)·Δt   Δp = R_bw0·½(a−g)·Δt²
+    /// ```
+    ///
+    /// Exactness here is not an accident, and it is the point of the test. At
+    /// step `k` the integrator forms `ΔR_k · accel_k`, and since
+    /// `ΔR_k = R_bw0·R_wb(t_k)` while `accel_k = R_wb(t_k)ᵀ·(a−g)`, the two
+    /// rotations cancel to leave the constant `R_bw0·(a−g)`. Summing a constant
+    /// has no discretization error, so the result is exact to machine precision
+    /// at any rate.
+    ///
+    /// That cancellation is fragile in exactly the useful way: it only holds if
+    /// the rotation handling is right. A transposed `ΔR`, a flipped gyro sign,
+    /// or `hat(ΔR·a)` in place of `ΔR·hat(a)` all break it and show up as a
+    /// large error rather than a subtle one. First-order convergence is checked
+    /// separately by `preintegration_converges_at_first_order`, which uses a
+    /// trajectory where the cancellation does not occur.
+    #[test]
+    fn preintegration_inverts_the_forward_model() {
+        let gravity = Vec3F64::new(0.0, 9.81, 0.0);
+        let omega = Vec3F64::new(0.3, -0.5, 0.2); // body-frame, constant
+        let accel_world = Vec3F64::new(0.4, -0.25, 0.6); // excludes gravity
+        let r0 = SO3F64::exp(Vec3F64::new(0.2, 0.1, -0.3));
+        let total = 0.5;
+
+        for rate_hz in [100.0f64, 400.0, 1600.0] {
+            let dt = 1.0 / rate_hz;
+            let n = (total / dt).round() as usize;
+
+            let mut pre = PreintegratedImu::new(ImuBias::default(), default_calib());
+            for k in 0..n {
+                let t = k as f64 * dt;
+                let r_wb = r0 * SO3F64::exp(omega * t);
+                let m = ImuMeasurement::simulate(
+                    t,
+                    &r_wb.matrix(),
+                    accel_world,
+                    omega,
+                    gravity,
+                    &ImuBias::default(),
+                );
+                pre.integrate(&m, dt);
+            }
+
+            let r_bw0 = Mat3F64(*r0.matrix().transpose());
+            let net = accel_world - gravity;
+
+            let rot = (SO3F64::exp(omega * total).inverse()
+                * SO3F64::from_matrix(&pre.delta_rotation))
+            .log()
+            .length();
+            let vel = (pre.delta_velocity - r_bw0 * net * total).length();
+            let pos = (pre.delta_position - r_bw0 * net * (0.5 * total * total)).length();
+
+            assert!(rot < 1e-12, "rotation error {rot} rad at {rate_hz} Hz");
+            assert!(vel < 1e-10, "velocity error {vel} m/s at {rate_hz} Hz");
+            assert!(pos < 1e-10, "position error {pos} m at {rate_hz} Hz");
+        }
+    }
+
+    /// Preintegration error must fall at first order once the exact
+    /// cancellation of `preintegration_inverts_the_forward_model` is broken.
+    ///
+    /// Adding a constant jerk makes world acceleration time-varying, so
+    /// `ΔR_k · accel_k` is no longer constant and the rectangular rule in
+    /// `integrate` — which advances `Δv += ΔR·a·dt` using `ΔR` from the start of
+    /// each step — leaves a genuine `O(dt)` residual. Ground truth stays closed
+    /// form:
+    ///
+    /// ```text
+    /// a(t) = a0 + j·t   v(t) = v0 + a0·t + ½j·t²   p(t) = p0 + v0·t + ½a0·t² + ⅙j·t³
+    /// ```
+    ///
+    /// Halving the timestep must halve the error. This is what discriminates a
+    /// discretization residual from a modelling error: a wrong frame or sign
+    /// gives a constant error that no rate increase removes.
+    #[test]
+    fn preintegration_converges_at_first_order() {
+        let gravity = Vec3F64::new(0.0, 9.81, 0.0);
+        let omega = Vec3F64::new(0.3, -0.5, 0.2);
+        let a0 = Vec3F64::new(0.4, -0.25, 0.6);
+        let jerk = Vec3F64::new(1.5, 2.0, -1.2);
+        let r0 = SO3F64::exp(Vec3F64::new(0.2, 0.1, -0.3));
+        let total = 0.5;
+
+        let error_at = |rate_hz: f64| -> (f64, f64) {
+            let dt = 1.0 / rate_hz;
+            let n = (total / dt).round() as usize;
+
+            let mut pre = PreintegratedImu::new(ImuBias::default(), default_calib());
+            for k in 0..n {
+                let t = k as f64 * dt;
+                let r_wb = r0 * SO3F64::exp(omega * t);
+                let m = ImuMeasurement::simulate(
+                    t,
+                    &r_wb.matrix(),
+                    a0 + jerk * t,
+                    omega,
+                    gravity,
+                    &ImuBias::default(),
+                );
+                pre.integrate(&m, dt);
+            }
+
+            let r_bw0 = Mat3F64(*r0.matrix().transpose());
+            let (t1, t2, t3) = (total, total * total, total * total * total);
+
+            // Δv = R_bw0·(v1 − v0 − g·Δt), with v1 − v0 = a0·Δt + ½j·Δt².
+            let expected_dv = r_bw0 * (a0 * t1 + jerk * (0.5 * t2) - gravity * t1);
+            // Δp = R_bw0·(p1 − p0 − v0·Δt − ½g·Δt²).
+            let expected_dp = r_bw0 * (a0 * (0.5 * t2) + jerk * (t3 / 6.0) - gravity * (0.5 * t2));
+
+            (
+                (pre.delta_velocity - expected_dv).length(),
+                (pre.delta_position - expected_dp).length(),
+            )
+        };
+
+        let coarse = error_at(200.0);
+        let fine = error_at(400.0);
+        let finer = error_at(800.0);
+
+        for (name, c, f, ff) in [
+            ("velocity", coarse.0, fine.0, finer.0),
+            ("position", coarse.1, fine.1, finer.1),
+        ] {
+            assert!(ff > 0.0, "{name} error vanished — trajectory is degenerate");
+            let (r1, r2) = (c / f, f / ff);
+            assert!(
+                (1.6..2.6).contains(&r1),
+                "{name} error ratio 200->400 Hz is {r1}, expected ~2 (first order)"
+            );
+            assert!(
+                (1.6..2.6).contains(&r2),
+                "{name} error ratio 400->800 Hz is {r2}, expected ~2 (first order)"
+            );
+        }
+    }
+
+    /// A level, stationary body reads `-g`, and bias adds straight through.
+    #[test]
+    fn forward_model_matches_hand_computed_readings() {
+        let gravity = Vec3F64::new(0.0, 9.81, 0.0);
+        let level = Mat3F64::IDENTITY;
+
+        let at_rest = ImuMeasurement::simulate(
+            0.0,
+            &level,
+            Vec3F64::ZERO,
+            Vec3F64::ZERO,
+            gravity,
+            &ImuBias::default(),
+        );
+        assert!((at_rest.accel - Vec3F64::new(0.0, -9.81, 0.0)).length() < EPS);
+        assert!(at_rest.gyro.length() < EPS);
+
+        // Free fall: specific force is zero.
+        let falling = ImuMeasurement::simulate(
+            0.0,
+            &level,
+            gravity,
+            Vec3F64::ZERO,
+            gravity,
+            &ImuBias::default(),
+        );
+        assert!(falling.accel.length() < EPS, "free fall should read zero");
+
+        // Bias is additive in both channels.
+        let bias = ImuBias {
+            gyro: Vec3F64::new(0.01, -0.02, 0.03),
+            accel: Vec3F64::new(0.1, 0.2, -0.3),
+        };
+        let biased =
+            ImuMeasurement::simulate(0.0, &level, Vec3F64::ZERO, Vec3F64::ZERO, gravity, &bias);
+        assert!((biased.accel - at_rest.accel - bias.accel).length() < EPS);
+        assert!((biased.gyro - at_rest.gyro - bias.gyro).length() < EPS);
+    }
+
+    /// Rotating the body rotates the measured gravity vector into the body
+    /// frame — the property a wrong transpose would silently invert.
+    #[test]
+    fn forward_model_expresses_gravity_in_the_body_frame() {
+        let gravity = Vec3F64::new(0.0, 9.81, 0.0);
+        // Roll 90 degrees about body x: world +Y (down) maps to body -Z.
+        let r_wb = SO3F64::exp(Vec3F64::new(std::f64::consts::FRAC_PI_2, 0.0, 0.0));
+        let m = ImuMeasurement::simulate(
+            0.0,
+            &r_wb.matrix(),
+            Vec3F64::ZERO,
+            Vec3F64::ZERO,
+            gravity,
+            &ImuBias::default(),
+        );
+        // accel = R_bw·(0 − g) = R_wbᵀ·(−g)
+        let expected = Mat3F64(*r_wb.matrix().transpose()) * -gravity;
+        assert!(
+            (m.accel - expected).length() < EPS,
+            "got {:?}, expected {expected:?}",
+            m.accel
+        );
+        // Concretely: −g along world +Y becomes +Z in the rolled body frame.
+        assert!((m.accel.z - 9.81).abs() < 1e-6, "got {:?}", m.accel);
     }
 }

--- a/crates/kornia-slam/Cargo.toml
+++ b/crates/kornia-slam/Cargo.toml
@@ -6,6 +6,14 @@ description = "Spatial runtime for real-time pose estimation, mapping, and agent
 license.workspace = true
 repository.workspace = true
 
+[features]
+# The measurement simulator (`sim` module). On by default so CI's
+# `cargo test --workspace` and `cargo clippy --all-targets` — both of which run
+# with default features — actually cover it. Downstream consumers who don't
+# want the simulator compiled in can opt out with `default-features = false`.
+default = ["sim"]
+sim = []
+
 [dependencies]
 kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", branch = "main" }

--- a/crates/kornia-slam/Cargo.toml
+++ b/crates/kornia-slam/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 # with default features — actually cover it. Downstream consumers who don't
 # want the simulator compiled in can opt out with `default-features = false`.
 default = ["sim"]
-sim = []
+sim = ["dep:rand"]
 
 [dependencies]
 kornia-3d = { git = "https://github.com/kornia/kornia-rs", branch = "main" }
@@ -23,4 +23,7 @@ kornia-sensors = { path = "../kornia-sensors" }
 # Dense Cholesky solver for the reduced camera system in Schur-complement BA
 # (see vi_ba_schur.rs / ba_schur.rs).
 faer = "0.22"
+# Seeded RNG for the simulator, matching kornia-3d's StdRng usage.
+# Optional so `--no-default-features` does not pull it in.
+rand = { version = "0.10", optional = true }
 thiserror = "1"

--- a/crates/kornia-slam/src/lib.rs
+++ b/crates/kornia-slam/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod estimation;
 pub mod frame;
 pub mod map;
+#[cfg(feature = "sim")]
+pub mod sim;
 pub mod stereo;
 pub mod system;
 pub mod vi_ba_schur;

--- a/crates/kornia-slam/src/sim/imu.rs
+++ b/crates/kornia-slam/src/sim/imu.rs
@@ -1,0 +1,419 @@
+//! Synthetic IMU measurement generation.
+//!
+//! The simulator emits **raw [`ImuMeasurement`] values** and feeds them through
+//! the production [`PreintegratedImu`]. Preintegration is not reimplemented and
+//! not mocked, so a bug in `integrate` — or in its covariance or bias-Jacobian
+//! propagation — falls inside the blast radius of any test built on this,
+//! rather than outside it.
+//!
+//! # Measurement model
+//!
+//! For body-to-world rotation `R_wb`, world acceleration `a` and gravity vector
+//! `g`:
+//!
+//! ```text
+//! gyro(t)  = ω_body(t)              + b_g + n_g
+//! accel(t) = R_wbᵀ · (a(t) − g)     + b_a + n_a
+//! ```
+//!
+//! The accelerometer measures **specific force**, not acceleration: a body in
+//! free fall reads zero. The sign convention here is fixed by the IMU residual
+//! in [`crate::vi_ba_schur`], which propagates `v_j = v_i + g·Δt + R_wb_i·Δv` —
+//! subtracting `g` on generation is what makes that residual vanish on
+//! noiseless ground truth.
+
+use kornia_sensors::imu::{ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
+
+use super::SimError;
+use super::rng::SimRng;
+use super::trajectory::{DEFAULT_GRAVITY, Trajectory};
+use crate::vi_ba_schur::ImuFactor;
+
+use kornia_algebra::{Mat3F64, Vec3F64};
+
+/// EuRoC's ADIS16448 noise densities, used as the simulator's default.
+///
+/// Starting from real datasheet values rather than invented ones means a
+/// sensitivity sweep is anchored at a point that actually corresponds to
+/// hardware.
+pub const EUROC_IMU_CALIB: ImuCalib = ImuCalib {
+    gyro_noise: 1.6968e-4,
+    accel_noise: 2.0e-3,
+    gyro_bias_noise: 1.9393e-5,
+    accel_bias_noise: 3.0e-3,
+};
+
+/// How IMU measurements are generated.
+#[derive(Debug, Clone)]
+pub struct ImuSimConfig {
+    /// Sample rate in Hz.
+    pub rate_hz: f64,
+    /// The **true** bias baked into the measurements. This is the quantity a
+    /// recovery test injects and then asks the estimator to find.
+    pub bias: ImuBias,
+    /// Noise densities. Also what [`PreintegratedImu`] uses to build its
+    /// covariance, so generation and estimation stay consistent.
+    pub calib: ImuCalib,
+    /// Whether to add sensor noise. `false` gives exact measurements, which is
+    /// the right setting for a first recovery test — it separates "the
+    /// optimizer is wrong" from "the noise was too large".
+    pub add_noise: bool,
+}
+
+impl Default for ImuSimConfig {
+    fn default() -> Self {
+        Self {
+            rate_hz: 200.0, // EuRoC's IMU rate
+            bias: ImuBias::default(),
+            calib: EUROC_IMU_CALIB,
+            add_noise: false,
+        }
+    }
+}
+
+/// Generates IMU measurements over the trajectory's full time domain.
+///
+/// Noise is drawn at the **discrete** standard deviation `density / √dt`,
+/// which is the discretization [`PreintegratedImu::integrate`] assumes when it
+/// forms `density² / dt` as the per-sample variance. Getting this wrong would
+/// not make the simulator obviously broken — it would just silently miscalibrate
+/// every covariance-dependent assertion built on it.
+pub fn generate_imu(
+    trajectory: &Trajectory,
+    gravity: Vec3F64,
+    config: &ImuSimConfig,
+    rng: &mut SimRng,
+) -> Result<Vec<ImuMeasurement>, SimError> {
+    if config.rate_hz <= 0.0 || !config.rate_hz.is_finite() {
+        return Err(SimError::InvalidConfig(format!(
+            "IMU rate must be positive and finite, got {}",
+            config.rate_hz
+        )));
+    }
+
+    let dt = 1.0 / config.rate_hz;
+    let (gyro_std, accel_std) = if config.add_noise {
+        (
+            config.calib.gyro_noise / dt.sqrt(),
+            config.calib.accel_noise / dt.sqrt(),
+        )
+    } else {
+        (0.0, 0.0)
+    };
+
+    let n_samples = ((trajectory.t_end() - trajectory.t_start()) / dt).floor() as usize + 1;
+    let mut out = Vec::with_capacity(n_samples);
+
+    for k in 0..n_samples {
+        let t = trajectory.t_start() + k as f64 * dt;
+        // Guard the final sample against floating-point overshoot past t_end.
+        let t = t.min(trajectory.t_end());
+        let state = trajectory.state(t)?;
+
+        let r_bw = Mat3F64(*state.rotation.matrix().transpose());
+        let specific_force = r_bw * (state.acceleration - gravity);
+
+        let mut gyro = state.angular_velocity + config.bias.gyro;
+        let mut accel = specific_force + config.bias.accel;
+        if config.add_noise {
+            gyro += rng.normal_vec3(gyro_std);
+            accel += rng.normal_vec3(accel_std);
+        }
+
+        out.push(ImuMeasurement {
+            timestamp: t,
+            gyro,
+            accel,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Builds one [`ImuFactor`] per consecutive pair of keyframe times.
+///
+/// `bias_estimate` is the bias the factors are **linearized at** — the
+/// estimator's current guess, not the true bias. Passing the estimator's guess
+/// (typically zero) while the measurements carry the true bias is precisely
+/// what makes bias recovery a real test rather than a tautology.
+pub fn build_imu_factors(
+    measurements: &[ImuMeasurement],
+    keyframe_times: &[f64],
+    bias_estimate: ImuBias,
+    calib: ImuCalib,
+) -> Result<Vec<ImuFactor>, SimError> {
+    if keyframe_times.len() < 2 {
+        return Err(SimError::InvalidConfig(format!(
+            "need at least 2 keyframe times to form an IMU edge, got {}",
+            keyframe_times.len()
+        )));
+    }
+
+    let mut factors = Vec::with_capacity(keyframe_times.len() - 1);
+    for i in 0..keyframe_times.len() - 1 {
+        let (t0, t1) = (keyframe_times[i], keyframe_times[i + 1]);
+        if t1 <= t0 {
+            return Err(SimError::InvalidConfig(format!(
+                "keyframe times must be strictly increasing: {t0} then {t1}"
+            )));
+        }
+        factors.push(ImuFactor {
+            from_idx: i,
+            to_idx: i + 1,
+            preintegrated: PreintegratedImu::from_measurements(
+                bias_estimate,
+                calib,
+                measurements,
+                t0,
+                t1,
+            ),
+        });
+    }
+    Ok(factors)
+}
+
+/// Convenience wrapper generating measurements under
+/// [`DEFAULT_GRAVITY`].
+pub fn generate_imu_default_gravity(
+    trajectory: &Trajectory,
+    config: &ImuSimConfig,
+    rng: &mut SimRng,
+) -> Result<Vec<ImuMeasurement>, SimError> {
+    generate_imu(trajectory, DEFAULT_GRAVITY, config, rng)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::trajectory::ArcConfig;
+    use kornia_algebra::SO3F64;
+
+    fn traj() -> Trajectory {
+        Trajectory::arc(&ArcConfig {
+            radius: 4.0,
+            climb: 0.5,
+            n_control: 20,
+            t_start: 0.0,
+            knot_dt: 0.25,
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn stationary_level_body_reads_only_gravity() {
+        // A body held level and still measures a specific force of -g: the
+        // classic "accelerometer reads +9.81 upward while at rest" check. With
+        // OpenCV Y-down gravity of [0, 9.81, 0], that is [0, -9.81, 0].
+        let n = 8;
+        let positions = vec![Vec3F64::new(1.0, 2.0, 3.0); n];
+        let rotations = vec![SO3F64::exp(Vec3F64::ZERO); n];
+        let trajectory = Trajectory::new(
+            crate::sim::spline::RSpline3::new(positions, 0.0, 0.5).unwrap(),
+            crate::sim::spline::So3Spline::new(rotations, 0.0, 0.5).unwrap(),
+        )
+        .unwrap();
+
+        let mut rng = SimRng::new(1);
+        let imu =
+            generate_imu_default_gravity(&trajectory, &ImuSimConfig::default(), &mut rng).unwrap();
+
+        for m in &imu {
+            assert!(m.gyro.length() < 1e-12, "stationary body should not rotate");
+            let expected = Vec3F64::new(0.0, -9.81, 0.0);
+            assert!(
+                (m.accel - expected).length() < 1e-9,
+                "accel {:?} != {expected:?}",
+                m.accel
+            );
+        }
+    }
+
+    #[test]
+    fn injected_bias_appears_in_the_measurements() {
+        let trajectory = traj();
+        let bias = ImuBias {
+            gyro: Vec3F64::new(0.01, -0.02, 0.005),
+            accel: Vec3F64::new(0.05, 0.03, -0.04),
+        };
+        let mut rng = SimRng::new(2);
+
+        let clean =
+            generate_imu_default_gravity(&trajectory, &ImuSimConfig::default(), &mut rng).unwrap();
+        let biased = generate_imu_default_gravity(
+            &trajectory,
+            &ImuSimConfig {
+                bias,
+                ..Default::default()
+            },
+            &mut rng,
+        )
+        .unwrap();
+
+        assert_eq!(clean.len(), biased.len());
+        for (c, b) in clean.iter().zip(biased.iter()) {
+            assert!((b.gyro - c.gyro - bias.gyro).length() < 1e-12);
+            assert!((b.accel - c.accel - bias.accel).length() < 1e-12);
+        }
+    }
+
+    /// Preintegration error against ground truth, at one sample rate.
+    fn preintegration_error(rate_hz: f64) -> (f64, f64, f64) {
+        let trajectory = traj();
+        let mut rng = SimRng::new(3);
+        let config = ImuSimConfig {
+            rate_hz,
+            ..Default::default()
+        };
+        let imu = generate_imu_default_gravity(&trajectory, &config, &mut rng).unwrap();
+
+        let (t0, t1) = (1.0, 1.5);
+        let pim =
+            PreintegratedImu::from_measurements(ImuBias::default(), config.calib, &imu, t0, t1);
+
+        let s0 = trajectory.state(t0).unwrap();
+        let s1 = trajectory.state(t1).unwrap();
+        let dt = t1 - t0;
+        let r_bw_0 = Mat3F64(*s0.rotation.matrix().transpose());
+
+        // ΔR should equal R_wb(t0)ᵀ · R_wb(t1).
+        let expected_dr = s0.rotation.inverse() * s1.rotation;
+        let actual_dr = SO3F64::from_matrix(&pim.delta_rotation);
+        let rot = (expected_dr.inverse() * actual_dr).log().length();
+
+        // Δv = R_bw_0 · (v1 − v0 − g·dt)
+        let expected_dv = r_bw_0 * (s1.velocity - s0.velocity - DEFAULT_GRAVITY * dt);
+        let vel = (pim.delta_velocity - expected_dv).length();
+
+        // Δp = R_bw_0 · (p1 − p0 − v0·dt − ½g·dt²)
+        let expected_dp = r_bw_0
+            * (s1.position - s0.position - s0.velocity * dt - DEFAULT_GRAVITY * (0.5 * dt * dt));
+        let pos = (pim.delta_position - expected_dp).length();
+
+        (rot, vel, pos)
+    }
+
+    /// The end-to-end consistency check between generation and preintegration:
+    /// integrating noiseless measurements must reproduce the trajectory's own
+    /// change in rotation, velocity and position.
+    ///
+    /// This asserts **first-order convergence** rather than a fixed tolerance,
+    /// and the distinction matters. The simulator's measurements are analytically
+    /// exact, but [`PreintegratedImu::integrate`] is a first-order (rectangular)
+    /// scheme: it advances `Δv += ΔR·a·dt` using `ΔR` from the *start* of each
+    /// step. The residual disagreement is therefore genuine discretization error,
+    /// on the order of 5 mm/s over a 0.5 s edge at 400 Hz — not a bug, and not
+    /// something a tighter tolerance could ever reach.
+    ///
+    /// Halving the timestep must halve the error. That is the assertion that
+    /// actually discriminates: a frame or sign-convention mismatch between the
+    /// measurement model and `vi_ba_schur`'s residual produces a *constant*
+    /// error that does not shrink with rate, and a fixed-tolerance test would
+    /// have to be loosened until it accepted exactly that.
+    #[test]
+    fn preintegration_converges_to_ground_truth_motion() {
+        let coarse = preintegration_error(200.0);
+        let fine = preintegration_error(400.0);
+        let finer = preintegration_error(800.0);
+
+        // Rotation is recovered to machine precision at every rate, not merely
+        // to first order. This arc turns about a fixed axis, so the incremental
+        // `exp(ω·dt)` factors all commute and their product telescopes exactly —
+        // there is no discretization error left to converge. Asserting the tight
+        // bound is worth more than a convergence ratio here: a wrong gyro sign
+        // or a body/world frame swap would land many orders of magnitude away,
+        // and dividing one rounding error by another only measures noise.
+        for (rate, e) in [(200.0, coarse.0), (400.0, fine.0), (800.0, finer.0)] {
+            assert!(
+                e < 1e-12,
+                "rotation error {e} rad at {rate} Hz is not exact"
+            );
+        }
+
+        // Velocity and position do carry genuine first-order error, so here the
+        // convergence rate is the meaningful check.
+        assert!(finer.1 < 1e-4, "velocity error {} m/s at 800 Hz", finer.1);
+        assert!(finer.2 < 1e-4, "position error {} m at 800 Hz", finer.2);
+
+        for (name, c, f, ff) in [
+            ("velocity", coarse.1, fine.1, finer.1),
+            ("position", coarse.2, fine.2, finer.2),
+        ] {
+            let r1 = c / f;
+            let r2 = f / ff;
+            assert!(
+                (1.6..2.6).contains(&r1),
+                "{name} error ratio 200→400 Hz is {r1}, expected ~2 (first order)"
+            );
+            assert!(
+                (1.6..2.6).contains(&r2),
+                "{name} error ratio 400→800 Hz is {r2}, expected ~2 (first order)"
+            );
+        }
+    }
+
+    #[test]
+    fn noise_has_the_discretized_standard_deviation() {
+        // Generate on a stationary, level trajectory so the signal is constant
+        // and every deviation is noise.
+        let n = 8;
+        let trajectory = Trajectory::new(
+            crate::sim::spline::RSpline3::new(vec![Vec3F64::ZERO; n], 0.0, 2.0).unwrap(),
+            crate::sim::spline::So3Spline::new(vec![SO3F64::exp(Vec3F64::ZERO); n], 0.0, 2.0)
+                .unwrap(),
+        )
+        .unwrap();
+
+        let config = ImuSimConfig {
+            rate_hz: 200.0,
+            add_noise: true,
+            ..Default::default()
+        };
+        let mut rng = SimRng::new(4);
+        let imu = generate_imu_default_gravity(&trajectory, &config, &mut rng).unwrap();
+
+        let dt = 1.0 / config.rate_hz;
+        let expected_gyro_std = config.calib.gyro_noise / dt.sqrt();
+
+        let n_samples = imu.len() as f64;
+        let mean = imu.iter().map(|m| m.gyro.x).sum::<f64>() / n_samples;
+        let var = imu.iter().map(|m| (m.gyro.x - mean).powi(2)).sum::<f64>() / n_samples;
+
+        let ratio = var.sqrt() / expected_gyro_std;
+        assert!(
+            (0.9..1.1).contains(&ratio),
+            "gyro noise std ratio {ratio} — discretization is off"
+        );
+    }
+
+    #[test]
+    fn imu_factors_span_consecutive_keyframes() {
+        let trajectory = traj();
+        let mut rng = SimRng::new(5);
+        let imu =
+            generate_imu_default_gravity(&trajectory, &ImuSimConfig::default(), &mut rng).unwrap();
+        let times: Vec<f64> = (0..5).map(|i| 0.5 + i as f64 * 0.3).collect();
+
+        let factors = build_imu_factors(&imu, &times, ImuBias::default(), EUROC_IMU_CALIB).unwrap();
+        assert_eq!(factors.len(), 4);
+        for (i, f) in factors.iter().enumerate() {
+            assert_eq!(f.from_idx, i);
+            assert_eq!(f.to_idx, i + 1);
+            assert!(
+                (f.preintegrated.dt - 0.3).abs() < 1e-9,
+                "edge dt {} != 0.3",
+                f.preintegrated.dt
+            );
+        }
+    }
+
+    #[test]
+    fn non_increasing_keyframe_times_are_rejected() {
+        let trajectory = traj();
+        let mut rng = SimRng::new(6);
+        let imu =
+            generate_imu_default_gravity(&trajectory, &ImuSimConfig::default(), &mut rng).unwrap();
+        let bad = vec![1.0, 0.9];
+        assert!(build_imu_factors(&imu, &bad, ImuBias::default(), EUROC_IMU_CALIB).is_err());
+    }
+}

--- a/crates/kornia-slam/src/sim/imu.rs
+++ b/crates/kornia-slam/src/sim/imu.rs
@@ -8,19 +8,15 @@
 //!
 //! # Measurement model
 //!
-//! For body-to-world rotation `R_wb`, world acceleration `a` and gravity vector
-//! `g`:
+//! The sensor equations themselves live in
+//! [`ImuMeasurement::simulate`][kornia_sensors::imu::ImuMeasurement::simulate],
+//! next to the preintegration they invert, and are not restated here — one copy
+//! of a sign convention is the most this codebase should have. This module
+//! supplies the kinematics to feed it, the sampling schedule, and the noise.
 //!
-//! ```text
-//! gyro(t)  = ω_body(t)              + b_g + n_g
-//! accel(t) = R_wbᵀ · (a(t) − g)     + b_a + n_a
-//! ```
-//!
-//! The accelerometer measures **specific force**, not acceleration: a body in
-//! free fall reads zero. The sign convention here is fixed by the IMU residual
-//! in [`crate::vi_ba_schur`], which propagates `v_j = v_i + g·Δt + R_wb_i·Δv` —
-//! subtracting `g` on generation is what makes that residual vanish on
-//! noiseless ground truth.
+//! Noise is drawn at the **discrete** standard deviation `density / √dt`, which
+//! is the discretization [`PreintegratedImu::integrate`] assumes when it forms
+//! `density² / dt` as the per-sample variance.
 
 use kornia_sensors::imu::{ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
 
@@ -29,7 +25,7 @@ use super::rng::SimRng;
 use super::trajectory::{DEFAULT_GRAVITY, Trajectory};
 use crate::vi_ba_schur::ImuFactor;
 
-use kornia_algebra::{Mat3F64, Vec3F64};
+use kornia_algebra::Vec3F64;
 
 /// EuRoC's ADIS16448 noise densities, used as the simulator's default.
 ///
@@ -110,21 +106,23 @@ pub fn generate_imu(
         let t = t.min(trajectory.t_end());
         let state = trajectory.state(t)?;
 
-        let r_bw = Mat3F64(*state.rotation.matrix().transpose());
-        let specific_force = r_bw * (state.acceleration - gravity);
-
-        let mut gyro = state.angular_velocity + config.bias.gyro;
-        let mut accel = specific_force + config.bias.accel;
+        // The measurement model itself lives in kornia-sensors, beside the
+        // preintegration it inverts. This loop only supplies the kinematics and
+        // the noise; it does not restate the sensor equations.
+        let mut measurement = ImuMeasurement::simulate(
+            t,
+            &state.rotation.matrix(),
+            state.acceleration,
+            state.angular_velocity,
+            gravity,
+            &config.bias,
+        );
         if config.add_noise {
-            gyro += rng.normal_vec3(gyro_std);
-            accel += rng.normal_vec3(accel_std);
+            measurement.gyro += rng.normal_vec3(gyro_std);
+            measurement.accel += rng.normal_vec3(accel_std);
         }
 
-        out.push(ImuMeasurement {
-            timestamp: t,
-            gyro,
-            accel,
-        });
+        out.push(measurement);
     }
 
     Ok(out)
@@ -186,7 +184,7 @@ pub fn generate_imu_default_gravity(
 mod tests {
     use super::*;
     use crate::sim::trajectory::ArcConfig;
-    use kornia_algebra::SO3F64;
+    use kornia_algebra::{Mat3F64, SO3F64};
 
     fn traj() -> Trajectory {
         Trajectory::arc(&ArcConfig {

--- a/crates/kornia-slam/src/sim/landmarks.rs
+++ b/crates/kornia-slam/src/sim/landmarks.rs
@@ -4,6 +4,24 @@
 //! [`kornia_3d::ba_schur::bundle_adjust_schur`] and
 //! [`crate::vi_ba_schur::visual_inertial_bundle_adjust`] with no adapter layer
 //! and nothing mocked.
+//!
+//! # Upstreaming
+//!
+//! **This module is intended to move to `kornia-3d`, beside `ba.rs`.** Every
+//! symbol it needs — `BaObservation`, `PinholeCamera`, `project_point`,
+//! `Pose3d` — already lives there, so the move adds no dependencies.
+//!
+//! It is the piece with a concrete debt to pay upstream. As of this writing
+//! `kornia-3d/src/ba_schur.rs` carries an identical hand-rolled `Lcg` struct
+//! **copy-pasted three times** (around lines 1195, 1415 and 1641) — same LCG
+//! constants, same Box-Muller, seeded `state = seed` with no scrambling, which
+//! is a poor generator to be driving perturbation tests. Alongside it,
+//! `schur_ba_recovers_perturbed_poses` runs on four hand-placed points and two
+//! poses: the same shape of test as `tests/sim_recovery.rs`, written narrower.
+//! `pgo.rs` has no tests at all and would get its first ones.
+//!
+//! Moving this also wants the pose helpers from [`super::trajectory`] to
+//! generate the poses to project from — see that module's note.
 
 use kornia_3d::ba::BaObservation;
 use kornia_3d::camera::{PinholeCamera, project_point};

--- a/crates/kornia-slam/src/sim/landmarks.rs
+++ b/crates/kornia-slam/src/sim/landmarks.rs
@@ -1,0 +1,467 @@
+//! Landmark sampling and synthetic visual observations.
+//!
+//! Produces [`BaObservation`] values directly, so the output drives
+//! [`kornia_3d::ba_schur::bundle_adjust_schur`] and
+//! [`crate::vi_ba_schur::visual_inertial_bundle_adjust`] with no adapter layer
+//! and nothing mocked.
+
+use kornia_3d::ba::BaObservation;
+use kornia_3d::camera::{PinholeCamera, project_point};
+use kornia_3d::pose::Pose3d;
+use kornia_algebra::Vec3F64;
+
+use super::SimError;
+use super::rng::SimRng;
+use super::trajectory::Trajectory;
+
+/// How landmarks are scattered around the trajectory.
+#[derive(Debug, Clone)]
+pub struct LandmarkConfig {
+    /// Number of landmarks to sample.
+    pub count: usize,
+    /// Inner radius of the sampling shell (metres).
+    pub min_range: f64,
+    /// Outer radius of the sampling shell (metres).
+    pub max_range: f64,
+    /// Half-angle (radians) of the cone around the camera's forward axis into
+    /// which landmarks are sampled.
+    pub cone_half_angle: f64,
+}
+
+impl Default for LandmarkConfig {
+    fn default() -> Self {
+        Self {
+            count: 400,
+            // A shell, not a box. A uniform box around the trajectory gives an
+            // unrealistic depth distribution — most volume ends up at the
+            // corners, far from the path — and admits degenerate configurations
+            // such as landmarks arbitrarily close to the camera centre.
+            min_range: 2.0,
+            max_range: 12.0,
+            // Slightly wider than a typical 90° horizontal FOV, so some
+            // landmarks fall outside the image and exercise the culling path
+            // rather than every sample being trivially visible.
+            cone_half_angle: 0.9,
+        }
+    }
+}
+
+/// Image bounds, depth gating and pixel noise for observation generation.
+#[derive(Debug, Clone)]
+pub struct ObservationConfig {
+    /// Image width in pixels.
+    pub image_width: f64,
+    /// Image height in pixels.
+    pub image_height: f64,
+    /// Observations closer than this are dropped (metres).
+    pub min_depth: f64,
+    /// Observations farther than this are dropped (metres).
+    pub max_depth: f64,
+    /// Standard deviation of the Gaussian noise added to each pixel
+    /// coordinate. Zero produces exact measurements.
+    pub pixel_noise_std: f64,
+    /// Optional cap on observations per keyframe — the landmark-density knob.
+    /// `None` keeps every visible landmark.
+    pub max_per_keyframe: Option<usize>,
+}
+
+impl Default for ObservationConfig {
+    fn default() -> Self {
+        Self {
+            image_width: 752.0,
+            image_height: 480.0,
+            min_depth: 0.5,
+            max_depth: 50.0,
+            // 1 px is a realistic ORB keypoint localization error and matches
+            // the sigma the estimators' chi-square thresholds assume.
+            pixel_noise_std: 1.0,
+            max_per_keyframe: None,
+        }
+    }
+}
+
+/// Landmarks plus the observations of them, kept index-consistent.
+#[derive(Debug, Clone)]
+pub struct VisualData {
+    /// Ground-truth landmark positions in the world frame, after pruning.
+    pub points: Vec<Vec3F64>,
+    /// Observations indexing into [`Self::points`] and the caller's pose slice.
+    pub observations: Vec<BaObservation>,
+    /// For each entry of [`Self::points`], its index in the pre-pruning
+    /// landmark list. Useful when correlating a failure back to the sample.
+    pub source_index: Vec<usize>,
+}
+
+impl VisualData {
+    /// Number of observations of each pose, indexed by pose.
+    pub fn observations_per_pose(&self, n_poses: usize) -> Vec<usize> {
+        let mut counts = vec![0usize; n_poses];
+        for obs in &self.observations {
+            if obs.pose_idx < n_poses {
+                counts[obs.pose_idx] += 1;
+            }
+        }
+        counts
+    }
+
+    /// Marks the given poses as fixed on every observation that references
+    /// them.
+    ///
+    /// `bundle_adjust_schur` takes its gauge anchoring per-observation, so
+    /// fixing a pose means setting the flag on all of its observations.
+    pub fn fix_poses(&mut self, poses: &[usize]) {
+        for obs in &mut self.observations {
+            if poses.contains(&obs.pose_idx) {
+                obs.fixed_pose = true;
+            }
+        }
+    }
+}
+
+/// Samples landmarks in a shell around the trajectory.
+///
+/// Each landmark is placed relative to a randomly chosen point along the path,
+/// inside a cone around that pose's forward axis, at a uniformly sampled range.
+/// Anchoring to the path rather than to a single global volume keeps the
+/// landmark density roughly constant along a long trajectory.
+pub fn sample_landmarks(
+    trajectory: &Trajectory,
+    config: &LandmarkConfig,
+    rng: &mut SimRng,
+) -> Result<Vec<Vec3F64>, SimError> {
+    if config.min_range <= 0.0 || config.max_range <= config.min_range {
+        return Err(SimError::InvalidConfig(format!(
+            "landmark shell must satisfy 0 < min_range < max_range, got {} .. {}",
+            config.min_range, config.max_range
+        )));
+    }
+
+    // Inset from the domain edges so anchors stay comfortably inside.
+    let span = trajectory.t_end() - trajectory.t_start();
+    let (lo, hi) = (
+        trajectory.t_start() + 0.02 * span,
+        trajectory.t_end() - 0.02 * span,
+    );
+
+    let mut points = Vec::with_capacity(config.count);
+    for _ in 0..config.count {
+        let state = trajectory.state(rng.uniform_range(lo, hi))?;
+
+        // Direction inside a cone about the body forward (+z) axis. Sampling
+        // cos(theta) uniformly gives an equal-area cap rather than one that
+        // bunches toward the axis.
+        let cos_min = config.cone_half_angle.cos();
+        let cos_theta = rng.uniform_range(cos_min, 1.0);
+        let sin_theta = (1.0 - cos_theta * cos_theta).max(0.0).sqrt();
+        let azimuth = rng.uniform_range(0.0, std::f64::consts::TAU);
+        let local = Vec3F64::new(
+            sin_theta * azimuth.cos(),
+            sin_theta * azimuth.sin(),
+            cos_theta,
+        );
+
+        let range = rng.uniform_range(config.min_range, config.max_range);
+        points.push(state.position + state.rotation * local * range);
+    }
+    Ok(points)
+}
+
+/// Projects landmarks into every pose, culling and adding pixel noise.
+///
+/// Landmarks seen by fewer than `min_observations` poses are dropped and the
+/// remaining ones re-indexed. This is not tidying: a point with a single
+/// observation is rank-deficient in the reduced camera system, and leaving such
+/// points in makes the Schur complement singular for reasons that have nothing
+/// to do with the behaviour under test.
+pub fn generate_observations(
+    poses: &[Pose3d],
+    points: &[Vec3F64],
+    camera: &PinholeCamera,
+    config: &ObservationConfig,
+    min_observations: usize,
+    rng: &mut SimRng,
+) -> Result<VisualData, SimError> {
+    if min_observations < 2 {
+        return Err(SimError::InvalidConfig(format!(
+            "min_observations must be at least 2 to constrain a point, got {min_observations}"
+        )));
+    }
+
+    // Pass 1: every visible (pose, point) pair.
+    let mut raw: Vec<Vec<BaObservation>> = vec![Vec::new(); poses.len()];
+    for (pose_idx, pose) in poses.iter().enumerate() {
+        for (point_idx, point) in points.iter().enumerate() {
+            let Some((u, v, depth)) = project_point(camera, pose, point) else {
+                continue; // behind the camera
+            };
+            if depth < config.min_depth || depth > config.max_depth {
+                continue;
+            }
+            let (nu, nv) = if config.pixel_noise_std > 0.0 {
+                (
+                    u + rng.normal_scaled(config.pixel_noise_std),
+                    v + rng.normal_scaled(config.pixel_noise_std),
+                )
+            } else {
+                (u, v)
+            };
+            // Bounds-check after noise: a measurement displaced outside the
+            // image would not have been detected in the first place.
+            if nu < 0.0 || nu >= config.image_width || nv < 0.0 || nv >= config.image_height {
+                continue;
+            }
+            raw[pose_idx].push(BaObservation {
+                pose_idx,
+                point_idx,
+                pixel: [nu as f32, nv as f32],
+                fixed_pose: false,
+                fixed_point: false,
+                depth_meas: None,
+                depth_sigma: 0.0,
+            });
+        }
+    }
+
+    // Pass 2: apply the per-keyframe density cap by random subsampling.
+    if let Some(cap) = config.max_per_keyframe {
+        for per_pose in raw.iter_mut() {
+            if per_pose.len() > cap {
+                // Partial Fisher-Yates: draw `cap` distinct entries to the
+                // front, then truncate. Deterministic given the seed.
+                for i in 0..cap {
+                    let j = i + (rng.next_u64() as usize) % (per_pose.len() - i);
+                    per_pose.swap(i, j);
+                }
+                per_pose.truncate(cap);
+            }
+        }
+    }
+
+    // Pass 3: drop under-observed points and re-index.
+    let mut counts = vec![0usize; points.len()];
+    for per_pose in &raw {
+        for obs in per_pose {
+            counts[obs.point_idx] += 1;
+        }
+    }
+
+    let mut remap = vec![usize::MAX; points.len()];
+    let mut kept_points = Vec::new();
+    let mut source_index = Vec::new();
+    for (idx, &count) in counts.iter().enumerate() {
+        if count >= min_observations {
+            remap[idx] = kept_points.len();
+            kept_points.push(points[idx]);
+            source_index.push(idx);
+        }
+    }
+
+    let mut observations = Vec::new();
+    for per_pose in raw {
+        for mut obs in per_pose {
+            let new_idx = remap[obs.point_idx];
+            if new_idx != usize::MAX {
+                obs.point_idx = new_idx;
+                observations.push(obs);
+            }
+        }
+    }
+
+    if kept_points.is_empty() {
+        return Err(SimError::NoVisibleLandmarks);
+    }
+
+    Ok(VisualData {
+        points: kept_points,
+        observations,
+        source_index,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::trajectory::ArcConfig;
+
+    fn test_camera() -> PinholeCamera {
+        PinholeCamera {
+            fx: 400.0,
+            fy: 400.0,
+            cx: 376.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        }
+    }
+
+    fn setup() -> (Trajectory, Vec<Pose3d>, Vec<Vec3F64>) {
+        let traj = Trajectory::arc(&ArcConfig {
+            radius: 4.0,
+            climb: 0.5,
+            n_control: 20,
+            t_start: 0.0,
+            knot_dt: 0.25,
+            ..Default::default()
+        })
+        .unwrap();
+        let mut rng = SimRng::new(1);
+        let points = sample_landmarks(&traj, &LandmarkConfig::default(), &mut rng).unwrap();
+        let poses = traj
+            .sample_uniform(10)
+            .unwrap()
+            .iter()
+            .map(|s| s.camera_pose(None))
+            .collect();
+        (traj, poses, points)
+    }
+
+    #[test]
+    fn landmarks_land_inside_the_configured_shell() {
+        let traj = Trajectory::arc(&ArcConfig {
+            radius: 4.0,
+            climb: 0.0,
+            n_control: 20,
+            t_start: 0.0,
+            knot_dt: 0.25,
+            ..Default::default()
+        })
+        .unwrap();
+        let cfg = LandmarkConfig {
+            count: 500,
+            min_range: 3.0,
+            max_range: 9.0,
+            cone_half_angle: 0.7,
+        };
+        let mut rng = SimRng::new(5);
+        let points = sample_landmarks(&traj, &cfg, &mut rng).unwrap();
+        assert_eq!(points.len(), 500);
+
+        // Every landmark must be within max_range of *some* point on the path,
+        // which is what "shell around the trajectory" means.
+        let path: Vec<Vec3F64> = traj
+            .sample_uniform(200)
+            .unwrap()
+            .iter()
+            .map(|s| s.position)
+            .collect();
+        for p in &points {
+            let nearest = path
+                .iter()
+                .map(|q| (*p - *q).length())
+                .fold(f64::INFINITY, f64::min);
+            assert!(
+                nearest <= cfg.max_range + 1e-6,
+                "landmark {nearest} m from path, beyond max_range {}",
+                cfg.max_range
+            );
+        }
+    }
+
+    #[test]
+    fn noiseless_observations_reproject_exactly() {
+        let (_, poses, points) = setup();
+        let camera = test_camera();
+        let cfg = ObservationConfig {
+            pixel_noise_std: 0.0,
+            ..Default::default()
+        };
+        let mut rng = SimRng::new(2);
+        let data = generate_observations(&poses, &points, &camera, &cfg, 2, &mut rng).unwrap();
+
+        assert!(!data.observations.is_empty());
+        for obs in &data.observations {
+            let (u, v, _) =
+                project_point(&camera, &poses[obs.pose_idx], &data.points[obs.point_idx]).unwrap();
+            // f32 pixel storage is the only loss here.
+            assert!((obs.pixel[0] as f64 - u).abs() < 1e-3);
+            assert!((obs.pixel[1] as f64 - v).abs() < 1e-3);
+        }
+    }
+
+    #[test]
+    fn observations_respect_image_bounds_and_depth_gate() {
+        let (_, poses, points) = setup();
+        let camera = test_camera();
+        let cfg = ObservationConfig {
+            min_depth: 3.0,
+            max_depth: 8.0,
+            pixel_noise_std: 0.0,
+            ..Default::default()
+        };
+        let mut rng = SimRng::new(3);
+        let data = generate_observations(&poses, &points, &camera, &cfg, 2, &mut rng).unwrap();
+
+        for obs in &data.observations {
+            let (u, v, depth) =
+                project_point(&camera, &poses[obs.pose_idx], &data.points[obs.point_idx]).unwrap();
+            assert!(
+                (3.0..=8.0).contains(&depth),
+                "depth {depth} outside the configured gate"
+            );
+            assert!((0.0..cfg.image_width).contains(&u));
+            assert!((0.0..cfg.image_height).contains(&v));
+        }
+    }
+
+    #[test]
+    fn under_observed_points_are_pruned_and_reindexed() {
+        let (_, poses, points) = setup();
+        let camera = test_camera();
+        let mut rng = SimRng::new(4);
+        let data = generate_observations(
+            &poses,
+            &points,
+            &camera,
+            &ObservationConfig::default(),
+            3,
+            &mut rng,
+        )
+        .unwrap();
+
+        let mut counts = vec![0usize; data.points.len()];
+        for obs in &data.observations {
+            assert!(obs.point_idx < data.points.len(), "stale point index");
+            counts[obs.point_idx] += 1;
+        }
+        for (idx, &c) in counts.iter().enumerate() {
+            assert!(c >= 3, "point {idx} kept with only {c} observations");
+        }
+        assert_eq!(data.source_index.len(), data.points.len());
+    }
+
+    #[test]
+    fn density_cap_is_respected() {
+        let (_, poses, points) = setup();
+        let camera = test_camera();
+        let cfg = ObservationConfig {
+            max_per_keyframe: Some(20),
+            pixel_noise_std: 0.0,
+            ..Default::default()
+        };
+        let mut rng = SimRng::new(6);
+        let data = generate_observations(&poses, &points, &camera, &cfg, 2, &mut rng).unwrap();
+        for (pose_idx, count) in data.observations_per_pose(poses.len()).iter().enumerate() {
+            assert!(*count <= 20, "pose {pose_idx} kept {count} observations");
+        }
+    }
+
+    #[test]
+    fn generation_is_deterministic_for_a_given_seed() {
+        let (_, poses, points) = setup();
+        let camera = test_camera();
+        let cfg = ObservationConfig::default();
+        let a =
+            generate_observations(&poses, &points, &camera, &cfg, 2, &mut SimRng::new(9)).unwrap();
+        let b =
+            generate_observations(&poses, &points, &camera, &cfg, 2, &mut SimRng::new(9)).unwrap();
+
+        assert_eq!(a.observations.len(), b.observations.len());
+        for (x, y) in a.observations.iter().zip(b.observations.iter()) {
+            assert_eq!(x.pose_idx, y.pose_idx);
+            assert_eq!(x.point_idx, y.point_idx);
+            assert_eq!(x.pixel, y.pixel);
+        }
+    }
+}

--- a/crates/kornia-slam/src/sim/mod.rs
+++ b/crates/kornia-slam/src/sim/mod.rs
@@ -1,0 +1,125 @@
+//! A measurement-level simulator for the estimators.
+//!
+//! Ground-truth spline trajectory → analytically exact IMU and landmark
+//! observations → optional noise → straight into the optimizers. No images, no
+//! renderer, no scene geometry.
+//!
+//! # Why measurement-level rather than photorealistic
+//!
+//! The instinct behind "simulator" is usually a renderer. For validating an
+//! *estimator* that is the wrong tool: generating pixels means generating a
+//! frontend problem, and it makes the ground truth only as good as the
+//! renderer's geometric consistency. Generating measurements instead —
+//! pixel coordinates of known landmarks, IMU readings from a differentiable
+//! trajectory — has exact ground truth by construction and isolates the
+//! component where the expensive bugs in this project have actually been.
+//!
+//! Simulating the frontend is a legitimate separate problem. It is not this
+//! one.
+//!
+//! # What this is for, and what it is not
+//!
+//! **Nothing here is mocked.** The simulator produces inputs; the code under
+//! test is the production optimizer ([`crate::vi_ba_schur`],
+//! [`kornia_3d::ba_schur`]) and the production preintegrator
+//! ([`kornia_sensors::imu::PreintegratedImu`]). The usual synthetic-test
+//! failure mode — testing a mock of the thing rather than the thing — does not
+//! apply.
+//!
+//! **This is not the acceptance gate.** Real sequences stay the gate. This is
+//! the instrument to reach for *after* a real sequence says something is wrong
+//! and the question is *which component*. On real data there is no way to ask
+//! "what if the bias were exactly 0.05 m/s² and nothing else were wrong?"; here
+//! that is the only kind of question there is.
+//!
+//! # Layout
+//!
+//! - [`rng`] — seeded, dependency-free deterministic random source.
+//! - [`spline`] — the split R³ + SO(3) B-spline and its analytic derivatives.
+//! - [`trajectory`] — ground-truth kinematic state and frame conventions.
+//! - [`landmarks`] — landmark sampling and [`kornia_3d::ba::BaObservation`]
+//!   generation.
+//! - [`imu`] — raw [`kornia_sensors::imu::ImuMeasurement`] generation and
+//!   preintegration into factors.
+//! - [`scene`] — assembles the above into estimator inputs, plus the
+//!   perturbation used by recovery tests.
+//!
+//! # Example
+//!
+//! ```
+//! use kornia_slam::sim::{ArcConfig, Scene, SceneConfig, Trajectory};
+//!
+//! let trajectory = Trajectory::arc(&ArcConfig::default())?;
+//! let scene = Scene::build(&trajectory, &SceneConfig::default())?;
+//!
+//! // Ground truth, exactly — not an approximation of it.
+//! assert_eq!(scene.camera_poses.len(), 12);
+//! assert!(!scene.visual.observations.is_empty());
+//! # Ok::<(), kornia_slam::sim::SimError>(())
+//! ```
+
+use thiserror::Error;
+
+pub mod imu;
+pub mod landmarks;
+pub mod rng;
+pub mod scene;
+pub mod spline;
+pub mod trajectory;
+
+pub use imu::{EUROC_IMU_CALIB, ImuSimConfig, build_imu_factors, generate_imu};
+pub use landmarks::{
+    LandmarkConfig, ObservationConfig, VisualData, generate_observations, sample_landmarks,
+};
+pub use rng::SimRng;
+pub use scene::{Perturbation, Scene, SceneConfig};
+pub use spline::{RSpline3, So3Spline};
+pub use trajectory::{ArcConfig, DEFAULT_GRAVITY, Trajectory, TrajectoryState};
+
+/// Errors from simulator construction and sampling.
+#[derive(Debug, Error)]
+pub enum SimError {
+    /// A time was requested outside the spline's valid domain.
+    #[error("time {t} outside spline domain [{start}, {end}]")]
+    TimeOutOfRange {
+        /// The requested time.
+        t: f64,
+        /// First valid time.
+        start: f64,
+        /// Last valid time.
+        end: f64,
+    },
+
+    /// A spline was constructed with fewer control points than its order.
+    #[error("spline needs at least {need} control points, got {got}")]
+    TooFewControlPoints {
+        /// Number supplied.
+        got: usize,
+        /// Number required.
+        need: usize,
+    },
+
+    /// Knot spacing was zero, negative or non-finite.
+    #[error("knot spacing must be positive and finite, got {0}")]
+    InvalidKnotSpacing(f64),
+
+    /// The translation and rotation splines cover different time ranges.
+    #[error(
+        "translation spline spans [{}, {}] but rotation spline spans [{}, {}]",
+        translation.0, translation.1, rotation.0, rotation.1
+    )]
+    MismatchedSplineDomains {
+        /// Translation spline domain.
+        translation: (f64, f64),
+        /// Rotation spline domain.
+        rotation: (f64, f64),
+    },
+
+    /// No landmark survived visibility culling.
+    #[error("no landmark was observed by enough keyframes")]
+    NoVisibleLandmarks,
+
+    /// A configuration value was inconsistent or out of range.
+    #[error("invalid simulator configuration: {0}")]
+    InvalidConfig(String),
+}

--- a/crates/kornia-slam/src/sim/mod.rs
+++ b/crates/kornia-slam/src/sim/mod.rs
@@ -44,6 +44,29 @@
 //! - [`scene`] — assembles the above into estimator inputs, plus the
 //!   perturbation used by recovery tests.
 //!
+//! # Upstreaming
+//!
+//! Parts of this module are general enough to belong in kornia-rs rather than
+//! here, and are expected to move once this has settled. Nothing below is
+//! required for kornia-slam to work — the case is reuse, plus deleting
+//! duplication that already exists upstream. Each module carries its own note
+//! with the details; this is the index.
+//!
+//! | Piece | Destination | Why |
+//! |---|---|---|
+//! | [`landmarks`] + the pose helpers from [`trajectory`] | `kornia-3d`, beside `ba.rs` | Needs only symbols already there. Deletes a triplicated hand-rolled `Lcg` in `ba_schur.rs`, widens a 4-point/2-pose recovery test, gives `pgo.rs` its first tests |
+//! | [`spline`] + the algebra-only core of [`trajectory`] | `kornia-algebra` (→ `kornia-manifold`), beside the Lie groups | Nothing comparable exists in kornia-rs; a manifold construct, not a domain factor. Needs `SO3F64` only — no `SE3F64` |
+//!
+//! Staying here: [`scene`] (needs `ViBaKeyframe`), [`imu`] (needs `ImuFactor`,
+//! which is solver window-slot bookkeeping rather than sensor data), and
+//! [`rng`] (a thin wrapper over `rand::StdRng`, nothing to move).
+//!
+//! Note the friction, since it shapes the sequencing: kornia-slam consumes
+//! kornia-rs via a git branch, so each upstream move is a land-wait-bump round
+//! trip. Worth batching into two PRs — one per destination crate — rather than
+//! going piecemeal, and worth coordinating the `kornia-algebra` one with the
+//! Phase 0 rename to `kornia-manifold`.
+//!
 //! # Example
 //!
 //! ```

--- a/crates/kornia-slam/src/sim/rng.rs
+++ b/crates/kornia-slam/src/sim/rng.rs
@@ -4,24 +4,31 @@
 //! recovery test that fails on one run and passes on the next is worse than no
 //! test, because it teaches you to ignore it.
 //!
-//! This is a self-contained xoshiro256++ rather than a `rand` dependency.
-//! kornia-slam has no RNG dependency today, and the simulator needs exactly
-//! three primitives (uniform, Gaussian, unit vector); pulling in `rand` plus
-//! `rand_distr` to get them would be a poor trade. The generator is a standard,
-//! well-tested design, not an invention — see the reference implementation by
-//! Blackman and Vigna (<https://prng.di.unimi.it/>).
+//! The generator itself is `rand`'s [`StdRng`] (ChaCha12), seeded via
+//! [`SeedableRng::seed_from_u64`], which is reproducible across platforms and
+//! across runs. That is the same pattern kornia-3d already uses in its RANSAC
+//! drivers, so the simulator does not introduce a second notion of "seeded
+//! randomness" into the stack.
+//!
+//! What this type adds on top is only the **distributions** the simulator needs
+//! and `rand` does not carry in its core crate: a Gaussian and a uniform
+//! direction on the sphere. Those are a dozen lines; `rand_distr` is not in the
+//! workspace and is not worth adding for them.
 
 use kornia_algebra::Vec3F64;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
 
 /// A seeded, reproducible random source.
 ///
-/// The same seed always yields the same sequence, on every platform: the state
-/// update is pure integer arithmetic and the float conversion is an exact
-/// power-of-two scaling, so there is no dependence on the host's floating-point
-/// rounding mode or on libm.
-#[derive(Debug, Clone)]
+/// The same seed always yields the same sequence, on every platform.
+///
+/// Deliberately not `Clone`: `StdRng` is not, and a cloned generator would
+/// silently replay the same stream into two places — a way to make a "seeded"
+/// run quietly non-independent.
+#[derive(Debug)]
 pub struct SimRng {
-    state: [u64; 4],
+    inner: StdRng,
     /// Box-Muller produces two independent normals per call; the spare is kept
     /// here so no sample is wasted.
     spare_normal: Option<f64>,
@@ -29,54 +36,26 @@ pub struct SimRng {
 
 impl SimRng {
     /// Creates a generator from a seed.
-    ///
-    /// The seed is expanded through SplitMix64, so even low-entropy seeds
-    /// (`0`, `1`, `2`, …) produce well-separated streams — which matters
-    /// because test seeds are almost always small integers.
     pub fn new(seed: u64) -> Self {
-        let mut z = seed;
-        let mut next = || {
-            z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
-            let mut x = z;
-            x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-            x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-            x ^ (x >> 31)
-        };
         Self {
-            state: [next(), next(), next(), next()],
+            inner: StdRng::seed_from_u64(seed),
             spare_normal: None,
         }
     }
 
-    /// Raw 64-bit output (xoshiro256++).
+    /// Raw 64-bit output.
     pub fn next_u64(&mut self) -> u64 {
-        let result = self.state[0]
-            .wrapping_add(self.state[3])
-            .rotate_left(23)
-            .wrapping_add(self.state[0]);
-
-        let t = self.state[1] << 17;
-        self.state[2] ^= self.state[0];
-        self.state[3] ^= self.state[1];
-        self.state[1] ^= self.state[2];
-        self.state[0] ^= self.state[3];
-        self.state[2] ^= t;
-        self.state[3] = self.state[3].rotate_left(45);
-
-        result
+        self.inner.random()
     }
 
     /// Uniform sample in `[0, 1)`.
-    ///
-    /// Takes the top 53 bits — the full mantissa width of an `f64` — so every
-    /// representable value in the range is reachable with uniform probability.
     pub fn uniform(&mut self) -> f64 {
-        (self.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
+        self.inner.random()
     }
 
     /// Uniform sample in `[lo, hi)`.
     pub fn uniform_range(&mut self, lo: f64, hi: f64) -> f64 {
-        lo + (hi - lo) * self.uniform()
+        self.inner.random_range(lo..hi)
     }
 
     /// Standard normal sample, `N(0, 1)`, via the polar Box-Muller transform.
@@ -146,8 +125,8 @@ mod tests {
     fn different_seeds_diverge() {
         let mut a = SimRng::new(1);
         let mut b = SimRng::new(2);
-        // Small seeds must not produce correlated streams; this is what the
-        // SplitMix64 expansion in `new` is for.
+        // Small seeds must not produce correlated streams — `seed_from_u64`
+        // runs the seed through a hash before keying the generator.
         let differing = (0..100).filter(|_| a.next_u64() != b.next_u64()).count();
         assert_eq!(differing, 100);
     }

--- a/crates/kornia-slam/src/sim/rng.rs
+++ b/crates/kornia-slam/src/sim/rng.rs
@@ -1,0 +1,199 @@
+//! Deterministic pseudo-random generation for the simulator.
+//!
+//! Every simulated quantity must be reproducible from a recorded seed — a
+//! recovery test that fails on one run and passes on the next is worse than no
+//! test, because it teaches you to ignore it.
+//!
+//! This is a self-contained xoshiro256++ rather than a `rand` dependency.
+//! kornia-slam has no RNG dependency today, and the simulator needs exactly
+//! three primitives (uniform, Gaussian, unit vector); pulling in `rand` plus
+//! `rand_distr` to get them would be a poor trade. The generator is a standard,
+//! well-tested design, not an invention — see the reference implementation by
+//! Blackman and Vigna (<https://prng.di.unimi.it/>).
+
+use kornia_algebra::Vec3F64;
+
+/// A seeded, reproducible random source.
+///
+/// The same seed always yields the same sequence, on every platform: the state
+/// update is pure integer arithmetic and the float conversion is an exact
+/// power-of-two scaling, so there is no dependence on the host's floating-point
+/// rounding mode or on libm.
+#[derive(Debug, Clone)]
+pub struct SimRng {
+    state: [u64; 4],
+    /// Box-Muller produces two independent normals per call; the spare is kept
+    /// here so no sample is wasted.
+    spare_normal: Option<f64>,
+}
+
+impl SimRng {
+    /// Creates a generator from a seed.
+    ///
+    /// The seed is expanded through SplitMix64, so even low-entropy seeds
+    /// (`0`, `1`, `2`, …) produce well-separated streams — which matters
+    /// because test seeds are almost always small integers.
+    pub fn new(seed: u64) -> Self {
+        let mut z = seed;
+        let mut next = || {
+            z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut x = z;
+            x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            x ^ (x >> 31)
+        };
+        Self {
+            state: [next(), next(), next(), next()],
+            spare_normal: None,
+        }
+    }
+
+    /// Raw 64-bit output (xoshiro256++).
+    pub fn next_u64(&mut self) -> u64 {
+        let result = self.state[0]
+            .wrapping_add(self.state[3])
+            .rotate_left(23)
+            .wrapping_add(self.state[0]);
+
+        let t = self.state[1] << 17;
+        self.state[2] ^= self.state[0];
+        self.state[3] ^= self.state[1];
+        self.state[1] ^= self.state[2];
+        self.state[0] ^= self.state[3];
+        self.state[2] ^= t;
+        self.state[3] = self.state[3].rotate_left(45);
+
+        result
+    }
+
+    /// Uniform sample in `[0, 1)`.
+    ///
+    /// Takes the top 53 bits — the full mantissa width of an `f64` — so every
+    /// representable value in the range is reachable with uniform probability.
+    pub fn uniform(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
+    }
+
+    /// Uniform sample in `[lo, hi)`.
+    pub fn uniform_range(&mut self, lo: f64, hi: f64) -> f64 {
+        lo + (hi - lo) * self.uniform()
+    }
+
+    /// Standard normal sample, `N(0, 1)`, via the polar Box-Muller transform.
+    pub fn normal(&mut self) -> f64 {
+        if let Some(spare) = self.spare_normal.take() {
+            return spare;
+        }
+        // Rejection-sample a point inside the unit disc. The polar form avoids
+        // the sin/cos of the basic transform and is numerically better behaved.
+        let (u, v, s) = loop {
+            let u = self.uniform_range(-1.0, 1.0);
+            let v = self.uniform_range(-1.0, 1.0);
+            let s = u * u + v * v;
+            // s == 0 would divide by zero below; s >= 1 is outside the disc.
+            if s > 0.0 && s < 1.0 {
+                break (u, v, s);
+            }
+        };
+        let factor = (-2.0 * s.ln() / s).sqrt();
+        self.spare_normal = Some(v * factor);
+        u * factor
+    }
+
+    /// Zero-mean normal sample with the given standard deviation.
+    pub fn normal_scaled(&mut self, std_dev: f64) -> f64 {
+        self.normal() * std_dev
+    }
+
+    /// Isotropic zero-mean Gaussian vector with per-axis standard deviation
+    /// `std_dev`.
+    pub fn normal_vec3(&mut self, std_dev: f64) -> Vec3F64 {
+        Vec3F64::new(
+            self.normal_scaled(std_dev),
+            self.normal_scaled(std_dev),
+            self.normal_scaled(std_dev),
+        )
+    }
+
+    /// A direction sampled uniformly over the unit sphere.
+    ///
+    /// Uses the cylindrical-projection method (Archimedes): sampling `z`
+    /// uniformly in `[-1, 1]` and the azimuth uniformly gives equal-area
+    /// coverage. Naively sampling spherical angles would instead bunch samples
+    /// at the poles and quietly bias the landmark distribution.
+    pub fn unit_vec3(&mut self) -> Vec3F64 {
+        let z = self.uniform_range(-1.0, 1.0);
+        let azimuth = self.uniform_range(0.0, std::f64::consts::TAU);
+        let r = (1.0 - z * z).max(0.0).sqrt();
+        Vec3F64::new(r * azimuth.cos(), r * azimuth.sin(), z)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_seed_gives_same_sequence() {
+        let mut a = SimRng::new(42);
+        let mut b = SimRng::new(42);
+        for _ in 0..100 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn different_seeds_diverge() {
+        let mut a = SimRng::new(1);
+        let mut b = SimRng::new(2);
+        // Small seeds must not produce correlated streams; this is what the
+        // SplitMix64 expansion in `new` is for.
+        let differing = (0..100).filter(|_| a.next_u64() != b.next_u64()).count();
+        assert_eq!(differing, 100);
+    }
+
+    #[test]
+    fn uniform_stays_in_range() {
+        let mut rng = SimRng::new(7);
+        for _ in 0..10_000 {
+            let x = rng.uniform();
+            assert!((0.0..1.0).contains(&x), "uniform out of range: {x}");
+        }
+    }
+
+    #[test]
+    fn normal_matches_requested_moments() {
+        let mut rng = SimRng::new(11);
+        let n = 200_000;
+        let std_dev = 2.5;
+        let samples: Vec<f64> = (0..n).map(|_| rng.normal_scaled(std_dev)).collect();
+
+        let mean = samples.iter().sum::<f64>() / n as f64;
+        let variance = samples.iter().map(|s| (s - mean).powi(2)).sum::<f64>() / n as f64;
+
+        // Standard error of the mean is std/sqrt(n) ~= 0.0056; 4 sigma is a
+        // generous but non-vacuous bound for a deterministic seed.
+        assert!(mean.abs() < 0.03, "mean {mean} too far from 0");
+        assert!(
+            (variance.sqrt() - std_dev).abs() < 0.03,
+            "std {} too far from {std_dev}",
+            variance.sqrt()
+        );
+    }
+
+    #[test]
+    fn unit_vec3_is_normalized_and_unbiased() {
+        let mut rng = SimRng::new(13);
+        let n = 50_000;
+        let mut sum = Vec3F64::ZERO;
+        for _ in 0..n {
+            let v = rng.unit_vec3();
+            assert!((v.length() - 1.0).abs() < 1e-12, "not unit length");
+            sum += v;
+        }
+        // A uniform sphere distribution has zero mean; a pole-biased sampler
+        // would show a clear z drift here.
+        let mean = sum * (1.0 / n as f64);
+        assert!(mean.length() < 0.02, "directional bias: {mean:?}");
+    }
+}

--- a/crates/kornia-slam/src/sim/scene.rs
+++ b/crates/kornia-slam/src/sim/scene.rs
@@ -1,0 +1,359 @@
+//! Assembles a trajectory, landmarks and sensor measurements into the exact
+//! input types the estimators take.
+//!
+//! A [`Scene`] is the bridge between "here is a trajectory I chose" and the six
+//! arguments of [`visual_inertial_bundle_adjust`]. Everything it hands back is
+//! ground truth, which is what makes a failure attributable: the estimate is
+//! compared against a quantity that was *defined*, not measured.
+//!
+//! [`visual_inertial_bundle_adjust`]: crate::vi_ba_schur::visual_inertial_bundle_adjust
+
+use kornia_3d::camera::PinholeCamera;
+use kornia_3d::pose::Pose3d;
+use kornia_algebra::Vec3F64;
+use kornia_sensors::imu::{ImuBias, ImuMeasurement};
+
+use super::SimError;
+use super::imu::{ImuSimConfig, build_imu_factors, generate_imu};
+use super::landmarks::{
+    LandmarkConfig, ObservationConfig, VisualData, generate_observations, sample_landmarks,
+};
+use super::rng::SimRng;
+use super::trajectory::{DEFAULT_GRAVITY, Trajectory, TrajectoryState};
+use crate::vi_ba_schur::{ImuFactor, ViBaKeyframe};
+
+/// Everything needed to build a [`Scene`] from a [`Trajectory`].
+#[derive(Debug, Clone)]
+pub struct SceneConfig {
+    /// Number of keyframes sampled along the trajectory.
+    pub n_keyframes: usize,
+    /// Camera intrinsics used for projection.
+    pub camera: PinholeCamera,
+    /// Landmark scattering.
+    pub landmarks: LandmarkConfig,
+    /// Projection, culling and pixel noise.
+    pub observations: ObservationConfig,
+    /// Minimum number of keyframes that must see a landmark for it to be kept.
+    pub min_observations: usize,
+    /// IMU generation. `None` builds a visual-only scene.
+    pub imu: Option<ImuSimConfig>,
+    /// Gravity in the world frame.
+    pub gravity: Vec3F64,
+    /// Camera-to-body extrinsic (`X_body = T_bc · X_cam`). `None` means the
+    /// camera and body frames coincide.
+    pub t_bc: Option<Pose3d>,
+    /// The seed. Recorded on the [`Scene`] so a failing run is reproducible
+    /// from its output alone.
+    pub seed: u64,
+}
+
+impl Default for SceneConfig {
+    fn default() -> Self {
+        Self {
+            n_keyframes: 12,
+            // EuRoC-like intrinsics, so the pixel scale relates to the datasets
+            // the estimators are actually tuned against.
+            camera: PinholeCamera {
+                fx: 458.654,
+                fy: 457.296,
+                cx: 367.215,
+                cy: 248.375,
+                k1: 0.0,
+                k2: 0.0,
+                p1: 0.0,
+                p2: 0.0,
+            },
+            landmarks: LandmarkConfig::default(),
+            observations: ObservationConfig::default(),
+            min_observations: 3,
+            imu: None,
+            gravity: DEFAULT_GRAVITY,
+            t_bc: None,
+            seed: 0,
+        }
+    }
+}
+
+/// A fully generated scene: ground truth plus the measurements derived from it.
+#[derive(Debug, Clone)]
+pub struct Scene {
+    /// Ground-truth kinematic state at each keyframe.
+    pub states: Vec<TrajectoryState>,
+    /// Ground-truth world→camera poses at each keyframe.
+    pub camera_poses: Vec<Pose3d>,
+    /// Landmarks and their observations.
+    pub visual: VisualData,
+    /// Raw IMU stream, empty when the scene is visual-only.
+    pub imu_measurements: Vec<ImuMeasurement>,
+    /// The IMU settings the stream was generated with. `None` for a
+    /// visual-only scene. Carried on the scene so [`Scene::imu_factors`] uses
+    /// the same noise model that generated the data rather than assuming a
+    /// default.
+    pub imu_config: Option<ImuSimConfig>,
+    /// Camera intrinsics used.
+    pub camera: PinholeCamera,
+    /// Gravity used.
+    pub gravity: Vec3F64,
+    /// Camera-to-body extrinsic used.
+    pub t_bc: Option<Pose3d>,
+    /// The seed this scene was generated from.
+    pub seed: u64,
+}
+
+impl Scene {
+    /// Generates a scene from a trajectory.
+    pub fn build(trajectory: &Trajectory, config: &SceneConfig) -> Result<Self, SimError> {
+        let mut rng = SimRng::new(config.seed);
+
+        let states = trajectory.sample_uniform(config.n_keyframes)?;
+        let camera_poses: Vec<Pose3d> = states
+            .iter()
+            .map(|s| s.camera_pose(config.t_bc.as_ref()))
+            .collect();
+
+        let points = sample_landmarks(trajectory, &config.landmarks, &mut rng)?;
+        let visual = generate_observations(
+            &camera_poses,
+            &points,
+            &config.camera,
+            &config.observations,
+            config.min_observations,
+            &mut rng,
+        )?;
+
+        let imu_measurements = match &config.imu {
+            Some(imu_config) => generate_imu(trajectory, config.gravity, imu_config, &mut rng)?,
+            None => Vec::new(),
+        };
+
+        Ok(Self {
+            states,
+            camera_poses,
+            visual,
+            imu_measurements,
+            imu_config: config.imu.clone(),
+            camera: config.camera.clone(),
+            gravity: config.gravity,
+            t_bc: config.t_bc,
+            seed: config.seed,
+        })
+    }
+
+    /// Keyframe timestamps.
+    pub fn keyframe_times(&self) -> Vec<f64> {
+        self.states.iter().map(|s| s.timestamp).collect()
+    }
+
+    /// Ground-truth [`ViBaKeyframe`] values: exact pose, exact world velocity
+    /// and the true bias.
+    ///
+    /// This is the target a recovery test measures against, and also the
+    /// starting point a perturbation is applied to.
+    pub fn ground_truth_keyframes(&self) -> Vec<ViBaKeyframe> {
+        self.states
+            .iter()
+            .zip(self.camera_poses.iter())
+            .map(|(state, pose)| ViBaKeyframe {
+                pose: *pose,
+                velocity: state.velocity,
+                bias: self.true_bias(),
+                fixed: false,
+            })
+            .collect()
+    }
+
+    /// The true bias baked into [`Self::imu_measurements`]. Zero for a
+    /// visual-only scene.
+    pub fn true_bias(&self) -> ImuBias {
+        self.imu_config.as_ref().map(|c| c.bias).unwrap_or_default()
+    }
+
+    /// Builds IMU factors between consecutive keyframes, linearized at
+    /// `bias_estimate`.
+    pub fn imu_factors(&self, bias_estimate: ImuBias) -> Result<Vec<ImuFactor>, SimError> {
+        let Some(config) = self.imu_config.as_ref() else {
+            return Err(SimError::InvalidConfig(
+                "scene has no IMU measurements".to_string(),
+            ));
+        };
+        build_imu_factors(
+            &self.imu_measurements,
+            &self.keyframe_times(),
+            bias_estimate,
+            config.calib,
+        )
+    }
+}
+
+/// Applies a known, seeded perturbation to a set of ground-truth keyframes.
+///
+/// This is the input side of a recovery test: displace the estimate by a known
+/// amount, then check the optimizer walks it back. The perturbation is
+/// deliberately applied in the tangent space so a rotation stays a rotation.
+///
+/// `fixed` keyframes are left untouched — they are the gauge anchor, and
+/// perturbing them would move the frame the answer is expressed in rather than
+/// creating an error to correct.
+#[derive(Debug, Clone, Default)]
+pub struct Perturbation {
+    /// Standard deviation of the translation offset (metres).
+    pub translation_std: f64,
+    /// Standard deviation of the rotation offset (radians).
+    pub rotation_std: f64,
+    /// Standard deviation of the velocity offset (m/s).
+    pub velocity_std: f64,
+    /// Standard deviation of the landmark position offset (metres).
+    pub point_std: f64,
+    /// Bias the estimate is *started from*, overriding ground truth. `None`
+    /// keeps the true bias.
+    pub initial_bias: Option<ImuBias>,
+}
+
+impl Perturbation {
+    /// Perturbs poses in place. Rotation is perturbed on the manifold via the
+    /// exponential map, so the result is always a valid rotation.
+    pub fn apply_to_poses(&self, poses: &mut [Pose3d], fixed: &[bool], rng: &mut SimRng) {
+        use kornia_algebra::SO3F64;
+        for (pose, is_fixed) in poses.iter_mut().zip(fixed.iter()) {
+            if *is_fixed {
+                continue;
+            }
+            if self.rotation_std > 0.0 {
+                // Right-multiplied tangent perturbation: the result is a
+                // product of rotations, never a matrix with noise added to its
+                // entries, so it stays exactly on SO(3).
+                let delta = SO3F64::exp(rng.normal_vec3(self.rotation_std));
+                let r = SO3F64::from_matrix(&pose.rotation) * delta;
+                pose.rotation = r.matrix();
+            }
+            if self.translation_std > 0.0 {
+                pose.translation += rng.normal_vec3(self.translation_std);
+            }
+        }
+    }
+
+    /// Perturbs landmark positions in place.
+    pub fn apply_to_points(&self, points: &mut [Vec3F64], rng: &mut SimRng) {
+        if self.point_std <= 0.0 {
+            return;
+        }
+        for p in points.iter_mut() {
+            *p += rng.normal_vec3(self.point_std);
+        }
+    }
+
+    /// Perturbs full VI-BA keyframes: pose, velocity and bias.
+    pub fn apply_to_keyframes(&self, keyframes: &mut [ViBaKeyframe], rng: &mut SimRng) {
+        let fixed: Vec<bool> = keyframes.iter().map(|k| k.fixed).collect();
+        let mut poses: Vec<Pose3d> = keyframes.iter().map(|k| k.pose).collect();
+        self.apply_to_poses(&mut poses, &fixed, rng);
+
+        for (kf, pose) in keyframes.iter_mut().zip(poses) {
+            kf.pose = pose;
+            if kf.fixed {
+                continue;
+            }
+            if self.velocity_std > 0.0 {
+                kf.velocity += rng.normal_vec3(self.velocity_std);
+            }
+            if let Some(bias) = self.initial_bias {
+                kf.bias = bias;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::trajectory::ArcConfig;
+
+    fn traj() -> Trajectory {
+        Trajectory::arc(&ArcConfig {
+            radius: 4.0,
+            climb: 0.5,
+            n_control: 20,
+            t_start: 0.0,
+            knot_dt: 0.25,
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn visual_only_scene_has_no_imu() {
+        let scene = Scene::build(&traj(), &SceneConfig::default()).unwrap();
+        assert!(scene.imu_measurements.is_empty());
+        assert_eq!(scene.camera_poses.len(), 12);
+        assert!(!scene.visual.observations.is_empty());
+        assert!(scene.imu_factors(ImuBias::default()).is_err());
+    }
+
+    #[test]
+    fn inertial_scene_produces_one_factor_per_gap() {
+        let config = SceneConfig {
+            n_keyframes: 8,
+            imu: Some(ImuSimConfig::default()),
+            ..Default::default()
+        };
+        let scene = Scene::build(&traj(), &config).unwrap();
+        assert!(!scene.imu_measurements.is_empty());
+        let factors = scene.imu_factors(ImuBias::default()).unwrap();
+        assert_eq!(factors.len(), 7);
+    }
+
+    #[test]
+    fn ground_truth_keyframes_match_the_scene_poses() {
+        let scene = Scene::build(&traj(), &SceneConfig::default()).unwrap();
+        let kfs = scene.ground_truth_keyframes();
+        for (kf, pose) in kfs.iter().zip(scene.camera_poses.iter()) {
+            assert!((kf.pose.translation - pose.translation).length() < 1e-15);
+        }
+    }
+
+    #[test]
+    fn perturbation_keeps_rotations_valid_and_spares_fixed_frames() {
+        let scene = Scene::build(&traj(), &SceneConfig::default()).unwrap();
+        let mut kfs = scene.ground_truth_keyframes();
+        kfs[0].fixed = true;
+        let original_first = kfs[0].pose;
+
+        let perturbation = Perturbation {
+            translation_std: 0.1,
+            rotation_std: 0.02,
+            velocity_std: 0.1,
+            point_std: 0.05,
+            initial_bias: None,
+        };
+        let mut rng = SimRng::new(99);
+        perturbation.apply_to_keyframes(&mut kfs, &mut rng);
+
+        assert!((kfs[0].pose.translation - original_first.translation).length() < 1e-15);
+        for kf in &kfs {
+            let det = kf.pose.rotation.determinant();
+            assert!((det - 1.0).abs() < 1e-9, "perturbed rotation det {det}");
+        }
+        assert!((kfs[3].pose.translation - scene.camera_poses[3].translation).length() > 1e-6);
+    }
+
+    #[test]
+    fn scene_generation_is_reproducible() {
+        let config = SceneConfig {
+            seed: 1234,
+            imu: Some(ImuSimConfig {
+                add_noise: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let a = Scene::build(&traj(), &config).unwrap();
+        let b = Scene::build(&traj(), &config).unwrap();
+
+        assert_eq!(a.visual.observations.len(), b.visual.observations.len());
+        assert_eq!(a.imu_measurements.len(), b.imu_measurements.len());
+        for (x, y) in a.imu_measurements.iter().zip(b.imu_measurements.iter()) {
+            assert_eq!(x.gyro.x, y.gyro.x);
+            assert_eq!(x.accel.z, y.accel.z);
+        }
+    }
+}

--- a/crates/kornia-slam/src/sim/spline.rs
+++ b/crates/kornia-slam/src/sim/spline.rs
@@ -22,6 +22,28 @@
 //! the measurements are generated from, so there is no modelling error between
 //! ground truth and what the estimator is asked to recover. That is the whole
 //! point of generating measurements analytically.
+//!
+//! # Upstreaming
+//!
+//! **This module is intended to move to `kornia-algebra`, beside the Lie
+//! groups.** A split R³ + SO(3) B-spline is a general trajectory primitive,
+//! kornia-rs has nothing like it (checked across all its crates), and it is a
+//! manifold construct rather than a domain factor — so it sits on the right side
+//! of the kornia-manifold roadmap's rule that domain factors stay in domain
+//! crates.
+//!
+//! Dependencies are already satisfied upstream: this needs only `SO3F64` (landed
+//! in kornia-rs PR #931) and `Vec3F64`. It deliberately does **not** need
+//! `SE3F64`, which still does not exist — see §4.1 of the plan.
+//!
+//! Two things to handle when moving it:
+//!
+//! 1. It returns [`SimError`] for `TimeOutOfRange`, `TooFewControlPoints` and
+//!    `InvalidKnotSpacing`. Those need a local error type upstream; they are the
+//!    only coupling to kornia-slam.
+//! 2. `kornia-algebra` is being renamed to `kornia-manifold` in Phase 0 of the
+//!    manifold roadmap. Coordinate rather than race it — a new module landing
+//!    mid-rename is avoidable churn.
 
 use kornia_algebra::{SO3F64, Vec3F64};
 
@@ -133,7 +155,7 @@ impl RSpline3 {
     /// Builds a spline from control points on a uniform knot vector starting at
     /// `t_start` with spacing `knot_dt`.
     ///
-    /// A cubic spline needs at least [`SPLINE_ORDER`] control points to define
+    /// A cubic spline needs at least `SPLINE_ORDER` control points to define
     /// even one segment.
     pub fn new(control: Vec<Vec3F64>, t_start: f64, knot_dt: f64) -> Result<Self, SimError> {
         if control.len() < SPLINE_ORDER {

--- a/crates/kornia-slam/src/sim/spline.rs
+++ b/crates/kornia-slam/src/sim/spline.rs
@@ -1,0 +1,510 @@
+//! Uniform cubic B-splines on R³ and SO(3).
+//!
+//! The trajectory is represented as **two independent splines** — a cubic
+//! B-spline for translation and a cumulative cubic B-spline for rotation —
+//! rather than a single spline on SE(3).
+//!
+//! Three reasons, in order of importance:
+//!
+//! 1. It needs no `SE3F64`. `kornia_algebra` has `SO3F64` but its SE(3) type is
+//!    f32-only, and kornia-slam's estimation is f64 throughout. The split
+//!    representation reaches f64 ground truth today.
+//! 2. Derivatives stay simple. Translational velocity and acceleration are
+//!    plain polynomial derivatives; angular velocity from a cumulative SO(3)
+//!    spline has a closed form (see [`So3Spline::angular_velocity`]). A coupled
+//!    SE(3) spline's derivatives are messier for no gain here.
+//! 3. Rotation and translation become independently controllable, which is
+//!    what makes degenerate scenarios — pure rotation with no translation,
+//!    translation with no rotation — expressible at all.
+//!
+//! **The spline is the ground truth.** It is not an approximation of some other
+//! "true" curve: whatever curve the control points describe *is* the trajectory
+//! the measurements are generated from, so there is no modelling error between
+//! ground truth and what the estimator is asked to recover. That is the whole
+//! point of generating measurements analytically.
+
+use kornia_algebra::{SO3F64, Vec3F64};
+
+use super::SimError;
+
+/// Number of control points influencing any one spline segment (cubic → 4).
+const SPLINE_ORDER: usize = 4;
+
+/// Uniform cubic B-spline basis, evaluated at `u ∈ [0, 1)` within a segment.
+///
+/// Returns the four weights applied to control points `i .. i+3`, using the
+/// standard De Boor basis matrix
+///
+/// ```text
+///           [  1   4   1   0 ]
+/// M = 1/6 · [ -3   0   3   0 ]
+///           [  3  -6   3   0 ]
+///           [ -1   3  -3   1 ]
+/// ```
+///
+/// as `b(u) = [1, u, u², u³] · M`.
+fn basis(u: f64) -> [f64; SPLINE_ORDER] {
+    let (u2, u3) = (u * u, u * u * u);
+    [
+        (1.0 - 3.0 * u + 3.0 * u2 - u3) / 6.0,
+        (4.0 - 6.0 * u2 + 3.0 * u3) / 6.0,
+        (1.0 + 3.0 * u + 3.0 * u2 - 3.0 * u3) / 6.0,
+        u3 / 6.0,
+    ]
+}
+
+/// First derivative of [`basis`] with respect to `u`.
+fn basis_d1(u: f64) -> [f64; SPLINE_ORDER] {
+    let u2 = u * u;
+    [
+        (-3.0 + 6.0 * u - 3.0 * u2) / 6.0,
+        (-12.0 * u + 9.0 * u2) / 6.0,
+        (3.0 + 6.0 * u - 9.0 * u2) / 6.0,
+        3.0 * u2 / 6.0,
+    ]
+}
+
+/// Second derivative of [`basis`] with respect to `u`.
+fn basis_d2(u: f64) -> [f64; SPLINE_ORDER] {
+    [
+        (6.0 - 6.0 * u) / 6.0,
+        (-12.0 + 18.0 * u) / 6.0,
+        (6.0 - 18.0 * u) / 6.0,
+        6.0 * u / 6.0,
+    ]
+}
+
+/// Cumulative cubic B-spline basis: `λ_j(u) = Σ_{s ≥ j} b_s(u)`.
+///
+/// Only `λ_1..λ_3` are returned; `λ_0 ≡ 1` because the basis is a partition of
+/// unity, and it multiplies the segment's anchor rotation directly.
+fn cumulative_basis(u: f64) -> [f64; 3] {
+    let (u2, u3) = (u * u, u * u * u);
+    [
+        (5.0 + 3.0 * u - 3.0 * u2 + u3) / 6.0,
+        (1.0 + 3.0 * u + 3.0 * u2 - 2.0 * u3) / 6.0,
+        u3 / 6.0,
+    ]
+}
+
+/// First derivative of [`cumulative_basis`] with respect to `u`.
+fn cumulative_basis_d1(u: f64) -> [f64; 3] {
+    let u2 = u * u;
+    [
+        (3.0 - 6.0 * u + 3.0 * u2) / 6.0,
+        (3.0 + 6.0 * u - 6.0 * u2) / 6.0,
+        3.0 * u2 / 6.0,
+    ]
+}
+
+/// Locates `t` within a uniform knot vector.
+///
+/// Returns the index of the first of the four control points governing the
+/// segment, plus the normalized position `u ∈ [0, 1]` inside it.
+fn locate(t: f64, t_start: f64, knot_dt: f64, n_control: usize) -> Result<(usize, f64), SimError> {
+    let n_segments = n_control - (SPLINE_ORDER - 1);
+    let t_end = t_start + n_segments as f64 * knot_dt;
+
+    if !(t_start..=t_end).contains(&t) {
+        return Err(SimError::TimeOutOfRange {
+            t,
+            start: t_start,
+            end: t_end,
+        });
+    }
+
+    let scaled = (t - t_start) / knot_dt;
+    // `t == t_end` lands exactly on the segment boundary, where floor() would
+    // index one segment past the end. Clamp it back to the final segment's
+    // closing edge (u = 1), which evaluates to the same point by continuity.
+    let segment = (scaled.floor() as usize).min(n_segments - 1);
+    Ok((segment, scaled - segment as f64))
+}
+
+/// A uniform cubic B-spline on R³, used for the translational trajectory.
+#[derive(Debug, Clone)]
+pub struct RSpline3 {
+    control: Vec<Vec3F64>,
+    t_start: f64,
+    knot_dt: f64,
+}
+
+impl RSpline3 {
+    /// Builds a spline from control points on a uniform knot vector starting at
+    /// `t_start` with spacing `knot_dt`.
+    ///
+    /// A cubic spline needs at least [`SPLINE_ORDER`] control points to define
+    /// even one segment.
+    pub fn new(control: Vec<Vec3F64>, t_start: f64, knot_dt: f64) -> Result<Self, SimError> {
+        if control.len() < SPLINE_ORDER {
+            return Err(SimError::TooFewControlPoints {
+                got: control.len(),
+                need: SPLINE_ORDER,
+            });
+        }
+        if knot_dt <= 0.0 || !knot_dt.is_finite() {
+            return Err(SimError::InvalidKnotSpacing(knot_dt));
+        }
+        Ok(Self {
+            control,
+            t_start,
+            knot_dt,
+        })
+    }
+
+    /// First time at which the spline is defined.
+    pub fn t_start(&self) -> f64 {
+        self.t_start
+    }
+
+    /// Last time at which the spline is defined.
+    ///
+    /// A cubic B-spline with `n` control points spans `n - 3` segments; the
+    /// leading and trailing control points shape the curve without extending
+    /// its valid domain.
+    pub fn t_end(&self) -> f64 {
+        self.t_start + (self.control.len() - (SPLINE_ORDER - 1)) as f64 * self.knot_dt
+    }
+
+    fn weighted(&self, segment: usize, weights: [f64; SPLINE_ORDER]) -> Vec3F64 {
+        let mut acc = Vec3F64::ZERO;
+        for (k, w) in weights.iter().enumerate() {
+            acc += self.control[segment + k] * *w;
+        }
+        acc
+    }
+
+    /// Position at time `t`.
+    pub fn position(&self, t: f64) -> Result<Vec3F64, SimError> {
+        let (segment, u) = locate(t, self.t_start, self.knot_dt, self.control.len())?;
+        Ok(self.weighted(segment, basis(u)))
+    }
+
+    /// Velocity at time `t`. Chain rule: `du/dt = 1 / knot_dt`.
+    pub fn velocity(&self, t: f64) -> Result<Vec3F64, SimError> {
+        let (segment, u) = locate(t, self.t_start, self.knot_dt, self.control.len())?;
+        Ok(self.weighted(segment, basis_d1(u)) * (1.0 / self.knot_dt))
+    }
+
+    /// Acceleration at time `t`.
+    pub fn acceleration(&self, t: f64) -> Result<Vec3F64, SimError> {
+        let (segment, u) = locate(t, self.t_start, self.knot_dt, self.control.len())?;
+        Ok(self.weighted(segment, basis_d2(u)) * (1.0 / (self.knot_dt * self.knot_dt)))
+    }
+}
+
+/// A cumulative uniform cubic B-spline on SO(3), used for the rotational
+/// trajectory.
+///
+/// Interpolating rotations cannot use the plain weighted sum that works on R³ —
+/// a weighted average of rotation matrices is not a rotation. The cumulative
+/// form composes incremental rotations on the manifold instead:
+///
+/// ```text
+/// R(u) = R_i · Exp(λ₁(u)·d₁) · Exp(λ₂(u)·d₂) · Exp(λ₃(u)·d₃)
+/// d_j  = Log(R_{i+j-1}⁻¹ · R_{i+j})
+/// ```
+///
+/// so every evaluation is a product of rotations and therefore a rotation by
+/// construction (Kim, Kim & Shin, *A General Construction Scheme for Unit
+/// Quaternion Curves with Simple High Order Derivatives*, SIGGRAPH '95).
+#[derive(Debug, Clone)]
+pub struct So3Spline {
+    control: Vec<SO3F64>,
+    t_start: f64,
+    knot_dt: f64,
+}
+
+impl So3Spline {
+    /// Builds a rotation spline from control rotations on a uniform knot
+    /// vector.
+    pub fn new(control: Vec<SO3F64>, t_start: f64, knot_dt: f64) -> Result<Self, SimError> {
+        if control.len() < SPLINE_ORDER {
+            return Err(SimError::TooFewControlPoints {
+                got: control.len(),
+                need: SPLINE_ORDER,
+            });
+        }
+        if knot_dt <= 0.0 || !knot_dt.is_finite() {
+            return Err(SimError::InvalidKnotSpacing(knot_dt));
+        }
+        Ok(Self {
+            control,
+            t_start,
+            knot_dt,
+        })
+    }
+
+    /// First time at which the spline is defined.
+    pub fn t_start(&self) -> f64 {
+        self.t_start
+    }
+
+    /// Last time at which the spline is defined.
+    pub fn t_end(&self) -> f64 {
+        self.t_start + (self.control.len() - (SPLINE_ORDER - 1)) as f64 * self.knot_dt
+    }
+
+    /// The three incremental tangent vectors `d_j` for a segment.
+    fn deltas(&self, segment: usize) -> [Vec3F64; 3] {
+        let mut d = [Vec3F64::ZERO; 3];
+        for (j, slot) in d.iter_mut().enumerate() {
+            let prev = &self.control[segment + j];
+            let next = &self.control[segment + j + 1];
+            *slot = (prev.inverse() * *next).log();
+        }
+        d
+    }
+
+    /// Rotation at time `t`, as body-to-world.
+    pub fn rotation(&self, t: f64) -> Result<SO3F64, SimError> {
+        let (segment, u) = locate(t, self.t_start, self.knot_dt, self.control.len())?;
+        let d = self.deltas(segment);
+        let lambda = cumulative_basis(u);
+
+        let mut r = self.control[segment];
+        for j in 0..3 {
+            r *= SO3F64::exp(d[j] * lambda[j]);
+        }
+        Ok(r)
+    }
+
+    /// Body-frame angular velocity `ω` at time `t`, defined by
+    /// `Ṙ = R · hat(ω)`.
+    ///
+    /// # Derivation
+    ///
+    /// Write `R = A₀·A₁·A₂·A₃` with `A₀ = R_i` constant and
+    /// `A_j = Exp(λ_j(u)·d_j)`. Because `d_j` is fixed, the family `λ ↦
+    /// Exp(λ·d_j)` is a one-parameter subgroup, so `Ȧ_j = A_j · hat(λ̇_j·d_j)`
+    /// exactly — no left/right Jacobian correction is needed. Differentiating
+    /// the product and left-multiplying by `R⁻¹`:
+    ///
+    /// ```text
+    /// R⁻¹Ṙ = Σ_j (A_{j+1}···A₃)⁻¹ · hat(λ̇_j·d_j) · (A_{j+1}···A₃)
+    ///      = Σ_j hat( (A_{j+1}···A₃)⁻¹ · (λ̇_j·d_j) )
+    /// ```
+    ///
+    /// using the identity `Rᵀ·hat(v)·R = hat(Rᵀ·v)`. Hence
+    /// `ω = Σ_j (A_{j+1}···A₃)⁻¹ · (λ̇_j·d_j)`, accumulated below from `j = 3`
+    /// downwards so the trailing product is built incrementally.
+    ///
+    /// This is exact, not a finite-difference approximation — which is the
+    /// property that makes the generated gyro measurements trustworthy as
+    /// ground truth. `angular_velocity_matches_finite_difference` pins it.
+    pub fn angular_velocity(&self, t: f64) -> Result<Vec3F64, SimError> {
+        let (segment, u) = locate(t, self.t_start, self.knot_dt, self.control.len())?;
+        let d = self.deltas(segment);
+        let lambda = cumulative_basis(u);
+        let lambda_dot = cumulative_basis_d1(u);
+        let du_dt = 1.0 / self.knot_dt;
+
+        let mut omega = Vec3F64::ZERO;
+        // `trailing` holds (A_{j+1}···A₃) as j descends.
+        let mut trailing = SO3F64::exp(Vec3F64::ZERO);
+        for j in (0..3).rev() {
+            omega += trailing.inverse() * (d[j] * (lambda_dot[j] * du_dt));
+            trailing = SO3F64::exp(d[j] * lambda[j]) * trailing;
+        }
+        Ok(omega)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Control points tracing a helix — curved in all three axes so no
+    /// derivative component is trivially zero.
+    fn helix_positions(n: usize) -> Vec<Vec3F64> {
+        (0..n)
+            .map(|i| {
+                let a = i as f64 * 0.4;
+                Vec3F64::new(2.0 * a.cos(), 1.5 * a.sin(), 0.3 * a)
+            })
+            .collect()
+    }
+
+    /// Control rotations with a non-constant, non-planar angular rate.
+    fn twisting_rotations(n: usize) -> Vec<SO3F64> {
+        (0..n)
+            .map(|i| {
+                let a = i as f64 * 0.3;
+                SO3F64::exp(Vec3F64::new(0.4 * a.sin(), 0.25 * a, 0.3 * a.cos()))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn basis_is_a_partition_of_unity() {
+        // If the weights did not sum to 1 the spline would not be
+        // translation-invariant, which every other property depends on.
+        for k in 0..=20 {
+            let u = k as f64 / 20.0;
+            let sum: f64 = basis(u).iter().sum();
+            assert!((sum - 1.0).abs() < 1e-14, "basis sums to {sum} at u={u}");
+            // Derivative weights must sum to zero for the same reason.
+            let d1: f64 = basis_d1(u).iter().sum();
+            let d2: f64 = basis_d2(u).iter().sum();
+            assert!(d1.abs() < 1e-14, "d1 sums to {d1} at u={u}");
+            assert!(d2.abs() < 1e-14, "d2 sums to {d2} at u={u}");
+        }
+    }
+
+    #[test]
+    fn cumulative_basis_matches_summed_basis() {
+        // The cumulative form must be the running tail-sum of the plain basis,
+        // or the rotation spline is not the same curve family as the
+        // translation spline.
+        for k in 0..=20 {
+            let u = k as f64 / 20.0;
+            let b = basis(u);
+            let lambda = cumulative_basis(u);
+            for j in 0..3 {
+                let expected: f64 = b[(j + 1)..].iter().sum();
+                assert!(
+                    (lambda[j] - expected).abs() < 1e-14,
+                    "lambda[{j}] = {} != {expected} at u={u}",
+                    lambda[j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cumulative_basis_d1_matches_finite_difference() {
+        let h = 1e-6;
+        for k in 1..20 {
+            let u = k as f64 / 20.0;
+            let plus = cumulative_basis(u + h);
+            let minus = cumulative_basis(u - h);
+            let analytic = cumulative_basis_d1(u);
+            for j in 0..3 {
+                let numeric = (plus[j] - minus[j]) / (2.0 * h);
+                assert!(
+                    (analytic[j] - numeric).abs() < 1e-8,
+                    "lambda_dot[{j}] analytic {} vs numeric {numeric} at u={u}",
+                    analytic[j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn spline_is_continuous_across_segment_boundaries() {
+        let spline = RSpline3::new(helix_positions(10), 0.0, 0.5).unwrap();
+        // A cubic B-spline is C² everywhere, so evaluating either side of an
+        // interior knot must agree in value, velocity and acceleration.
+        for seg in 1..6 {
+            let t = seg as f64 * 0.5;
+            let eps = 1e-9;
+            let before = spline.position(t - eps).unwrap();
+            let after = spline.position(t + eps).unwrap();
+            assert!((before - after).length() < 1e-8, "position jump at t={t}");
+
+            let v_before = spline.velocity(t - eps).unwrap();
+            let v_after = spline.velocity(t + eps).unwrap();
+            assert!(
+                (v_before - v_after).length() < 1e-6,
+                "velocity jump at t={t}"
+            );
+
+            let a_before = spline.acceleration(t - eps).unwrap();
+            let a_after = spline.acceleration(t + eps).unwrap();
+            assert!((a_before - a_after).length() < 1e-4, "accel jump at t={t}");
+        }
+    }
+
+    /// The gate for the whole simulator: if the analytic derivatives are wrong,
+    /// every generated IMU measurement is wrong in a way that looks like an
+    /// estimator bug.
+    #[test]
+    fn velocity_and_acceleration_match_finite_difference() {
+        let spline = RSpline3::new(helix_positions(12), 0.0, 0.5).unwrap();
+        let h = 1e-5;
+
+        let mut samples = 0;
+        let mut t = spline.t_start() + 0.1;
+        while t < spline.t_end() - 0.1 {
+            let p_plus = spline.position(t + h).unwrap();
+            let p_minus = spline.position(t - h).unwrap();
+            let p_mid = spline.position(t).unwrap();
+
+            let v_numeric = (p_plus - p_minus) * (1.0 / (2.0 * h));
+            let v_analytic = spline.velocity(t).unwrap();
+            assert!(
+                (v_numeric - v_analytic).length() < 1e-6,
+                "velocity mismatch at t={t}: {v_analytic:?} vs {v_numeric:?}"
+            );
+
+            let a_numeric = (p_plus - p_mid * 2.0 + p_minus) * (1.0 / (h * h));
+            let a_analytic = spline.acceleration(t).unwrap();
+            // Second-order central differences lose ~half the mantissa, so the
+            // tolerance here is looser than the velocity one by necessity.
+            assert!(
+                (a_numeric - a_analytic).length() < 1e-3,
+                "acceleration mismatch at t={t}: {a_analytic:?} vs {a_numeric:?}"
+            );
+
+            samples += 1;
+            t += 0.13;
+        }
+        assert!(samples > 10, "test swept too few samples");
+    }
+
+    /// The rotational counterpart, and the subtler of the two: the closed form
+    /// in `angular_velocity` is the piece most likely to be silently wrong.
+    #[test]
+    fn angular_velocity_matches_finite_difference() {
+        let spline = So3Spline::new(twisting_rotations(12), 0.0, 0.5).unwrap();
+        let h = 1e-6;
+
+        let mut samples = 0;
+        let mut t = spline.t_start() + 0.1;
+        while t < spline.t_end() - 0.1 {
+            let r_minus = spline.rotation(t - h).unwrap();
+            let r_plus = spline.rotation(t + h).unwrap();
+
+            // Body-frame rate: Log(R(t-h)⁻¹ · R(t+h)) / 2h.
+            let numeric = (r_minus.inverse() * r_plus).log() * (1.0 / (2.0 * h));
+            let analytic = spline.angular_velocity(t).unwrap();
+
+            assert!(
+                (numeric - analytic).length() < 1e-6,
+                "angular velocity mismatch at t={t}: {analytic:?} vs {numeric:?}"
+            );
+
+            samples += 1;
+            t += 0.13;
+        }
+        assert!(samples > 10, "test swept too few samples");
+    }
+
+    #[test]
+    fn rotation_stays_on_the_manifold() {
+        let spline = So3Spline::new(twisting_rotations(10), 0.0, 0.5).unwrap();
+        let mut t = spline.t_start();
+        while t <= spline.t_end() {
+            let m = spline.rotation(t).unwrap().matrix();
+            let det = m.determinant();
+            assert!((det - 1.0).abs() < 1e-12, "determinant {det} at t={t}");
+            t += 0.1;
+        }
+    }
+
+    #[test]
+    fn out_of_range_time_is_rejected() {
+        let spline = RSpline3::new(helix_positions(8), 0.0, 0.5).unwrap();
+        assert!(spline.position(-0.1).is_err());
+        assert!(spline.position(spline.t_end() + 0.1).is_err());
+        // Both endpoints are inclusive and must evaluate.
+        assert!(spline.position(spline.t_start()).is_ok());
+        assert!(spline.position(spline.t_end()).is_ok());
+    }
+
+    #[test]
+    fn too_few_control_points_is_rejected() {
+        assert!(RSpline3::new(helix_positions(3), 0.0, 0.5).is_err());
+        assert!(RSpline3::new(helix_positions(4), 0.0, 0.5).is_ok());
+    }
+}

--- a/crates/kornia-slam/src/sim/trajectory.rs
+++ b/crates/kornia-slam/src/sim/trajectory.rs
@@ -1,0 +1,370 @@
+//! Ground-truth trajectories built from a translation spline and a rotation
+//! spline.
+//!
+//! # Frame conventions
+//!
+//! These follow the rest of kornia-slam and must not be varied casually — a
+//! frame-convention mismatch between the simulator and the estimator produces
+//! exactly the class of bug the simulator exists to catch, except undetectably.
+//!
+//! - **World axes are OpenCV-style Y-down**, matching [`ViBaParams::gravity`]'s
+//!   default of `[0, 9.81, 0]`.
+//! - **Body axes**: `x` right, `y` down, `z` forward.
+//! - `R_wb` maps body → world; its columns are the body axes in world
+//!   coordinates.
+//! - [`Pose3d`] values returned here are **world → camera** (`T_cw`), the
+//!   convention `BaObservation` and `ViBaKeyframe` expect.
+//! - The camera-to-body extrinsic `T_bc` satisfies `X_body = T_bc · X_cam`,
+//!   matching [`ViBaParams::imu_t_bc`].
+//!
+//! [`ViBaParams::gravity`]: crate::vi_ba_schur::ViBaParams::gravity
+//! [`ViBaParams::imu_t_bc`]: crate::vi_ba_schur::ViBaParams::imu_t_bc
+
+use kornia_3d::pose::Pose3d;
+use kornia_algebra::{Mat3F64, SO3F64, Vec3F64};
+
+use super::SimError;
+use super::spline::{RSpline3, So3Spline};
+
+/// Gravity in the simulator's default world frame: OpenCV Y-down, so "down" is
+/// `+Y`. Matches [`crate::vi_ba_schur::ViBaParams`]'s default.
+pub const DEFAULT_GRAVITY: Vec3F64 = Vec3F64 {
+    x: 0.0,
+    y: 9.81,
+    z: 0.0,
+};
+
+/// The full kinematic state of the body at one instant, all in ground truth.
+#[derive(Debug, Clone, Copy)]
+pub struct TrajectoryState {
+    /// Timestamp in seconds.
+    pub timestamp: f64,
+    /// Body position in the world frame.
+    pub position: Vec3F64,
+    /// Body velocity in the world frame (m/s).
+    pub velocity: Vec3F64,
+    /// Body acceleration in the world frame (m/s²), *excluding* gravity.
+    pub acceleration: Vec3F64,
+    /// Body-to-world rotation.
+    pub rotation: SO3F64,
+    /// Angular velocity in the **body** frame (rad/s) — what a gyroscope reads.
+    pub angular_velocity: Vec3F64,
+}
+
+impl TrajectoryState {
+    /// World → body pose (`T_bw`).
+    pub fn body_pose(&self) -> Pose3d {
+        let r_bw = Mat3F64(*self.rotation.matrix().transpose());
+        Pose3d::new(r_bw, r_bw * -self.position)
+    }
+
+    /// World → camera pose (`T_cw`) for a camera mounted at `t_bc`.
+    ///
+    /// `None` means the camera frame coincides with the body frame.
+    pub fn camera_pose(&self, t_bc: Option<&Pose3d>) -> Pose3d {
+        // T_wb, then T_wc = T_wb · T_bc, then invert to T_cw.
+        let t_wb = Pose3d::new(self.rotation.matrix(), self.position);
+        match t_bc {
+            Some(bc) => t_wb.compose(bc).inverse(),
+            None => t_wb.inverse(),
+        }
+    }
+}
+
+/// A ground-truth trajectory: independent splines for translation and rotation
+/// over a shared time domain.
+#[derive(Debug, Clone)]
+pub struct Trajectory {
+    translation: RSpline3,
+    rotation: So3Spline,
+}
+
+impl Trajectory {
+    /// Combines a translation and a rotation spline.
+    ///
+    /// The two must share a time domain — otherwise there are times at which
+    /// the trajectory has a position but no orientation, and sampling would
+    /// fail unpredictably partway through a run rather than at construction.
+    pub fn new(translation: RSpline3, rotation: So3Spline) -> Result<Self, SimError> {
+        let (ts, rs) = (translation.t_start(), rotation.t_start());
+        let (te, re) = (translation.t_end(), rotation.t_end());
+        if (ts - rs).abs() > 1e-9 || (te - re).abs() > 1e-9 {
+            return Err(SimError::MismatchedSplineDomains {
+                translation: (ts, te),
+                rotation: (rs, re),
+            });
+        }
+        Ok(Self {
+            translation,
+            rotation,
+        })
+    }
+
+    /// First time at which the trajectory is defined.
+    pub fn t_start(&self) -> f64 {
+        self.translation.t_start()
+    }
+
+    /// Last time at which the trajectory is defined.
+    pub fn t_end(&self) -> f64 {
+        self.translation.t_end()
+    }
+
+    /// Samples the complete kinematic state at time `t`.
+    pub fn state(&self, t: f64) -> Result<TrajectoryState, SimError> {
+        Ok(TrajectoryState {
+            timestamp: t,
+            position: self.translation.position(t)?,
+            velocity: self.translation.velocity(t)?,
+            acceleration: self.translation.acceleration(t)?,
+            rotation: self.rotation.rotation(t)?,
+            angular_velocity: self.rotation.angular_velocity(t)?,
+        })
+    }
+
+    /// Samples `count` states at evenly spaced times spanning the domain.
+    ///
+    /// The endpoints are inset by one interval so that finite-difference checks
+    /// and IMU intervals around each sample stay inside the valid domain.
+    pub fn sample_uniform(&self, count: usize) -> Result<Vec<TrajectoryState>, SimError> {
+        if count < 2 {
+            return Err(SimError::InvalidConfig(format!(
+                "need at least 2 samples, got {count}"
+            )));
+        }
+        let margin = (self.t_end() - self.t_start()) * 0.02;
+        let (lo, hi) = (self.t_start() + margin, self.t_end() - margin);
+        let step = (hi - lo) / (count - 1) as f64;
+        (0..count)
+            .map(|i| self.state(lo + i as f64 * step))
+            .collect()
+    }
+}
+
+/// Builds `R_wb` for a body travelling along `forward` while keeping `world_down`
+/// as close to its own down axis as the geometry allows.
+///
+/// Returns `None` when `forward` is degenerate or parallel to `world_down`, in
+/// which case "level" is undefined.
+fn look_along(forward: Vec3F64, world_down: Vec3F64) -> Option<SO3F64> {
+    let z = forward.normalize();
+    if !z.length().is_finite() || z.length() < 0.5 {
+        return None;
+    }
+    // right = down × forward, then re-orthogonalize down as forward × right so
+    // the three axes form an exact orthonormal basis even when the inputs are
+    // not perpendicular.
+    let x = world_down.cross(z);
+    if x.length() < 1e-9 {
+        return None;
+    }
+    let x = x.normalize();
+    let y = z.cross(x).normalize();
+    // Columns are the body axes expressed in world coordinates.
+    Some(SO3F64::from_matrix(&Mat3F64::from_cols(x, y, z)))
+}
+
+/// Shape parameters for [`Trajectory::arc`].
+#[derive(Debug, Clone)]
+pub struct ArcConfig {
+    /// Radius of the arc in metres.
+    pub radius: f64,
+    /// Total descent along the world down axis over the whole arc (metres).
+    /// Zero keeps the path planar.
+    pub climb: f64,
+    /// Total angle swept, in radians.
+    ///
+    /// This is the co-visibility knob, and the most consequential setting here.
+    /// A full revolution turns the camera through 360°, so landmarks visible at
+    /// the start are long gone by the end and few points are seen by enough
+    /// keyframes to be constrained. A modest sweep behaves like a local BA
+    /// window: large baseline, strong parallax, high co-visibility.
+    pub sweep: f64,
+    /// Number of spline control points.
+    pub n_control: usize,
+    /// Time of the first knot.
+    pub t_start: f64,
+    /// Knot spacing in seconds.
+    pub knot_dt: f64,
+}
+
+impl Default for ArcConfig {
+    fn default() -> Self {
+        Self {
+            radius: 4.0,
+            climb: 0.0,
+            sweep: std::f64::consts::FRAC_PI_3,
+            n_control: 12,
+            t_start: 0.0,
+            knot_dt: 0.25,
+        }
+    }
+}
+
+/// Presets used to construct trajectories.
+///
+/// These are deliberately minimal — enough to exercise the estimators, not the
+/// full scenario library. Degenerate-regime scenarios (`pure_rotation`,
+/// `stationary`, `constant_velocity`, …) come later, once each can be tied to a
+/// specific observed failure.
+impl Trajectory {
+    /// A forward-facing camera sweeping along a circular arc.
+    ///
+    /// The body always looks along its direction of travel, which is the
+    /// SLAM-typical configuration: continuously changing viewpoint with real
+    /// parallax, and a non-trivial angular rate so the gyro path is exercised.
+    ///
+    /// The resulting curve is the *spline through* these control points, not a
+    /// mathematically exact circle — and that is fine, because the spline is the
+    /// ground truth. [`ArcConfig::radius`] and friends shape the path; they are
+    /// not promises about it.
+    pub fn arc(config: &ArcConfig) -> Result<Self, SimError> {
+        if config.radius <= 0.0 {
+            return Err(SimError::InvalidConfig(format!(
+                "arc radius must be positive, got {}",
+                config.radius
+            )));
+        }
+        if config.n_control < 4 {
+            return Err(SimError::TooFewControlPoints {
+                got: config.n_control,
+                need: 4,
+            });
+        }
+
+        let angle_step = config.sweep / (config.n_control - 1) as f64;
+
+        let mut positions = Vec::with_capacity(config.n_control);
+        let mut rotations = Vec::with_capacity(config.n_control);
+        for i in 0..config.n_control {
+            let a = i as f64 * angle_step;
+            let fraction = if config.sweep.abs() > 0.0 {
+                a / config.sweep
+            } else {
+                0.0
+            };
+            // Arc in the world XZ plane; Y (down) carries the climb.
+            positions.push(Vec3F64::new(
+                config.radius * a.cos(),
+                config.climb * fraction,
+                config.radius * a.sin(),
+            ));
+            // Tangent to the arc: the derivative of the position expression
+            // above with respect to `a`. The climb term must be included —
+            // omitting it points the camera horizontally while the body
+            // actually travels at an angle, which shows up as a constant
+            // several-degree mismatch between the forward axis and the velocity.
+            let tangent = Vec3F64::new(
+                -config.radius * a.sin(),
+                config.climb / config.sweep,
+                config.radius * a.cos(),
+            );
+            let r = look_along(tangent, DEFAULT_GRAVITY)
+                .ok_or_else(|| SimError::InvalidConfig("degenerate arc tangent".to_string()))?;
+            rotations.push(r);
+        }
+
+        Self::new(
+            RSpline3::new(positions, config.t_start, config.knot_dt)?,
+            So3Spline::new(rotations, config.t_start, config.knot_dt)?,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circle_state_is_self_consistent() {
+        let traj = Trajectory::arc(&ArcConfig {
+            radius: 3.0,
+            climb: 0.5,
+            n_control: 16,
+            t_start: 0.0,
+            knot_dt: 0.25,
+            ..Default::default()
+        })
+        .unwrap();
+        let states = traj.sample_uniform(20).unwrap();
+        assert_eq!(states.len(), 20);
+
+        for s in &states {
+            // Forward-facing means the body z axis aligns with the velocity.
+            let forward = s.rotation * Vec3F64::new(0.0, 0.0, 1.0);
+            let speed = s.velocity.length();
+            assert!(speed > 1e-3, "trajectory should be moving");
+            let alignment = forward.dot(s.velocity * (1.0 / speed));
+            assert!(
+                alignment > 0.99,
+                "camera not looking along travel: alignment {alignment}"
+            );
+        }
+    }
+
+    #[test]
+    fn camera_pose_round_trips_through_the_body_frame() {
+        let traj = Trajectory::arc(&ArcConfig {
+            radius: 2.0,
+            climb: 0.0,
+            n_control: 12,
+            t_start: 0.0,
+            knot_dt: 0.3,
+            ..Default::default()
+        })
+        .unwrap();
+        let s = traj.state(1.0).unwrap();
+
+        // With no extrinsic, camera pose is exactly the body pose.
+        let t_cw = s.camera_pose(None);
+        let t_bw = s.body_pose();
+        assert!((t_cw.translation - t_bw.translation).length() < 1e-12);
+
+        // T_cw maps the body's own world position to the camera origin.
+        let origin = t_cw.transform_point(&s.position);
+        assert!(origin.length() < 1e-9, "body origin not at camera origin");
+    }
+
+    #[test]
+    fn extrinsic_offsets_the_camera_by_the_expected_amount() {
+        let traj = Trajectory::arc(&ArcConfig {
+            radius: 2.0,
+            climb: 0.0,
+            n_control: 12,
+            t_start: 0.0,
+            knot_dt: 0.3,
+            ..Default::default()
+        })
+        .unwrap();
+        let s = traj.state(1.0).unwrap();
+
+        // Camera sits 10 cm along the body x axis: X_body = T_bc · X_cam.
+        let t_bc = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.1, 0.0, 0.0));
+        let t_cw = s.camera_pose(Some(&t_bc));
+
+        // The camera centre in world coords is p_wb + R_wb · t_bc.
+        let expected = s.position + s.rotation * Vec3F64::new(0.1, 0.0, 0.0);
+        let actual = t_cw.inverse().translation;
+        assert!(
+            (actual - expected).length() < 1e-12,
+            "camera centre {actual:?} != {expected:?}"
+        );
+    }
+
+    #[test]
+    fn mismatched_spline_domains_are_rejected() {
+        let traj = Trajectory::arc(&ArcConfig {
+            radius: 2.0,
+            climb: 0.0,
+            n_control: 12,
+            t_start: 0.0,
+            knot_dt: 0.3,
+            ..Default::default()
+        })
+        .unwrap();
+        let positions: Vec<Vec3F64> = (0..12).map(|i| Vec3F64::new(i as f64, 0.0, 0.0)).collect();
+        // Same control count, different knot spacing → different end time.
+        let shifted = RSpline3::new(positions, 0.0, 0.5).unwrap();
+        assert!(Trajectory::new(shifted, traj.rotation.clone()).is_err());
+    }
+}

--- a/crates/kornia-slam/src/sim/trajectory.rs
+++ b/crates/kornia-slam/src/sim/trajectory.rs
@@ -19,6 +19,22 @@
 //!
 //! [`ViBaParams::gravity`]: crate::vi_ba_schur::ViBaParams::gravity
 //! [`ViBaParams::imu_t_bc`]: crate::vi_ba_schur::ViBaParams::imu_t_bc
+//!
+//! # Upstreaming
+//!
+//! **This module splits across two crates when it moves.** Only two methods
+//! touch `kornia-3d` at all:
+//!
+//! - [`Trajectory`], [`TrajectoryState`]'s fields, [`Trajectory::sample_uniform`],
+//!   [`Trajectory::arc`] and `look_along` are `kornia-algebra`-only, and travel
+//!   with [`super::spline`] to `kornia-algebra`/`kornia-manifold`.
+//! - [`TrajectoryState::body_pose`] and [`TrajectoryState::camera_pose`] need
+//!   `Pose3d`, and belong in `kornia-3d` alongside [`super::landmarks`].
+//!
+//! The frame conventions documented above are the part most worth carrying over
+//! verbatim: they are what keeps the simulator and the estimators agreeing, and
+//! a mismatch introduced during a move would be invisible in exactly the way
+//! this whole module exists to prevent.
 
 use kornia_3d::pose::Pose3d;
 use kornia_algebra::{Mat3F64, SO3F64, Vec3F64};

--- a/crates/kornia-slam/tests/sim_recovery.rs
+++ b/crates/kornia-slam/tests/sim_recovery.rs
@@ -1,0 +1,431 @@
+//! Perturbation-recovery tests driven by the measurement simulator.
+//!
+//! Each test generates ground truth, displaces the estimate by a known amount,
+//! runs the **production** optimizer, and asserts the estimate returns. Nothing
+//! is mocked: the code under test is `bundle_adjust_schur` and
+//! `visual_inertial_bundle_adjust` as shipped.
+//!
+//! This is not the acceptance gate — real sequences remain that. These are the
+//! instrument for answering "which component is wrong?" once a real sequence has
+//! said that something is.
+
+#![cfg(feature = "sim")]
+
+use kornia_3d::ba::BaParams;
+use kornia_3d::ba_schur::bundle_adjust_schur;
+use kornia_3d::pose::Pose3d;
+use kornia_algebra::{SO3F64, Vec3F64};
+use kornia_sensors::imu::ImuBias;
+use kornia_slam::sim::{
+    ArcConfig, ImuSimConfig, LandmarkConfig, ObservationConfig, Perturbation, Scene, SceneConfig,
+    SimRng, Trajectory,
+};
+use kornia_slam::vi_ba_schur::{ViBaParams, visual_inertial_bundle_adjust};
+
+/// Translation and rotation error of `estimate` relative to `truth`.
+fn pose_error(estimate: &Pose3d, truth: &Pose3d) -> (f64, f64) {
+    let dt = (estimate.translation - truth.translation).length();
+    let dr = (SO3F64::from_matrix(&truth.rotation).inverse()
+        * SO3F64::from_matrix(&estimate.rotation))
+    .log()
+    .length();
+    (dt, dr)
+}
+
+/// Worst-case pose error across all frames.
+fn max_pose_error(estimates: &[Pose3d], truth: &[Pose3d]) -> (f64, f64) {
+    estimates
+        .iter()
+        .zip(truth.iter())
+        .map(|(e, t)| pose_error(e, t))
+        .fold((0.0f64, 0.0f64), |acc, e| (acc.0.max(e.0), acc.1.max(e.1)))
+}
+
+/// A visual scene with the given pixel noise, sized for good co-visibility.
+fn visual_scene(pixel_noise_std: f64, seed: u64) -> Scene {
+    let trajectory = Trajectory::arc(&ArcConfig::default()).expect("trajectory");
+    let config = SceneConfig {
+        n_keyframes: 10,
+        landmarks: LandmarkConfig {
+            count: 600,
+            ..Default::default()
+        },
+        observations: ObservationConfig {
+            pixel_noise_std,
+            ..Default::default()
+        },
+        min_observations: 3,
+        seed,
+        ..Default::default()
+    };
+    Scene::build(&trajectory, &config).expect("scene")
+}
+
+/// Phase 2 baseline: with exact measurements the optimizer must return to
+/// ground truth.
+///
+/// Two poses are fixed rather than one. Monocular BA has a 7-DOF gauge freedom
+/// — six from the rigid transform plus **scale** — and fixing a single pose
+/// leaves scale free, so the reconstruction could shrink or grow uniformly and
+/// still be a perfect optimum. Fixing two pins the baseline and makes "returned
+/// to ground truth" a well-posed claim.
+#[test]
+fn visual_ba_recovers_poses_from_noiseless_observations() {
+    let scene = visual_scene(0.0, 7);
+    let truth_poses = scene.camera_poses.clone();
+
+    let mut visual = scene.visual.clone();
+    visual.fix_poses(&[0, 1]);
+
+    let mut poses = truth_poses.clone();
+    let mut points = visual.points.clone();
+    let fixed = vec![true, true]
+        .into_iter()
+        .chain(std::iter::repeat_n(false, poses.len() - 2))
+        .collect::<Vec<bool>>();
+
+    let perturbation = Perturbation {
+        translation_std: 0.05,
+        rotation_std: 0.01,
+        point_std: 0.10,
+        ..Default::default()
+    };
+    let mut rng = SimRng::new(1000);
+    perturbation.apply_to_poses(&mut poses, &fixed, &mut rng);
+    perturbation.apply_to_points(&mut points, &mut rng);
+
+    let (start_t, start_r) = max_pose_error(&poses, &truth_poses);
+    assert!(
+        start_t > 0.02,
+        "perturbation was too small to be a real test: {start_t} m"
+    );
+
+    let params = BaParams {
+        max_iterations: 30,
+        ..Default::default()
+    };
+    let result = bundle_adjust_schur(
+        &poses,
+        &points,
+        &visual.observations,
+        &scene.camera,
+        &params,
+    )
+    .expect("bundle adjustment");
+
+    let (end_t, end_r) = max_pose_error(&result.poses, &truth_poses);
+    println!(
+        "visual noiseless: translation {start_t:.4} -> {end_t:.6} m, rotation {start_r:.4} -> {end_r:.6} rad"
+    );
+
+    // The floor here is not machine precision. `bundle_adjust_schur` converts
+    // poses to `SE3F32` internally, so ~1e-7 relative precision on a metre-scale
+    // translation is the best attainable regardless of how exact the input is.
+    // Measured: 2e-6 m / 3e-7 rad. The bounds keep ~50x margin over that so
+    // the test is not brittle, while staying far tighter than the perturbation
+    // it started from — a vacuous bound here would silently accept a solver
+    // that had stopped working.
+    assert!(end_t < 1e-4, "translation error {end_t} m after recovery");
+    assert!(end_r < 1e-5, "rotation error {end_r} rad after recovery");
+    assert!(
+        end_t < start_t / 100.0,
+        "optimizer barely improved the estimate"
+    );
+}
+
+/// Phase 2 with noise: the recovered error must be commensurate with the
+/// injected pixel noise, not with the size of the perturbation.
+///
+/// The tolerance is derived rather than picked. A 1 px measurement error at
+/// focal length `f` subtends `1/f` radians; over a mean landmark depth `d` the
+/// induced position uncertainty is about `d/f` per observation, shrinking as
+/// `1/√n` with the number of observations. For `f ≈ 458`, `d ≈ 7 m` and tens of
+/// observations per keyframe, that is a few centimetres — which is the order the
+/// bound below encodes.
+#[test]
+fn visual_ba_error_scales_with_pixel_noise() {
+    let mut previous = 0.0;
+    // Bounds bracket the measured errors (0 m, 0.008 m, 0.040 m) with ~2x margin.
+    for (noise, bound) in [(0.0, 1e-4), (0.5, 0.02), (2.0, 0.08)] {
+        let scene = visual_scene(noise, 11);
+        let truth_poses = scene.camera_poses.clone();
+
+        let mut visual = scene.visual.clone();
+        visual.fix_poses(&[0, 1]);
+
+        let mut poses = truth_poses.clone();
+        let mut points = visual.points.clone();
+        let fixed = vec![true, true]
+            .into_iter()
+            .chain(std::iter::repeat_n(false, poses.len() - 2))
+            .collect::<Vec<bool>>();
+
+        let perturbation = Perturbation {
+            translation_std: 0.03,
+            rotation_std: 0.005,
+            point_std: 0.05,
+            ..Default::default()
+        };
+        let mut rng = SimRng::new(2000);
+        perturbation.apply_to_poses(&mut poses, &fixed, &mut rng);
+        perturbation.apply_to_points(&mut points, &mut rng);
+
+        let params = BaParams {
+            max_iterations: 30,
+            ..Default::default()
+        };
+        let result = bundle_adjust_schur(
+            &poses,
+            &points,
+            &visual.observations,
+            &scene.camera,
+            &params,
+        )
+        .expect("bundle adjustment");
+
+        let (end_t, _) = max_pose_error(&result.poses, &truth_poses);
+        println!("visual noise {noise} px: translation error {end_t:.5} m");
+
+        assert!(
+            end_t < bound,
+            "at {noise} px noise, translation error {end_t} m exceeded {bound} m"
+        );
+        // Monotonicity: more measurement noise must not produce a better
+        // estimate. This is the property a sensitivity sweep rests on.
+        assert!(
+            end_t >= previous * 0.5,
+            "error fell from {previous} to {end_t} as noise increased — suspicious"
+        );
+        previous = end_t;
+    }
+}
+
+/// An inertial scene carrying a known bias.
+fn inertial_scene(bias: ImuBias, seed: u64) -> Scene {
+    let trajectory = Trajectory::arc(&ArcConfig {
+        climb: 0.4,
+        ..Default::default()
+    })
+    .expect("trajectory");
+    let config = SceneConfig {
+        n_keyframes: 10,
+        landmarks: LandmarkConfig {
+            count: 600,
+            ..Default::default()
+        },
+        observations: ObservationConfig {
+            pixel_noise_std: 0.0,
+            ..Default::default()
+        },
+        min_observations: 3,
+        imu: Some(ImuSimConfig {
+            bias,
+            add_noise: false,
+            ..Default::default()
+        }),
+        seed,
+        ..Default::default()
+    };
+    Scene::build(&trajectory, &config).expect("scene")
+}
+
+/// VI-BA parameters suited to a controlled experiment.
+fn vi_ba_params() -> ViBaParams {
+    ViBaParams {
+        max_iterations: 40,
+        // The accel-bias prior exists to absorb gravity error in a windowed
+        // solve on real data (issue #51). Here gravity is exactly right by
+        // construction, so the prior only fights the quantity under test —
+        // disabling it is what makes "did the bias converge to the injected
+        // value?" a clean question rather than a tug-of-war.
+        accel_bias_prior_weight: 0.0,
+        ..Default::default()
+    }
+}
+
+/// Phase 3, the milestone: inject a known constant accel bias, start the
+/// estimate at zero, and assert VI-BA converges to the injected value.
+///
+/// This is the accel-bias blowup from issue #51 expressed as an assertion.
+#[test]
+fn vi_ba_recovers_injected_accel_bias() {
+    let true_bias = ImuBias {
+        gyro: Vec3F64::new(0.004, -0.003, 0.002),
+        accel: Vec3F64::new(0.05, -0.04, 0.03),
+    };
+    let scene = inertial_scene(true_bias, 21);
+
+    let mut keyframes = scene.ground_truth_keyframes();
+    // The oldest keyframe anchors the gauge, as in ORB-SLAM3's local inertial
+    // BA. Its 15 DOF — pose, velocity and bias — are all held at ground truth.
+    keyframes[0].fixed = true;
+
+    // Every free keyframe starts with zero bias: the estimator is told nothing
+    // about the injected value.
+    for kf in keyframes.iter_mut().skip(1) {
+        kf.bias = ImuBias::default();
+    }
+
+    // Factors are linearized at the estimator's guess (zero), not at truth.
+    let imu_edges = scene.imu_factors(ImuBias::default()).expect("imu factors");
+
+    let result = visual_inertial_bundle_adjust(
+        &keyframes,
+        &scene.visual.points,
+        &scene.visual.observations,
+        &imu_edges,
+        &scene.camera,
+        &vi_ba_params(),
+    )
+    .expect("vi-ba");
+
+    let mut worst_accel = 0.0f64;
+    let mut worst_gyro = 0.0f64;
+    for kf in result.keyframes.iter().skip(1) {
+        worst_accel = worst_accel.max((kf.bias.accel - true_bias.accel).length());
+        worst_gyro = worst_gyro.max((kf.bias.gyro - true_bias.gyro).length());
+    }
+
+    let initial_accel_error = true_bias.accel.length();
+    let initial_gyro_error = true_bias.gyro.length();
+    println!(
+        "accel bias error {initial_accel_error:.5} -> {worst_accel:.5} m/s^2, \
+         gyro bias error {initial_gyro_error:.5} -> {worst_gyro:.5} rad/s"
+    );
+
+    assert!(
+        // Measured: recovers to 0.7 % of the injected magnitude.
+        worst_accel < initial_accel_error * 0.05,
+        "accel bias did not converge: {worst_accel} vs injected {initial_accel_error}"
+    );
+    assert!(
+        worst_gyro < initial_gyro_error * 0.05,
+        "gyro bias did not converge: {worst_gyro} vs injected {initial_gyro_error}"
+    );
+}
+
+/// VI-BA must also recover the trajectory itself from a perturbed start.
+///
+/// Unlike the visual-only case a single fixed keyframe suffices: the IMU makes
+/// scale observable, which is the whole reason for fusing it.
+#[test]
+fn vi_ba_recovers_perturbed_poses_and_velocities() {
+    let scene = inertial_scene(ImuBias::default(), 23);
+    let truth_poses = scene.camera_poses.clone();
+    let truth_velocities: Vec<Vec3F64> = scene.states.iter().map(|s| s.velocity).collect();
+
+    let mut keyframes = scene.ground_truth_keyframes();
+    keyframes[0].fixed = true;
+
+    let perturbation = Perturbation {
+        translation_std: 0.05,
+        rotation_std: 0.01,
+        velocity_std: 0.05,
+        ..Default::default()
+    };
+    let mut rng = SimRng::new(3000);
+    perturbation.apply_to_keyframes(&mut keyframes, &mut rng);
+
+    let mut points = scene.visual.points.clone();
+    Perturbation {
+        point_std: 0.05,
+        ..Default::default()
+    }
+    .apply_to_points(&mut points, &mut rng);
+
+    let start_poses: Vec<Pose3d> = keyframes.iter().map(|k| k.pose).collect();
+    let (start_t, _) = max_pose_error(&start_poses, &truth_poses);
+
+    let imu_edges = scene.imu_factors(ImuBias::default()).expect("imu factors");
+    let result = visual_inertial_bundle_adjust(
+        &keyframes,
+        &points,
+        &scene.visual.observations,
+        &imu_edges,
+        &scene.camera,
+        &vi_ba_params(),
+    )
+    .expect("vi-ba");
+
+    let end_poses: Vec<Pose3d> = result.keyframes.iter().map(|k| k.pose).collect();
+    let (end_t, end_r) = max_pose_error(&end_poses, &truth_poses);
+
+    let worst_velocity = result
+        .keyframes
+        .iter()
+        .zip(truth_velocities.iter())
+        .map(|(kf, v)| (kf.velocity - *v).length())
+        .fold(0.0f64, f64::max);
+
+    println!(
+        "vi-ba poses: translation {start_t:.4} -> {end_t:.5} m, rotation {end_r:.5} rad, \
+         velocity error {worst_velocity:.5} m/s"
+    );
+
+    // Measured: 2e-4 m, 3e-7 rad, 1.2e-4 m/s.
+    assert!(end_t < 0.002, "translation error {end_t} m after recovery");
+    assert!(end_r < 0.001, "rotation error {end_r} rad after recovery");
+    assert!(
+        worst_velocity < 0.002,
+        "velocity error {worst_velocity} m/s after recovery"
+    );
+}
+
+/// Scale is the quantity monocular BA cannot see and the IMU can. Starting from
+/// a uniformly rescaled reconstruction, VI-BA must pull the scale back.
+///
+/// This is the ±10 % scale wobble from PR #46 posed as a controlled question:
+/// given exact measurements and no frontend, can the optimizer recover scale at
+/// all? A failure here localizes the problem to the back end; a pass says to
+/// look elsewhere.
+#[test]
+fn vi_ba_recovers_scale_from_a_rescaled_start() {
+    let scene = inertial_scene(ImuBias::default(), 29);
+    let truth_poses = scene.camera_poses.clone();
+
+    let scale = 1.10;
+    let mut keyframes = scene.ground_truth_keyframes();
+    keyframes[0].fixed = true;
+
+    // Scale the world about the anchor keyframe's camera centre, so the fixed
+    // frame stays consistent and only the *relative* geometry is wrong.
+    let origin = truth_poses[0].inverse().translation;
+    let rescale = |p: Vec3F64| origin + (p - origin) * scale;
+
+    for kf in keyframes.iter_mut().skip(1) {
+        let centre = kf.pose.inverse().translation;
+        let moved = rescale(centre);
+        // Rebuild T_cw with the same rotation and the moved camera centre.
+        kf.pose = Pose3d::new(kf.pose.rotation, kf.pose.rotation * -moved);
+        kf.velocity *= scale;
+    }
+    let points: Vec<Vec3F64> = scene.visual.points.iter().map(|p| rescale(*p)).collect();
+
+    let start_poses: Vec<Pose3d> = keyframes.iter().map(|k| k.pose).collect();
+    let (start_t, _) = max_pose_error(&start_poses, &truth_poses);
+    assert!(
+        start_t > 0.1,
+        "rescaling did not displace anything: {start_t}"
+    );
+
+    let imu_edges = scene.imu_factors(ImuBias::default()).expect("imu factors");
+    let result = visual_inertial_bundle_adjust(
+        &keyframes,
+        &points,
+        &scene.visual.observations,
+        &imu_edges,
+        &scene.camera,
+        &vi_ba_params(),
+    )
+    .expect("vi-ba");
+
+    let end_poses: Vec<Pose3d> = result.keyframes.iter().map(|k| k.pose).collect();
+    let (end_t, _) = max_pose_error(&end_poses, &truth_poses);
+    println!("vi-ba scale {scale}: translation {start_t:.4} -> {end_t:.5} m");
+
+    assert!(
+        // Measured: 0.32 m -> 2.4e-4 m, a factor of ~1300.
+        end_t < start_t / 100.0,
+        "scale not recovered: {start_t} -> {end_t} m"
+    );
+}


### PR DESCRIPTION
Implements phases 1–3 of `docs/plans/2026-08-06-measurement-simulator.md`: a frontend-free simulator where a ground-truth spline trajectory generates analytically exact IMU and landmark measurements that feed straight into the production estimators. No images, no renderer, no scene geometry.

## Why

Every expensive bug here recently has been in the back end, and none were findable from a trajectory plot — PR #44's `T_BC` extrinsic, issue #51's accel-bias blowup, PR #46's scale wobble. In each case the only observable was an ATE number, and the loop was long because **the input was not controlled**: on real data you cannot ask "what if the bias were exactly 0.05 m/s² and nothing else were wrong?" Here that is the only kind of question there is.

This is deliberately *not* the acceptance gate — real sequences stay that. It is the instrument for localizing a fault once a real sequence has said there is one.

## Design decisions

The plan left six decisions open. Resolved as:

| Decision | Resolution |
|---|---|
| Where it lives | `sim` module in kornia-slam, behind a **default-on** `sim` feature. CI runs `cargo test --workspace` and `clippy --all-targets` with default features only, so a default-off feature would be neither tested nor linted. Consumers can still opt out. |
| Seeding | Self-contained xoshiro256++ + SplitMix64 seeding. Only three primitives were needed and the crate had no RNG dependency; `rand` + `rand_distr` was a poor trade. |
| Does phase 1 wait for f64 SE(3)? | No. The split R³ + SO(3) spline sidesteps it, as the plan argued. |
| Tolerances | Derived from measurement, not picked — see below. |
| Scenario library | Deferred (phase 4), as planned. |

**Split spline, not SE(3) spline.** Translation is a cubic B-spline; rotation is a cumulative cubic B-spline on SO(3) via the existing `SO3F64`. Needs no `SE3F64` (kornia-algebra's SE3 is f32-only, estimation here is f64), keeps derivatives simple, and makes rotation and translation independently controllable — which is what will make the degenerate scenarios expressible later.

**Nothing is mocked.** The simulator produces inputs; the code under test is `bundle_adjust_schur` and `visual_inertial_bundle_adjust` as shipped. Raw `ImuMeasurement`s go through the production `PreintegratedImu`, so a bug in `integrate` or its covariance/bias-Jacobian propagation is inside the blast radius.

## What landed

`crates/kornia-slam/src/sim/`: `rng`, `spline`, `trajectory`, `landmarks`, `imu`, `scene` — 35 unit tests. `tests/sim_recovery.rs` — 5 recovery tests against the real optimizers.

The headline, `vi_ba_recovers_injected_accel_bias`, is issue #51 as an assertion: inject a known bias, start every free keyframe at zero, and VI-BA converges to within **0.7 %** of the injected value.

| Test | Measured |
|---|---|
| Visual BA, noiseless | 0.138 m → **2 µm** |
| Visual BA vs pixel noise | 0 / 0.5 / 2 px → 0 / 7.9 mm / 39.7 mm, monotonic |
| VI-BA accel bias | 0.0707 → **0.00051 m/s²** |
| VI-BA poses + velocities | 0.130 m → 0.20 mm; velocity 0.12 mm/s |
| VI-BA scale (+10 % start) | 0.32 m → 0.24 mm |

## Three findings worth recording

1. **`bundle_adjust_schur` converts poses to `SE3F32` internally.** The plan expected noiseless recovery "to near machine precision"; f32 caps it at ~1e-7 relative, so ~2 µm on a metre-scale translation is the actual floor. Tolerances reflect that.

2. **Preintegration agreement with ground truth is limited by the preintegrator, not the simulator.** `integrate` is a first-order rectangular scheme. Rather than pick a tolerance that would accommodate it, the test asserts **first-order convergence** — halving the timestep halves the error (measured ratios: exactly 2.00). That discriminates where a fixed tolerance would not: a frame or sign-convention mismatch produces a *constant* error that does not shrink with rate, and a loose enough tolerance would accept exactly that. Rotation is separately asserted exact (~1e-16), since this arc turns about a fixed axis so the `exp` factors commute and telescope.

3. **VI-BA reports `converged = false` at `max_iterations = 40`** even with final residuals at 1e-7. Its convergence criterion looks unreachable on well-conditioned problems. Not touched here — flagging it as a separate question.

## Honest tension

This cuts against `feedback_verify_euroc_500` (default verification is end-to-end on EuRoC, explicitly *not* synthetic unit tests). Two things reconcile it, and both are stated in the module docs rather than assumed: nothing is mocked, and this is not the acceptance gate. The plan's guard — every scenario must be justified by a real failure — is why the scenario library is deferred rather than shipped speculatively; the three inertial tests here each map onto a specific past failure (#51, #46, #44's frame conventions).

## Notes

- `.gitignore` and `docs/` have uncommitted local changes un-ignoring `docs/plans/`. Left out of this PR as separate work, so the plan document is referenced by path but not included.
- Verified: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` (63 lib + 5 recovery + doctest, all passing), and `--no-default-features` builds.