### PR TITLE
imu init: keep the accel-bias prior at VIBA2

### DIFF
--- a/crates/kornia-slam/src/estimation/imu_init.rs
+++ b/crates/kornia-slam/src/estimation/imu_init.rs
@@ -416,6 +416,18 @@ impl ImuInitializer {
             println!("[imu_init] rejected: non-finite bias");
             return None;
         }
+        // Reject a diverged refinement instead of replacing the last valid bias.
+        const MAX_PLAUSIBLE_ACCEL_BIAS: f64 = 1.0; // m/s^2
+        if ba_out.length() > MAX_PLAUSIBLE_ACCEL_BIAS {
+            println!(
+                "[imu_init] rejected: implausible accel bias |ba|={:.3} > {MAX_PLAUSIBLE_ACCEL_BIAS} m/s^2 ({:.3},{:.3},{:.3})",
+                ba_out.length(),
+                ba_out.x,
+                ba_out.y,
+                ba_out.z,
+            );
+            return None;
+        }
         // Reconstruct the PHYSICAL gravity vector using the *same* gI the factor
         // used internally — do not reuse rwg_out assuming any other convention.
         let gravity_world = rwg_out * Vec3F64::new(0.0, 0.0, -GRAVITY_MAGNITUDE);
@@ -516,6 +528,8 @@ mod tests {
 
     const RADIUS: f64 = 2.0;
     const OMEGA: f64 = 0.5;
+    // Weak rotation makes acceleration bias less observable.
+    const WEAK_YAW_RATE: f64 = 0.2;
 
     /// True trajectory: circular translation *plus* the body yawing in sync
     /// with it (like a vehicle banking into the turn) — needed so `R_wb(t)`
@@ -525,19 +539,17 @@ mod tests {
     /// bias stays observable either way since it only needs rotation-only
     /// consistency, which is why `bg` recovered correctly even with the
     /// bug below.
-    fn circular_trajectory(t: f64) -> (Vec3F64, Vec3F64, Vec3F64, Mat3F64) {
-        let theta = OMEGA * t;
+    fn circular_trajectory(t: f64, omega: f64) -> (Vec3F64, Vec3F64, Vec3F64, Mat3F64) {
+        let theta = omega * t;
         let (s, c) = theta.sin_cos();
         let p = Vec3F64::new(RADIUS * c, 0.0, RADIUS * s);
-        let v = Vec3F64::new(-RADIUS * OMEGA * s, 0.0, RADIUS * OMEGA * c);
+        let v = Vec3F64::new(-RADIUS * omega * s, 0.0, RADIUS * omega * c);
         let a = Vec3F64::new(
-            -RADIUS * OMEGA * OMEGA * c,
+            -RADIUS * omega * omega * c,
             0.0,
-            -RADIUS * OMEGA * OMEGA * s,
+            -RADIUS * omega * omega * s,
         );
-        // Rotation about the (world) Y axis by theta — angular velocity is
-        // exactly (0, OMEGA, 0) in both body and world frame since Y is a
-        // fixed eigenvector of this rotation for all theta.
+        // Rotation about world Y keeps angular velocity (0, omega, 0) in either frame.
         let r_wb = SO3F64::exp(Vec3F64::new(0.0, theta, 0.0)).matrix();
         (p, v, a, r_wb)
     }
@@ -585,10 +597,12 @@ mod tests {
     /// so it integrates the biased signal uncorrected, exactly like a real
     /// biased sensor (`PreintegratedImu::integrate` subtracts `self.bias`,
     /// which is zero here — see `imu.rs:140-143`).
+    #[allow(clippy::too_many_arguments)]
     fn integrate_true_imu(
         t0: f64,
         t1: f64,
         imu_rate_hz: f64,
+        omega: f64,
         gravity_true: Vec3F64,
         bias_gyro_true: Vec3F64,
         bias_accel_true: Vec3F64,
@@ -598,8 +612,8 @@ mod tests {
         let dt = 1.0 / imu_rate_hz;
         let mut t = t0;
         while t < t1 - 1e-9 {
-            let (_, _, a_true, r_wb_true) = circular_trajectory(t + 0.5 * dt);
-            let gyro_meas = Vec3F64::new(0.0, OMEGA, 0.0) + bias_gyro_true; // true body-frame ω + bias
+            let (_, _, a_true, r_wb_true) = circular_trajectory(t + 0.5 * dt, omega);
+            let gyro_meas = Vec3F64::new(0.0, omega, 0.0) + bias_gyro_true; // true body-frame ω + bias
             let accel_meas = r_wb_true.transpose() * (a_true - gravity_true) + bias_accel_true; // specific force in body frame + bias
             pim.integrate(
                 &ImuMeasurement {
@@ -612,6 +626,198 @@ mod tests {
             t += dt;
         }
         pim
+    }
+
+    fn synth_map(s_true: f64, r_arb: Mat3F64) -> Map {
+        synth_map_with_calib(
+            s_true,
+            r_arb,
+            ImuCalib {
+                gyro_noise: 1e-3,
+                accel_noise: 1e-2,
+                gyro_bias_noise: 1e-5,
+                accel_bias_noise: 1e-4,
+            },
+            OMEGA,
+        )
+    }
+
+    fn synth_map_with_calib(s_true: f64, r_arb: Mat3F64, calib: ImuCalib, omega: f64) -> Map {
+        let bias_gyro_true = Vec3F64::new(0.01, -0.02, 0.005);
+        let bias_accel_true = Vec3F64::new(0.05, -0.03, 0.02);
+        let gravity_true = Vec3F64::new(0.0, GRAVITY_MAGNITUDE, 0.0);
+        let n_keyframes = 30;
+        let kf_dt = 0.2;
+        let imu_rate = 200.0;
+
+        let mut map = Map::new();
+        for k in 0..n_keyframes {
+            let t = k as f64 * kf_dt;
+            let (p_true, _, _, r_wb_true) = circular_trajectory(t, omega);
+            let pose = synth_pose_world_to_cam(r_arb, s_true, p_true, r_wb_true);
+            map.upsert_keyframe(Keyframe::from_frame(synth_frame(k, pose)));
+            if k > 0 {
+                let pim = integrate_true_imu(
+                    t - kf_dt,
+                    t,
+                    imu_rate,
+                    omega,
+                    gravity_true,
+                    bias_gyro_true,
+                    bias_accel_true,
+                    calib,
+                );
+                map.add_imu_factor(k - 1, k, pim, Vec::new(), t - kf_dt, t);
+            }
+        }
+        map
+    }
+
+    /// Checks that recovered scale remains inversely proportional to vision-map scale.
+    #[test]
+    fn viba0_scale_is_invariant_to_vision_map_scale() {
+        let r_arb = SO3F64::exp(Vec3F64::new(0.3, -0.5, 0.2)).matrix();
+        let initializer = ImuInitializer::new(ImuInitConfig {
+            min_keyframes: 10,
+            min_time_sec: 1.0,
+            min_motion: 0.1,
+        });
+
+        let mut products = Vec::new();
+        for s_true in [0.25, 0.5, 1.0, 2.0, 4.0] {
+            let map = synth_map(s_true, r_arb);
+            let init = initializer
+                .try_initialize(
+                    &map,
+                    Some(Pose3d::IDENTITY),
+                    ImuBias::default(),
+                    0,
+                    1e2,
+                    1e10,
+                    false,
+                )
+                .expect("VIBA0 should solve on clean synthetic data at any map scale");
+            println!(
+                "[scale-invariance] s_true={s_true:<5} s_recovered={:<10.5} product={:.5}",
+                init.scale,
+                init.scale * s_true
+            );
+            products.push(init.scale * s_true);
+        }
+
+        let mean = products.iter().sum::<f64>() / products.len() as f64;
+        let max_rel_dev = products
+            .iter()
+            .map(|p| (p - mean).abs() / mean)
+            .fold(0.0f64, f64::max);
+        assert!(
+            max_rel_dev < 0.02,
+            "VIBA0 scale does not track map size: products {products:?} (mean {mean:.5}, \
+             max deviation {:.1}%)",
+            max_rel_dev * 100.0,
+        );
+    }
+
+    /// Ensures the VIBA2 prior keeps acceleration bias bounded when fixed poses
+    /// disagree with the IMU (kornia-slam#51).
+    #[test]
+    fn viba2_accel_bias_stays_bounded_under_pose_inconsistency() {
+        let r_arb = SO3F64::exp(Vec3F64::new(0.3, -0.5, 0.2)).matrix();
+        let bias_accel_true = Vec3F64::new(0.05, -0.03, 0.02);
+        // Realistic noise makes the synthetic pose inconsistency representative.
+        let euroc_calib = ImuCalib {
+            gyro_noise: 1.6968e-4,
+            accel_noise: 2.0e-3,
+            gyro_bias_noise: 1.9393e-5,
+            accel_bias_noise: 3.0e-3,
+        };
+        let initializer = ImuInitializer::new(ImuInitConfig {
+            min_keyframes: 10,
+            min_time_sec: 1.0,
+            min_motion: 0.1,
+        });
+
+        // Add deterministic millimetre-scale front-end noise.
+        let mut map = synth_map_with_calib(0.5, r_arb, euroc_calib, WEAK_YAW_RATE);
+        for (k, kf) in map.keyframes_mut().iter_mut().enumerate() {
+            let f = k as f64;
+            let jitter = Vec3F64::new(
+                (3.7 * f).sin(),
+                (5.1 * f + 1.3).sin(),
+                (2.3 * f + 0.7).sin(),
+            ) * 2e-3;
+            let cam_to_world = kf.frame.pose_world_to_cam.inverse();
+            kf.frame.pose_world_to_cam =
+                Pose3d::new(cam_to_world.rotation, cam_to_world.translation + jitter).inverse();
+        }
+
+        let viba0 = initializer
+            .try_initialize(
+                &map,
+                Some(Pose3d::IDENTITY),
+                ImuBias::default(),
+                0,
+                1e2,
+                1e10,
+                false,
+            )
+            .expect("VIBA0 should solve");
+        let mut state = SystemState::new();
+        let mut bias = ImuBias::default();
+        let mut gravity_world = Vec3F64::ZERO;
+        initializer.apply_initialization(
+            &mut map,
+            &mut state,
+            &mut bias,
+            &mut gravity_world,
+            viba0,
+            0,
+        );
+
+        let solve_viba2 = |prior_a: f64| -> Vec3F64 {
+            initializer
+                .try_initialize(
+                    &map.clone(),
+                    Some(Pose3d::IDENTITY),
+                    bias,
+                    0,
+                    0.0,
+                    prior_a,
+                    true,
+                )
+                .map(|init| init.bias.accel)
+                // Map a plausibility-gate rejection to its threshold for comparison.
+                .unwrap_or(Vec3F64::new(0.0, 1.0, 0.0))
+        };
+
+        let ba_with_prior = solve_viba2(1e5);
+        let ba_no_prior = solve_viba2(0.0);
+        let err_with_prior = (ba_with_prior - bias_accel_true).length();
+        let err_no_prior = (ba_no_prior - bias_accel_true).length();
+        println!(
+            "[viba2] prior_a=1e5 ba=({:+.4},{:+.4},{:+.4}) err={err_with_prior:.4}\n\
+             [viba2] prior_a=0   ba=({:+.4},{:+.4},{:+.4}) err={err_no_prior:.4}",
+            ba_with_prior.x,
+            ba_with_prior.y,
+            ba_with_prior.z,
+            ba_no_prior.x,
+            ba_no_prior.y,
+            ba_no_prior.z,
+        );
+
+        assert!(
+            err_with_prior < 0.1,
+            "accel bias should stay near truth with the prior retained: \
+             got {ba_with_prior:?}, want ~{bias_accel_true:?}"
+        );
+        assert!(
+            err_no_prior > err_with_prior,
+            "dropping the accel-bias prior is what lets the bias run away; if this \
+             ever stops holding, the poses have become IMU-consistent (e.g. a \
+             FullInertialBA equivalent landed) and `VIBA_PRIOR_A` can be revisited. \
+             with prior: {ba_with_prior:?} ({err_with_prior:.4}), \
+             without: {ba_no_prior:?} ({err_no_prior:.4})"
+        );
     }
 
     #[test]
@@ -636,7 +842,7 @@ mod tests {
         let mut map = Map::new();
         for k in 0..n_keyframes {
             let t = k as f64 * kf_dt;
-            let (p_true, _, _, r_wb_true) = circular_trajectory(t);
+            let (p_true, _, _, r_wb_true) = circular_trajectory(t, OMEGA);
             let pose = synth_pose_world_to_cam(r_arb, s_true, p_true, r_wb_true);
             map.upsert_keyframe(Keyframe::from_frame(synth_frame(k, pose)));
 
@@ -645,6 +851,7 @@ mod tests {
                     t - kf_dt,
                     t,
                     imu_rate,
+                    OMEGA,
                     gravity_true,
                     bias_gyro_true,
                     bias_accel_true,
@@ -751,7 +958,7 @@ mod tests {
         // `result.velocities_world` here).
         for k in 0..n_keyframes {
             let t = k as f64 * kf_dt;
-            let (_, v_true, _, _) = circular_trajectory(t);
+            let (_, v_true, _, _) = circular_trajectory(t, OMEGA);
             let expected_v = rwg_viba0 * ((r_arb * v_true) * s_true * viba0_scale);
             let err = (result.velocities_world[k] - expected_v).length();
             assert!(

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -1019,6 +1019,10 @@ impl Pipeline {
         true
     }
 
+    /// Kept at VIBA2 because this pipeline lacks the intervening pose-adjusting
+    /// inertial BA that lets ORB-SLAM3 safely remove the prior (kornia-slam#51).
+    const VIBA_PRIOR_A: f64 = 1e5;
+
     /// VIBA1 (mTinit>5s) / VIBA2 (mTinit>15s): progressive re-solves with
     /// relaxed priors over the same (now-growing) window that VIBA0 used,
     /// mirroring LocalMapping.cc:200-228. Each fires at most once and refines
@@ -1038,9 +1042,9 @@ impl Pipeline {
         }
 
         let (prior_g, prior_a, stage) = if !self.imu_viba1_done && mtinit > 5.0 {
-            (1.0, 1e5, "VIBA1")
+            (1.0, Self::VIBA_PRIOR_A, "VIBA1")
         } else if self.imu_viba1_done && !self.imu_viba2_done && mtinit > 15.0 {
-            (0.0, 0.0, "VIBA2")
+            (0.0, Self::VIBA_PRIOR_A, "VIBA2")
         } else {
             return;
         };


### PR DESCRIPTION
Supersedes #53 with the commit attributed to the current `cjpurackal` GitHub author identity.

Fixes #51.

## Root cause

The VIBA refinement solves hold the visual keyframe poses **fixed**, so any disagreement between those poses and the preintegrated IMU has to be absorbed by the remaining free variables. On MH_01 that disagreement is large — the VIBA2 solve sits at **~40σ per residual** (cost 1.3e6 over 729 residual dims) — and the softest direction available is the **accel bias along gravity**, which is degenerate with gravity magnitude (pinned at 9.81) traded against map scale.

VIBA1 resists this because it keeps `priorA = 1e5`. VIBA2 relaxed the prior to 0 and had nothing left holding that direction, so it absorbed the model error: `ba_y` went from a healthy 0.009 at VIBA1 to **0.386** at VIBA2, against MH_01's own bias ground truth of 0.137. It also dragged gravity 2.2° off, since bias and gravity are coupled in `InertialInitFactor`.

ORB-SLAM3 gets away with `priorA = 0` at VIBA2 only because it runs a `FullInertialBA` after *every* `InitializeIMU` stage (`LocalMapping.cc:213`), so the poses its VIBA2 holds fixed have already been pulled into agreement with the IMU. We have no such stage.

## Change

VIBA2 keeps VIBA1's accel-bias prior instead of relaxing it to 0 (`Pipeline::VIBA_PRIOR_A = 1e5`). That is ORB-SLAM3's own value at the previous stage, so it introduces no new tuned constant. The deviation and its reason are documented on the constant.

Also included:

- **Plausibility gate** in `ImuInitializer::try_initialize`: reject any solve with `|ba| > 1 m/s²` (~10% of gravity, far above any calibrated MEMS bias) so a diverged refinement can never be applied to the map. Rejecting leaves the previous stage's bias in place, which is the safe fallback. Deliberately loose — it is a backstop for gross divergence, not the fix.

## Results

MH_01, 500 frames, VIBA2 vs the dataset's own bias ground truth `ba = (-0.026, 0.137, 0.076)`:

| `prior_a` | `ba` | gravity err |
|-----------|------|-------------|
| 0 (before) | (-0.041, **0.386**, 0.041) | 2.2° |
| 1e4 | (-0.038, 0.207, 0.068) | 1.2° |
| **1e5 (this PR)** | **(-0.042, 0.047, 0.076)** | **0.26°** |

Full-length MH_01 (3682 frames) improves as well:

| | before | after |
|---|---|---|
| ATE RMSE | 0.2388 m | **0.1977 m** |
| Final drift | 0.5805 % | **0.3458 %** |
| RPE RMSE | 0.0171 m | 0.0179 m |

## Tests

- `viba2_accel_bias_stays_bounded_under_pose_inconsistency` reproduces the mechanism on synthetic data: millimetre keyframe jitter plus real EuRoC noise densities. Body rotation is the only thing that separates a body-fixed accel bias from world-fixed gravity, so the test runs at a weak **66° of yaw** across the window — there the bias is recovered only with the prior retained. At the existing test's 166° the prior is irrelevant either way, which is why this never showed up before. Below ~33° the window is too degenerate for either setting.
- `viba0_scale_is_invariant_to_vision_map_scale` pins the exact invariance `s_recovered × map_scale = const` (holds to 5 digits across a 16× range of map scales).

## Hypotheses ruled out along the way

Recorded so they are not re-investigated:

- **Solver under-convergence** — the scale invariance above holds exactly, so VIBA0 is reaching its optimum.
- **f32 generic optimizer precision** — with EuRoC-tight noise on *consistent* synthetic data, VIBA2 at `priorA = 0` recovers `ba` to 6e-4. Single precision only fails once real model error is present.
- **Missing information-matrix eigenvalue clamping** (ORB-SLAM3 clamps in `EdgeInertialGS`, we do not) — measured condition number ≈ 5e2 on real data and Cholesky never fails, so the clamp is a no-op here.
- **Mis-scaled post-init map** — windowed GT/estimate path-length ratio is ≈ 1.00 for frames 100–400. The run-wide eval `Scale` of 0.61 is dominated by the pre-init prefix (0.17), not by post-init error.

## Limitations

- **Not validated on V1_01** — the sequence is not available locally and the ETH dataset host is unreachable from the machine this was developed on. Validation rests on MH_01 (500-frame and full-length).
- The prior is a stand-in, not the real fix. The underlying problem is that our fixed keyframe poses are not IMU-consistent; the proper solution is a `FullInertialBA` equivalent between the VIBA stages. A naive port of that was tried and made things worse (VIBA2 `ba_y` 0.573 → 0.937), because VIBA0's rough scale gets baked in by conditioning on it. The regression test's second assertion is written to fail loudly if the poses ever *do* become IMU-consistent, at which point `VIBA_PRIOR_A` should be revisited.
- The full-length run still shows map scale decaying to ~0.57 in its later windows. That is the pre-existing long-run scale drift, untouched here (the baseline was worse on the run-wide metric).
