### PR TITLE
slam: add KLT optical-flow tracking primitives

### DIFF
--- a/crates/kornia-slam/src/estimation/mod.rs
+++ b/crates/kornia-slam/src/estimation/mod.rs
@@ -11,7 +11,10 @@ use kornia_3d::pose::Pose3d;
 
 pub use imu_init::{ImuInitConfig, ImuInitResult, ImuInitializer};
 pub use map_projection::MapProjectionEstimator;
-pub use optical_flow::{Track, TrackState};
+pub use optical_flow::{
+    FlowSurvivor, KeypointCorrespondence, KltTracker, MapKeypointMatch, SurvivorFilterConfig,
+    Track, TrackId, TrackSet, TrackSetError,
+};
 
 /// Successful pose estimate returned by any estimator.
 #[derive(Debug, Clone)]

--- a/crates/kornia-slam/src/estimation/mod.rs
+++ b/crates/kornia-slam/src/estimation/mod.rs
@@ -3,6 +3,7 @@
 pub mod imu_init;
 pub mod inertial_init_factor;
 pub mod map_projection;
+pub mod optical_flow;
 pub mod pnp;
 pub mod two_view;
 
@@ -10,6 +11,7 @@ use kornia_3d::pose::Pose3d;
 
 pub use imu_init::{ImuInitConfig, ImuInitResult, ImuInitializer};
 pub use map_projection::MapProjectionEstimator;
+pub use optical_flow::{Track, TrackState};
 
 /// Successful pose estimate returned by any estimator.
 #[derive(Debug, Clone)]

--- a/crates/kornia-slam/src/estimation/optical_flow.rs
+++ b/crates/kornia-slam/src/estimation/optical_flow.rs
@@ -1,13 +1,4 @@
-//! Persistent per-point track identity for optical-flow tracking.
-//!
-//! Unlike [`super::map_projection`], which re-derives every correspondence
-//! from scratch each frame (project map points via the candidate pose, match
-//! by descriptor), optical-flow tracking carries a point's identity and
-//! map-point association *forward* from frame to frame — established once,
-//! then just followed, not re-matched every time. This module holds that
-//! carried state; the KLT call itself and the merge logic that produces a
-//! new [`TrackState`] each frame live elsewhere (see the tracker built on
-//! top of `kornia_imgproc::optical_flow_pyr_lk`).
+//! Persistent KLT track state and map-point associations.
 
 use std::collections::HashMap;
 
@@ -16,54 +7,30 @@ use kornia_imgproc::optical_flow_pyr_lk::{
     BorderMode, PyrLKError, PyrLKParams, TermCriteria, calc_optical_flow_pyr_lk,
 };
 
-/// One point being tracked frame-to-frame via optical flow, independent of
-/// how many detection cycles it has survived.
+/// One point tracked frame-to-frame by optical flow.
 #[derive(Debug, Clone, Copy)]
 pub struct Track {
-    /// Stable identity across frames, for observability only — nothing in
-    /// the tracking mechanism itself keys off this; carrying state forward
-    /// frame-to-frame is positional (see [`TrackState::pixels`] and the KLT
-    /// call it feeds).
+    /// Stable identity across frames.
     pub track_id: u64,
-    /// Raw (distorted) pixel position in the frame this `Track` belongs to —
-    /// same convention as `Frame::features.keypoints_xy`, since KLT tracks
-    /// directly on the raw image (there's no full-image undistortion step
-    /// anywhere in this codebase, only point-wise). Undistort on demand
-    /// wherever undistorted coordinates are needed, exactly as
-    /// `Frame::undistorted_xy` already does for detected keypoints.
+    /// Raw, distorted pixel position in the current frame.
     pub pixel: [f32; 2],
-    /// Map point this track is associated with, if any. `None` until the
-    /// track survives to become part of a keyframe.
+    /// Associated map-point index, if any.
     pub map_point_idx: Option<usize>,
     /// Consecutive frames this track has survived. 1 = just detected.
     pub age: u32,
 }
 
-/// The set of points currently being tracked, owned by the pipeline and
-/// carried from frame to frame.
-///
-/// Rebuilt wholesale each frame via [`TrackState::set_tracks`]: KLT survivors
-/// keep their `Track` (carried-forward `track_id`/`map_point_idx`,
-/// incremented `age`), failed tracks are dropped, and replenished detections
-/// are appended as new `Track`s minted via [`TrackState::new_track`].
+/// Persistent state for points carried between frames.
 #[derive(Debug, Default)]
 pub struct TrackState {
     next_track_id: u64,
     tracks: Vec<Track>,
 }
 
-/// Tunable parameters for KLT tracking: the library's own LK math
-/// (`win_size` through `border_mode`, matching `PyrLKParams` field-for-field
-/// — kept flattened here rather than nested, at the cost of an explicit
-/// conversion where `track()` builds the `PyrLKParams` it actually passes to
-/// `calc_optical_flow_pyr_lk`) plus the three accept/reject gates the library
-/// itself doesn't provide.
+/// KLT solver parameters and survivor acceptance thresholds.
 #[derive(Debug)]
 pub struct OpticalFlowConfig {
-    /// LK integration window size in pixels. The library currently only
-    /// supports exactly `21` — kept as a field (not a constant) so
-    /// `calc_optical_flow_pyr_lk`'s own validation is what enforces that,
-    /// not a silent assumption baked in here.
+    /// LK integration window size in pixels (currently required to be 21).
     pub win_size: usize,
     /// Pyramid depth: more levels track larger displacements, at higher cost
     /// and less precision at the coarsest level.
@@ -75,29 +42,18 @@ pub struct OpticalFlowConfig {
     /// Minimum structure-tensor eigenvalue for a patch to be considered
     /// trackable at all (rejects flat/aliased regions).
     pub min_eigen_threshold: f32,
-    /// Seed the search from a provided initial guess instead of `prev_pts`'
-    /// own position. Left `false` for now — the pose-informed hybrid this
-    /// would enable is a later refinement, not needed for the first working
-    /// version.
+    /// Seed the search from a provided initial-flow estimate.
     pub use_initial_flow: bool,
     /// Iteration stopping rule (count / epsilon / both).
     pub term_criteria: TermCriteria,
-    /// How the LK math itself samples pixels near the image edge during
-    /// iteration. Separate from `border_margin_px` below, which governs
-    /// whether a result close to the edge is *trusted* afterward.
+    /// Sampling policy near image borders during iteration.
     pub border_mode: BorderMode,
 
-    /// Reject a track if KLT's own reported error exceeds this, even when
-    /// `status == 1` — `status` only means "didn't fail outright," `error`
-    /// is the actual residual.
+    /// Maximum accepted KLT residual when tracking succeeds.
     pub max_error: f32,
-    /// Reject a track whose pixel displacement from the previous frame
-    /// exceeds this — catches LK converging to a plausible-looking but
-    /// wrong local optimum (e.g. aliasing onto a nearby similar patch).
+    /// Maximum accepted frame-to-frame displacement in pixels.
     pub max_movement_px: f32,
-    /// Reject a track landing within this many pixels of the image edge —
-    /// stricter than `border_mode`, which only affects the LK math's
-    /// internal sampling, not whether the final result is trustworthy.
+    /// Required distance in pixels from the output image border.
     pub border_margin_px: f32,
 }
 
@@ -120,9 +76,7 @@ impl Default for OpticalFlowConfig {
 }
 
 impl OpticalFlowConfig {
-    /// Packs the flattened LK-math fields back into the `PyrLKParams` shape
-    /// `calc_optical_flow_pyr_lk` actually takes. Pure plumbing — nothing
-    /// here is a decision, just matching field-for-field.
+    /// Converts the public configuration into the underlying LK parameters.
     fn to_pyr_lk_params(&self) -> PyrLKParams {
         PyrLKParams {
             win_size: self.win_size,
@@ -138,7 +92,7 @@ impl OpticalFlowConfig {
 }
 
 impl TrackState {
-    /// Empty track state, as at startup or right after a re-bootstrap.
+    /// Creates an empty track state.
     pub fn new() -> Self {
         Self {
             next_track_id: 0,
@@ -146,7 +100,7 @@ impl TrackState {
         }
     }
 
-    /// Current tracks, in the same order [`TrackState::pixels`] hands to KLT.
+    /// Returns current tracks in KLT input order.
     pub fn tracks(&self) -> &[Track] {
         &self.tracks
     }
@@ -160,17 +114,12 @@ impl TrackState {
         self.tracks.is_empty()
     }
 
-    /// Pixel positions of all current tracks, in a form the KLT call
-    /// consumes directly as `prev_pts`. Positional order must be preserved
-    /// through that call — `status`/`next_pts` come back parallel to this —
-    /// so whatever merges KLT's output back into a new `TrackState` can zip
-    /// them against `tracks()` by index.
+    /// Returns pixel positions in the same order as [`Self::tracks`].
     pub fn pixels(&self) -> Vec<[f32; 2]> {
         self.tracks.iter().map(|t| t.pixel).collect()
     }
 
-    /// Mints a fresh, uniquely-identified `Track` for a newly detected point
-    /// (replenishment) — not yet associated with any map point.
+    /// Creates a uniquely identified, unassociated track.
     pub fn new_track(&mut self, pixel: [f32; 2]) -> Track {
         let track_id = self.next_track_id;
         self.next_track_id += 1;
@@ -182,28 +131,13 @@ impl TrackState {
         }
     }
 
-    /// Replaces the track list wholesale with the next frame's full set.
-    /// Callers assemble `tracks` themselves — carried-forward survivors
-    /// (via [`Track`]'s fields, incremented `age`) plus any freshly-minted
-    /// tracks from [`TrackState::new_track`] — this just commits it.
+    /// Replaces the current track set.
     pub fn set_tracks(&mut self, tracks: Vec<Track>) {
         self.tracks = tracks;
     }
 
-    /// Advances `self` one frame via pyramidal Lucas-Kanade: tracks every
-    /// point in `self` from `prev_img` into `next_img`, and returns the
-    /// survivors as a fresh `Vec<Track>` — carried-forward `track_id`/
-    /// `map_point_idx`, `age` incremented, `pixel` updated to wherever KLT
-    /// found it.
-    ///
-    /// Does **not** call [`TrackState::set_tracks`] itself, and does not
-    /// replenish — this only tracks what's already in `self`. The caller
-    /// decides how to merge these survivors with newly-detected points
-    /// before committing the next frame's state.
-    ///
-    /// `prev_img`/`next_img` must be the raw (distorted) grayscale images
-    /// for the frames `self` and the frame being tracked into, respectively
-    /// — same pixel space as `Track::pixel`.
+    /// Tracks current points between raw grayscale images and returns the
+    /// accepted survivors without mutating this state.
     pub fn track(
         &self,
         prev_img: &Image<u8, 1>,
@@ -214,9 +148,7 @@ impl TrackState {
             return Ok(Vec::new());
         }
 
-        // u8 -> f32 is always exactly representable (every u8 value fits a
-        // f32 with no precision loss), so `cast`'s only failure mode
-        // (genuine numeric conversion loss) can't happen here.
+        // Every u8 value is exactly representable as f32.
         let prev_f32 = prev_img
             .cast::<f32>()
             .expect("u8 -> f32 image cast is always representable");
@@ -268,20 +200,8 @@ impl TrackState {
         Ok(survivors)
     }
 
-    /// Rebuilds the track list from a frame's winning correspondence set —
-    /// meant to be called once per successful `estimate_pose`, regardless
-    /// of whether `matches` came from KLT-seeded correspondences (see
-    /// [`klt_correspondences`]) or the existing projection-search /
-    /// reference-keyframe fallback. That's deliberate: it's what lets
-    /// tracking *recover* rather than being a one-way ratchet that can only
-    /// ever lose tracks — any map point the fallback path finds (e.g. one
-    /// KLT lost, or one newly visible) becomes a fresh, trackable point
-    /// again starting next frame.
-    ///
-    /// Track identity (`track_id`/`age`) is preserved for any map point
-    /// that was already being tracked; anything new mints a fresh `Track`.
-    /// `keypoints` must be the current frame's raw (distorted) keypoints,
-    /// indexed the same way `matches`' second element is.
+    /// Rebuilds tracks from `(map_point_idx, keypoint_idx)` matches, preserving
+    /// identity and age for map points already present in the state.
     pub fn refresh_from_matches(&mut self, matches: &[(usize, usize)], keypoints: &[[f32; 2]]) {
         let mut old_by_mp: HashMap<usize, Track> = self
             .tracks
@@ -313,9 +233,7 @@ impl TrackState {
     }
 }
 
-/// Nearest keypoint in `keypoints` to `predicted`, within `radius_px` —
-/// brute-force since per-frame track counts are modest (hundreds, not
-/// thousands); a spatial grid isn't justified yet.
+/// Finds the nearest keypoint within `radius_px`.
 fn nearest_keypoint(predicted: [f32; 2], keypoints: &[[f32; 2]], radius_px: f32) -> Option<usize> {
     let r2 = radius_px * radius_px;
     let mut best: Option<(usize, f32)> = None;
@@ -334,16 +252,8 @@ fn nearest_keypoint(predicted: [f32; 2], keypoints: &[[f32; 2]], radius_px: f32)
     best.map(|(i, _)| i)
 }
 
-/// Snaps each survivor's predicted pixel onto the nearest freshly detected
-/// keypoint in `curr_keypoints` (raw/distorted, same convention as
-/// `Track::pixel`) within `snap_radius_px`, producing
-/// `(map_point_idx, current_frame_keypoint_idx)` correspondences.
-///
-/// Split out from [`klt_correspondences`] so a caller can hold onto
-/// `survivors` itself (e.g. to commit them back via
-/// [`TrackState::set_tracks`] even on a frame whose correspondences don't
-/// win — see that method's doc) instead of only getting the derived
-/// correspondences.
+/// Snaps associated survivors to detected keypoints, producing
+/// `(map_point_idx, keypoint_idx)` correspondences.
 pub fn snap_survivors(
     survivors: &[Track],
     curr_keypoints: &[[f32; 2]],
@@ -360,19 +270,7 @@ pub fn snap_survivors(
     correspondences
 }
 
-/// Produces `(map_point_idx, current_frame_keypoint_idx)` correspondences by
-/// KLT-tracking `track_state`'s existing points from `prev_img` into
-/// `next_img`, then snapping each survivor's predicted pixel onto the
-/// nearest freshly detected keypoint in `curr_keypoints` (raw/distorted,
-/// same convention as `Track::pixel`) within `snap_radius_px`.
-///
-/// Returns only correspondences, not an updated `TrackState` — the caller
-/// rebuilds that from the *winning* `Estimate`'s matches afterward via
-/// [`TrackState::refresh_from_matches`], not from this function's output
-/// directly (see that method's doc for why). Callers that also need the raw
-/// survivors (e.g. to keep KLT continuity alive across a losing frame)
-/// should call [`TrackState::track`] and [`snap_survivors`] directly instead
-/// of this convenience wrapper.
+/// Tracks existing points and snaps survivors to current-frame keypoints.
 pub fn klt_correspondences(
     track_state: &TrackState,
     prev_img: &Image<u8, 1>,
@@ -409,9 +307,7 @@ mod tests {
         assert_eq!(state.pixels(), vec![[1.0, 2.0], [3.0, 4.0]]);
     }
 
-    /// Builds a 200x200 black image with a white square, corner at `origin`,
-    /// 40px on a side — the corner itself is the useful test feature (a
-    /// real gradient in both x and y), not the square's flat interior.
+    /// Builds a black image with a white square whose corner is trackable.
     fn square_image(origin: [usize; 2]) -> Image<u8, 1> {
         const SIZE: usize = 200;
         let mut data = vec![0u8; SIZE * SIZE];
@@ -436,8 +332,7 @@ mod tests {
         let next_img = square_image([93, 92]); // shifted by (+3, +2)
 
         let mut state = TrackState::new();
-        // Seed at the square's top-left corner in `prev` — a real corner
-        // feature (gradient in both directions), not the flat interior.
+        // Seed the square's top-left corner, which has gradients on both axes.
         let t = state.new_track([90.0, 90.0]);
         state.set_tracks(vec![t]);
 
@@ -462,9 +357,7 @@ mod tests {
         t0.map_point_idx = Some(42);
         state.set_tracks(vec![t0]);
 
-        // Map point 42 matched again this frame (at a new pixel, as if KLT
-        // + snapping had moved it), and a brand-new map point 7 shows up
-        // via the fallback path.
+        // Map point 42 persists while map point 7 appears for the first time.
         let keypoints = [[5.0, 6.0], [10.0, 11.0]];
         state.refresh_from_matches(&[(42, 0), (7, 1)], &keypoints);
 

--- a/crates/kornia-slam/src/estimation/optical_flow.rs
+++ b/crates/kornia-slam/src/estimation/optical_flow.rs
@@ -1,0 +1,482 @@
+//! Persistent per-point track identity for optical-flow tracking.
+//!
+//! Unlike [`super::map_projection`], which re-derives every correspondence
+//! from scratch each frame (project map points via the candidate pose, match
+//! by descriptor), optical-flow tracking carries a point's identity and
+//! map-point association *forward* from frame to frame — established once,
+//! then just followed, not re-matched every time. This module holds that
+//! carried state; the KLT call itself and the merge logic that produces a
+//! new [`TrackState`] each frame live elsewhere (see the tracker built on
+//! top of `kornia_imgproc::optical_flow_pyr_lk`).
+
+use std::collections::HashMap;
+
+use kornia_image::Image;
+use kornia_imgproc::optical_flow_pyr_lk::{
+    BorderMode, PyrLKError, PyrLKParams, TermCriteria, calc_optical_flow_pyr_lk,
+};
+
+/// One point being tracked frame-to-frame via optical flow, independent of
+/// how many detection cycles it has survived.
+#[derive(Debug, Clone, Copy)]
+pub struct Track {
+    /// Stable identity across frames, for observability only — nothing in
+    /// the tracking mechanism itself keys off this; carrying state forward
+    /// frame-to-frame is positional (see [`TrackState::pixels`] and the KLT
+    /// call it feeds).
+    pub track_id: u64,
+    /// Raw (distorted) pixel position in the frame this `Track` belongs to —
+    /// same convention as `Frame::features.keypoints_xy`, since KLT tracks
+    /// directly on the raw image (there's no full-image undistortion step
+    /// anywhere in this codebase, only point-wise). Undistort on demand
+    /// wherever undistorted coordinates are needed, exactly as
+    /// `Frame::undistorted_xy` already does for detected keypoints.
+    pub pixel: [f32; 2],
+    /// Map point this track is associated with, if any. `None` until the
+    /// track survives to become part of a keyframe.
+    pub map_point_idx: Option<usize>,
+    /// Consecutive frames this track has survived. 1 = just detected.
+    pub age: u32,
+}
+
+/// The set of points currently being tracked, owned by the pipeline and
+/// carried from frame to frame.
+///
+/// Rebuilt wholesale each frame via [`TrackState::set_tracks`]: KLT survivors
+/// keep their `Track` (carried-forward `track_id`/`map_point_idx`,
+/// incremented `age`), failed tracks are dropped, and replenished detections
+/// are appended as new `Track`s minted via [`TrackState::new_track`].
+#[derive(Debug, Default)]
+pub struct TrackState {
+    next_track_id: u64,
+    tracks: Vec<Track>,
+}
+
+/// Tunable parameters for KLT tracking: the library's own LK math
+/// (`win_size` through `border_mode`, matching `PyrLKParams` field-for-field
+/// — kept flattened here rather than nested, at the cost of an explicit
+/// conversion where `track()` builds the `PyrLKParams` it actually passes to
+/// `calc_optical_flow_pyr_lk`) plus the three accept/reject gates the library
+/// itself doesn't provide.
+#[derive(Debug)]
+pub struct OpticalFlowConfig {
+    /// LK integration window size in pixels. The library currently only
+    /// supports exactly `21` — kept as a field (not a constant) so
+    /// `calc_optical_flow_pyr_lk`'s own validation is what enforces that,
+    /// not a silent assumption baked in here.
+    pub win_size: usize,
+    /// Pyramid depth: more levels track larger displacements, at higher cost
+    /// and less precision at the coarsest level.
+    pub max_level: usize,
+    /// Gauss-Newton iterations per pyramid level before giving up.
+    pub max_iter: usize,
+    /// Convergence threshold on the incremental flow update.
+    pub epsilon: f32,
+    /// Minimum structure-tensor eigenvalue for a patch to be considered
+    /// trackable at all (rejects flat/aliased regions).
+    pub min_eigen_threshold: f32,
+    /// Seed the search from a provided initial guess instead of `prev_pts`'
+    /// own position. Left `false` for now — the pose-informed hybrid this
+    /// would enable is a later refinement, not needed for the first working
+    /// version.
+    pub use_initial_flow: bool,
+    /// Iteration stopping rule (count / epsilon / both).
+    pub term_criteria: TermCriteria,
+    /// How the LK math itself samples pixels near the image edge during
+    /// iteration. Separate from `border_margin_px` below, which governs
+    /// whether a result close to the edge is *trusted* afterward.
+    pub border_mode: BorderMode,
+
+    /// Reject a track if KLT's own reported error exceeds this, even when
+    /// `status == 1` — `status` only means "didn't fail outright," `error`
+    /// is the actual residual.
+    pub max_error: f32,
+    /// Reject a track whose pixel displacement from the previous frame
+    /// exceeds this — catches LK converging to a plausible-looking but
+    /// wrong local optimum (e.g. aliasing onto a nearby similar patch).
+    pub max_movement_px: f32,
+    /// Reject a track landing within this many pixels of the image edge —
+    /// stricter than `border_mode`, which only affects the LK math's
+    /// internal sampling, not whether the final result is trustworthy.
+    pub border_margin_px: f32,
+}
+
+impl Default for OpticalFlowConfig {
+    fn default() -> Self {
+        Self {
+            win_size: 21,
+            max_level: 3,
+            max_iter: 30,
+            epsilon: 0.01,
+            min_eigen_threshold: 1e-4,
+            use_initial_flow: false,
+            term_criteria: TermCriteria::Both,
+            border_mode: BorderMode::Clamp,
+            max_error: 20.0,
+            max_movement_px: 60.0,
+            border_margin_px: 10.0,
+        }
+    }
+}
+
+impl OpticalFlowConfig {
+    /// Packs the flattened LK-math fields back into the `PyrLKParams` shape
+    /// `calc_optical_flow_pyr_lk` actually takes. Pure plumbing — nothing
+    /// here is a decision, just matching field-for-field.
+    fn to_pyr_lk_params(&self) -> PyrLKParams {
+        PyrLKParams {
+            win_size: self.win_size,
+            max_level: self.max_level,
+            max_iter: self.max_iter,
+            epsilon: self.epsilon,
+            min_eigen_threshold: self.min_eigen_threshold,
+            use_initial_flow: self.use_initial_flow,
+            term_criteria: self.term_criteria.clone(),
+            border_mode: self.border_mode,
+        }
+    }
+}
+
+impl TrackState {
+    /// Empty track state, as at startup or right after a re-bootstrap.
+    pub fn new() -> Self {
+        Self {
+            next_track_id: 0,
+            tracks: Vec::new(),
+        }
+    }
+
+    /// Current tracks, in the same order [`TrackState::pixels`] hands to KLT.
+    pub fn tracks(&self) -> &[Track] {
+        &self.tracks
+    }
+
+    /// Number of points currently tracked.
+    pub fn len(&self) -> usize {
+        self.tracks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tracks.is_empty()
+    }
+
+    /// Pixel positions of all current tracks, in a form the KLT call
+    /// consumes directly as `prev_pts`. Positional order must be preserved
+    /// through that call — `status`/`next_pts` come back parallel to this —
+    /// so whatever merges KLT's output back into a new `TrackState` can zip
+    /// them against `tracks()` by index.
+    pub fn pixels(&self) -> Vec<[f32; 2]> {
+        self.tracks.iter().map(|t| t.pixel).collect()
+    }
+
+    /// Mints a fresh, uniquely-identified `Track` for a newly detected point
+    /// (replenishment) — not yet associated with any map point.
+    pub fn new_track(&mut self, pixel: [f32; 2]) -> Track {
+        let track_id = self.next_track_id;
+        self.next_track_id += 1;
+        Track {
+            track_id,
+            pixel,
+            map_point_idx: None,
+            age: 1,
+        }
+    }
+
+    /// Replaces the track list wholesale with the next frame's full set.
+    /// Callers assemble `tracks` themselves — carried-forward survivors
+    /// (via [`Track`]'s fields, incremented `age`) plus any freshly-minted
+    /// tracks from [`TrackState::new_track`] — this just commits it.
+    pub fn set_tracks(&mut self, tracks: Vec<Track>) {
+        self.tracks = tracks;
+    }
+
+    /// Advances `self` one frame via pyramidal Lucas-Kanade: tracks every
+    /// point in `self` from `prev_img` into `next_img`, and returns the
+    /// survivors as a fresh `Vec<Track>` — carried-forward `track_id`/
+    /// `map_point_idx`, `age` incremented, `pixel` updated to wherever KLT
+    /// found it.
+    ///
+    /// Does **not** call [`TrackState::set_tracks`] itself, and does not
+    /// replenish — this only tracks what's already in `self`. The caller
+    /// decides how to merge these survivors with newly-detected points
+    /// before committing the next frame's state.
+    ///
+    /// `prev_img`/`next_img` must be the raw (distorted) grayscale images
+    /// for the frames `self` and the frame being tracked into, respectively
+    /// — same pixel space as `Track::pixel`.
+    pub fn track(
+        &self,
+        prev_img: &Image<u8, 1>,
+        next_img: &Image<u8, 1>,
+        config: &OpticalFlowConfig,
+    ) -> Result<Vec<Track>, PyrLKError> {
+        if self.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // u8 -> f32 is always exactly representable (every u8 value fits a
+        // f32 with no precision loss), so `cast`'s only failure mode
+        // (genuine numeric conversion loss) can't happen here.
+        let prev_f32 = prev_img
+            .cast::<f32>()
+            .expect("u8 -> f32 image cast is always representable");
+        let next_f32 = next_img
+            .cast::<f32>()
+            .expect("u8 -> f32 image cast is always representable");
+
+        let prev_pts = self.pixels();
+        let result = calc_optical_flow_pyr_lk(
+            &prev_f32,
+            &next_f32,
+            &prev_pts,
+            None,
+            &config.to_pyr_lk_params(),
+        )?;
+
+        let width = next_img.width() as f32;
+        let height = next_img.height() as f32;
+        let margin = config.border_margin_px;
+
+        let mut survivors = Vec::with_capacity(self.tracks.len());
+        for (i, track) in self.tracks.iter().enumerate() {
+            if result.status[i] == 0 {
+                continue; // KLT itself failed for this point.
+            }
+            if result.error[i] > config.max_error {
+                continue;
+            }
+            let next_pt = result.next_pts[i];
+            if next_pt[0] < margin
+                || next_pt[1] < margin
+                || next_pt[0] > width - margin
+                || next_pt[1] > height - margin
+            {
+                continue; // Too close to the edge to trust.
+            }
+            let dx = next_pt[0] - track.pixel[0];
+            let dy = next_pt[1] - track.pixel[1];
+            if (dx * dx + dy * dy).sqrt() > config.max_movement_px {
+                continue; // Implausible jump — likely aliased onto the wrong patch.
+            }
+            survivors.push(Track {
+                track_id: track.track_id,
+                pixel: next_pt,
+                map_point_idx: track.map_point_idx,
+                age: track.age + 1,
+            });
+        }
+        Ok(survivors)
+    }
+
+    /// Rebuilds the track list from a frame's winning correspondence set —
+    /// meant to be called once per successful `estimate_pose`, regardless
+    /// of whether `matches` came from KLT-seeded correspondences (see
+    /// [`klt_correspondences`]) or the existing projection-search /
+    /// reference-keyframe fallback. That's deliberate: it's what lets
+    /// tracking *recover* rather than being a one-way ratchet that can only
+    /// ever lose tracks — any map point the fallback path finds (e.g. one
+    /// KLT lost, or one newly visible) becomes a fresh, trackable point
+    /// again starting next frame.
+    ///
+    /// Track identity (`track_id`/`age`) is preserved for any map point
+    /// that was already being tracked; anything new mints a fresh `Track`.
+    /// `keypoints` must be the current frame's raw (distorted) keypoints,
+    /// indexed the same way `matches`' second element is.
+    pub fn refresh_from_matches(&mut self, matches: &[(usize, usize)], keypoints: &[[f32; 2]]) {
+        let mut old_by_mp: HashMap<usize, Track> = self
+            .tracks
+            .drain(..)
+            .filter_map(|t| t.map_point_idx.map(|mp| (mp, t)))
+            .collect();
+
+        let mut new_tracks = Vec::with_capacity(matches.len());
+        for &(mp_idx, kp_idx) in matches {
+            let Some(&pixel) = keypoints.get(kp_idx) else {
+                continue;
+            };
+            let track = match old_by_mp.remove(&mp_idx) {
+                Some(old) => Track {
+                    track_id: old.track_id,
+                    pixel,
+                    map_point_idx: Some(mp_idx),
+                    age: old.age + 1,
+                },
+                None => {
+                    let mut t = self.new_track(pixel);
+                    t.map_point_idx = Some(mp_idx);
+                    t
+                }
+            };
+            new_tracks.push(track);
+        }
+        self.tracks = new_tracks;
+    }
+}
+
+/// Nearest keypoint in `keypoints` to `predicted`, within `radius_px` —
+/// brute-force since per-frame track counts are modest (hundreds, not
+/// thousands); a spatial grid isn't justified yet.
+fn nearest_keypoint(predicted: [f32; 2], keypoints: &[[f32; 2]], radius_px: f32) -> Option<usize> {
+    let r2 = radius_px * radius_px;
+    let mut best: Option<(usize, f32)> = None;
+    for (i, &kp) in keypoints.iter().enumerate() {
+        let dx = kp[0] - predicted[0];
+        let dy = kp[1] - predicted[1];
+        let d2 = dx * dx + dy * dy;
+        if d2 > r2 {
+            continue;
+        }
+        match best {
+            Some((_, best_d2)) if d2 >= best_d2 => {}
+            _ => best = Some((i, d2)),
+        }
+    }
+    best.map(|(i, _)| i)
+}
+
+/// Snaps each survivor's predicted pixel onto the nearest freshly detected
+/// keypoint in `curr_keypoints` (raw/distorted, same convention as
+/// `Track::pixel`) within `snap_radius_px`, producing
+/// `(map_point_idx, current_frame_keypoint_idx)` correspondences.
+///
+/// Split out from [`klt_correspondences`] so a caller can hold onto
+/// `survivors` itself (e.g. to commit them back via
+/// [`TrackState::set_tracks`] even on a frame whose correspondences don't
+/// win — see that method's doc) instead of only getting the derived
+/// correspondences.
+pub fn snap_survivors(
+    survivors: &[Track],
+    curr_keypoints: &[[f32; 2]],
+    snap_radius_px: f32,
+) -> Vec<(usize, usize)> {
+    let mut correspondences = Vec::new();
+    for t in survivors {
+        if let Some(mp_idx) = t.map_point_idx
+            && let Some(kp_idx) = nearest_keypoint(t.pixel, curr_keypoints, snap_radius_px)
+        {
+            correspondences.push((mp_idx, kp_idx));
+        }
+    }
+    correspondences
+}
+
+/// Produces `(map_point_idx, current_frame_keypoint_idx)` correspondences by
+/// KLT-tracking `track_state`'s existing points from `prev_img` into
+/// `next_img`, then snapping each survivor's predicted pixel onto the
+/// nearest freshly detected keypoint in `curr_keypoints` (raw/distorted,
+/// same convention as `Track::pixel`) within `snap_radius_px`.
+///
+/// Returns only correspondences, not an updated `TrackState` — the caller
+/// rebuilds that from the *winning* `Estimate`'s matches afterward via
+/// [`TrackState::refresh_from_matches`], not from this function's output
+/// directly (see that method's doc for why). Callers that also need the raw
+/// survivors (e.g. to keep KLT continuity alive across a losing frame)
+/// should call [`TrackState::track`] and [`snap_survivors`] directly instead
+/// of this convenience wrapper.
+pub fn klt_correspondences(
+    track_state: &TrackState,
+    prev_img: &Image<u8, 1>,
+    next_img: &Image<u8, 1>,
+    curr_keypoints: &[[f32; 2]],
+    config: &OpticalFlowConfig,
+    snap_radius_px: f32,
+) -> Result<Vec<(usize, usize)>, PyrLKError> {
+    let survivors = track_state.track(prev_img, next_img, config)?;
+    Ok(snap_survivors(&survivors, curr_keypoints, snap_radius_px))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kornia_image::ImageSize;
+
+    #[test]
+    fn new_track_gets_unique_ids() {
+        let mut state = TrackState::new();
+        let a = state.new_track([1.0, 2.0]);
+        let b = state.new_track([3.0, 4.0]);
+        assert_ne!(a.track_id, b.track_id);
+        assert_eq!(a.map_point_idx, None);
+        assert_eq!(a.age, 1);
+    }
+
+    #[test]
+    fn pixels_are_positional_with_tracks() {
+        let mut state = TrackState::new();
+        let t0 = state.new_track([1.0, 2.0]);
+        let t1 = state.new_track([3.0, 4.0]);
+        state.set_tracks(vec![t0, t1]);
+        assert_eq!(state.pixels(), vec![[1.0, 2.0], [3.0, 4.0]]);
+    }
+
+    /// Builds a 200x200 black image with a white square, corner at `origin`,
+    /// 40px on a side — the corner itself is the useful test feature (a
+    /// real gradient in both x and y), not the square's flat interior.
+    fn square_image(origin: [usize; 2]) -> Image<u8, 1> {
+        const SIZE: usize = 200;
+        let mut data = vec![0u8; SIZE * SIZE];
+        for y in origin[1]..(origin[1] + 40).min(SIZE) {
+            for x in origin[0]..(origin[0] + 40).min(SIZE) {
+                data[y * SIZE + x] = 255;
+            }
+        }
+        Image::new(
+            ImageSize {
+                width: SIZE,
+                height: SIZE,
+            },
+            data,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn track_follows_a_known_shift() {
+        let prev_img = square_image([90, 90]);
+        let next_img = square_image([93, 92]); // shifted by (+3, +2)
+
+        let mut state = TrackState::new();
+        // Seed at the square's top-left corner in `prev` — a real corner
+        // feature (gradient in both directions), not the flat interior.
+        let t = state.new_track([90.0, 90.0]);
+        state.set_tracks(vec![t]);
+
+        let survivors = state
+            .track(&prev_img, &next_img, &OpticalFlowConfig::default())
+            .expect("KLT should succeed on a clean synthetic shift");
+
+        assert_eq!(survivors.len(), 1, "the corner should track successfully");
+        let got = survivors[0].pixel;
+        assert!(
+            (got[0] - 93.0).abs() < 1.5 && (got[1] - 92.0).abs() < 1.5,
+            "expected tracked pixel near (93, 92), got {got:?}"
+        );
+        assert_eq!(survivors[0].track_id, t.track_id);
+        assert_eq!(survivors[0].age, 2);
+    }
+
+    #[test]
+    fn refresh_from_matches_preserves_identity_for_known_map_points() {
+        let mut state = TrackState::new();
+        let mut t0 = state.new_track([1.0, 2.0]);
+        t0.map_point_idx = Some(42);
+        state.set_tracks(vec![t0]);
+
+        // Map point 42 matched again this frame (at a new pixel, as if KLT
+        // + snapping had moved it), and a brand-new map point 7 shows up
+        // via the fallback path.
+        let keypoints = [[5.0, 6.0], [10.0, 11.0]];
+        state.refresh_from_matches(&[(42, 0), (7, 1)], &keypoints);
+
+        let tracks = state.tracks();
+        assert_eq!(tracks.len(), 2);
+        let mp42 = tracks.iter().find(|t| t.map_point_idx == Some(42)).unwrap();
+        assert_eq!(mp42.track_id, t0.track_id, "identity must carry forward");
+        assert_eq!(mp42.age, 2);
+        assert_eq!(mp42.pixel, [5.0, 6.0]);
+
+        let mp7 = tracks.iter().find(|t| t.map_point_idx == Some(7)).unwrap();
+        assert_ne!(mp7.track_id, t0.track_id, "new map point gets a fresh id");
+        assert_eq!(mp7.age, 1);
+    }
+}

--- a/crates/kornia-slam/src/estimation/optical_flow.rs
+++ b/crates/kornia-slam/src/estimation/optical_flow.rs
@@ -1,111 +1,108 @@
 //! Persistent KLT track state and map-point associations.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use kornia_image::Image;
-use kornia_imgproc::optical_flow_pyr_lk::{
-    BorderMode, PyrLKError, PyrLKParams, TermCriteria, calc_optical_flow_pyr_lk,
-};
+use kornia_imgproc::optical_flow_pyr_lk::{PyrLKError, PyrLKParams, calc_optical_flow_pyr_lk};
+use thiserror::Error;
 
-/// One point tracked frame-to-frame by optical flow.
-#[derive(Debug, Clone, Copy)]
-pub struct Track {
-    /// Stable identity across frames.
-    pub track_id: u64,
-    /// Raw, distorted pixel position in the current frame.
-    pub pixel: [f32; 2],
-    /// Associated map-point index, if any.
-    pub map_point_idx: Option<usize>,
-    /// Consecutive frames this track has survived. 1 = just detected.
-    pub age: u32,
+/// Stable identity for a feature track.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TrackId(u64);
+
+impl TrackId {
+    /// Returns the numeric identifier for logging or serialization.
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
-/// Persistent state for points carried between frames.
+/// One point tracked frame-to-frame by optical flow.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Track {
+    id: TrackId,
+    pixel: [f32; 2],
+    map_point_idx: Option<usize>,
+    age: u32,
+}
+
+impl Track {
+    /// Stable identity across frames.
+    pub fn id(&self) -> TrackId {
+        self.id
+    }
+
+    /// Raw, distorted pixel position in the current frame.
+    pub fn pixel(&self) -> [f32; 2] {
+        self.pixel
+    }
+
+    /// Associated map-point index, if any.
+    pub fn map_point_idx(&self) -> Option<usize> {
+        self.map_point_idx
+    }
+
+    /// Number of consecutive frames represented by this track.
+    pub fn age(&self) -> u32 {
+        self.age
+    }
+}
+
+/// A map point matched to a detected keypoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapKeypointMatch {
+    pub map_point_idx: usize,
+    pub keypoint_idx: usize,
+}
+
+/// One accepted numerical-flow result.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FlowSurvivor {
+    pub track_id: TrackId,
+    pub pixel: [f32; 2],
+    pub error: f32,
+}
+
+/// A one-to-one association between a track, map point, and keypoint.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KeypointCorrespondence {
+    pub track_id: TrackId,
+    pub map_point_idx: usize,
+    pub keypoint_idx: usize,
+    pub distance_sq: f32,
+}
+
+/// Invalid input to a persistent track-state transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum TrackSetError {
+    #[error("unknown track ID {0:?}")]
+    UnknownTrackId(TrackId),
+    #[error("duplicate track ID {0:?}")]
+    DuplicateTrackId(TrackId),
+    #[error("duplicate map-point index {0}")]
+    DuplicateMapPoint(usize),
+    #[error("duplicate keypoint index {0}")]
+    DuplicateKeypoint(usize),
+    #[error("invalid keypoint index {0}")]
+    InvalidKeypointIndex(usize),
+}
+
+/// Persistent owner of track identity, age, and map-point associations.
 #[derive(Debug, Default)]
-pub struct TrackState {
-    next_track_id: u64,
+pub struct TrackSet {
+    next_id: u64,
     tracks: Vec<Track>,
 }
 
-/// KLT solver parameters and survivor acceptance thresholds.
-#[derive(Debug)]
-pub struct OpticalFlowConfig {
-    /// LK integration window size in pixels (currently required to be 21).
-    pub win_size: usize,
-    /// Pyramid depth: more levels track larger displacements, at higher cost
-    /// and less precision at the coarsest level.
-    pub max_level: usize,
-    /// Gauss-Newton iterations per pyramid level before giving up.
-    pub max_iter: usize,
-    /// Convergence threshold on the incremental flow update.
-    pub epsilon: f32,
-    /// Minimum structure-tensor eigenvalue for a patch to be considered
-    /// trackable at all (rejects flat/aliased regions).
-    pub min_eigen_threshold: f32,
-    /// Seed the search from a provided initial-flow estimate.
-    pub use_initial_flow: bool,
-    /// Iteration stopping rule (count / epsilon / both).
-    pub term_criteria: TermCriteria,
-    /// Sampling policy near image borders during iteration.
-    pub border_mode: BorderMode,
-
-    /// Maximum accepted KLT residual when tracking succeeds.
-    pub max_error: f32,
-    /// Maximum accepted frame-to-frame displacement in pixels.
-    pub max_movement_px: f32,
-    /// Required distance in pixels from the output image border.
-    pub border_margin_px: f32,
-}
-
-impl Default for OpticalFlowConfig {
-    fn default() -> Self {
-        Self {
-            win_size: 21,
-            max_level: 3,
-            max_iter: 30,
-            epsilon: 0.01,
-            min_eigen_threshold: 1e-4,
-            use_initial_flow: false,
-            term_criteria: TermCriteria::Both,
-            border_mode: BorderMode::Clamp,
-            max_error: 20.0,
-            max_movement_px: 60.0,
-            border_margin_px: 10.0,
-        }
-    }
-}
-
-impl OpticalFlowConfig {
-    /// Converts the public configuration into the underlying LK parameters.
-    fn to_pyr_lk_params(&self) -> PyrLKParams {
-        PyrLKParams {
-            win_size: self.win_size,
-            max_level: self.max_level,
-            max_iter: self.max_iter,
-            epsilon: self.epsilon,
-            min_eigen_threshold: self.min_eigen_threshold,
-            use_initial_flow: self.use_initial_flow,
-            term_criteria: self.term_criteria.clone(),
-            border_mode: self.border_mode,
-        }
-    }
-}
-
-impl TrackState {
-    /// Creates an empty track state.
+impl TrackSet {
     pub fn new() -> Self {
-        Self {
-            next_track_id: 0,
-            tracks: Vec::new(),
-        }
+        Self::default()
     }
 
-    /// Returns current tracks in KLT input order.
     pub fn tracks(&self) -> &[Track] {
         &self.tracks
     }
 
-    /// Number of points currently tracked.
     pub fn len(&self) -> usize {
         self.tracks.len()
     }
@@ -114,173 +111,361 @@ impl TrackState {
         self.tracks.is_empty()
     }
 
-    /// Returns pixel positions in the same order as [`Self::tracks`].
-    pub fn pixels(&self) -> Vec<[f32; 2]> {
-        self.tracks.iter().map(|t| t.pixel).collect()
-    }
-
-    /// Creates a uniquely identified, unassociated track.
-    pub fn new_track(&mut self, pixel: [f32; 2]) -> Track {
-        let track_id = self.next_track_id;
-        self.next_track_id += 1;
-        Track {
-            track_id,
+    /// Inserts a new, unassociated track and returns its identity.
+    pub fn spawn(&mut self, pixel: [f32; 2]) -> TrackId {
+        let id = self.allocate_id();
+        self.tracks.push(Track {
+            id,
             pixel,
             map_point_idx: None,
             age: 1,
+        });
+        id
+    }
+
+    /// Advances the active set to the supplied KLT survivors.
+    ///
+    /// Validation completes before state changes, so an error leaves the set
+    /// unchanged.
+    pub fn advance(&mut self, survivors: Vec<FlowSurvivor>) -> Result<(), TrackSetError> {
+        let by_id: HashMap<TrackId, Track> =
+            self.tracks.iter().map(|track| (track.id, *track)).collect();
+        let mut seen = HashSet::with_capacity(survivors.len());
+        for survivor in &survivors {
+            if !by_id.contains_key(&survivor.track_id) {
+                return Err(TrackSetError::UnknownTrackId(survivor.track_id));
+            }
+            if !seen.insert(survivor.track_id) {
+                return Err(TrackSetError::DuplicateTrackId(survivor.track_id));
+            }
+        }
+
+        self.tracks = survivors
+            .into_iter()
+            .map(|survivor| {
+                let previous = by_id[&survivor.track_id];
+                Track {
+                    id: survivor.track_id,
+                    pixel: survivor.pixel,
+                    map_point_idx: previous.map_point_idx,
+                    age: previous.age.saturating_add(1),
+                }
+            })
+            .collect();
+        Ok(())
+    }
+
+    /// Reconciles active tracks with detector/map matches for this frame.
+    ///
+    /// Existing map points retain identity and advance one frame. New map
+    /// points receive fresh identities at age one. Unmatched tracks are
+    /// removed. Validation is transactional.
+    pub fn reconcile_from_matches(
+        &mut self,
+        matches: &[MapKeypointMatch],
+        keypoints: &[[f32; 2]],
+    ) -> Result<(), TrackSetError> {
+        let mut seen_map_points = HashSet::with_capacity(matches.len());
+        let mut seen_keypoints = HashSet::with_capacity(matches.len());
+        for matched in matches {
+            if matched.keypoint_idx >= keypoints.len() {
+                return Err(TrackSetError::InvalidKeypointIndex(matched.keypoint_idx));
+            }
+            if !seen_map_points.insert(matched.map_point_idx) {
+                return Err(TrackSetError::DuplicateMapPoint(matched.map_point_idx));
+            }
+            if !seen_keypoints.insert(matched.keypoint_idx) {
+                return Err(TrackSetError::DuplicateKeypoint(matched.keypoint_idx));
+            }
+        }
+
+        let old_by_map_point: HashMap<usize, Track> = self
+            .tracks
+            .iter()
+            .filter_map(|track| track.map_point_idx.map(|idx| (idx, *track)))
+            .collect();
+        let new_count = matches
+            .iter()
+            .filter(|matched| !old_by_map_point.contains_key(&matched.map_point_idx))
+            .count();
+        let start_id = self.reserve_ids(new_count);
+        let mut next_new_id = start_id;
+
+        self.tracks = matches
+            .iter()
+            .map(|matched| {
+                if let Some(previous) = old_by_map_point.get(&matched.map_point_idx) {
+                    Track {
+                        id: previous.id,
+                        pixel: keypoints[matched.keypoint_idx],
+                        map_point_idx: Some(matched.map_point_idx),
+                        age: previous.age.saturating_add(1),
+                    }
+                } else {
+                    let id = TrackId(next_new_id);
+                    next_new_id += 1;
+                    Track {
+                        id,
+                        pixel: keypoints[matched.keypoint_idx],
+                        map_point_idx: Some(matched.map_point_idx),
+                        age: 1,
+                    }
+                }
+            })
+            .collect();
+        Ok(())
+    }
+
+    fn allocate_id(&mut self) -> TrackId {
+        let id = TrackId(self.next_id);
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .expect("track ID space exhausted");
+        id
+    }
+
+    fn reserve_ids(&mut self, count: usize) -> u64 {
+        let start = self.next_id;
+        self.next_id = self
+            .next_id
+            .checked_add(count as u64)
+            .expect("track ID space exhausted");
+        start
+    }
+}
+
+/// SLAM-specific acceptance thresholds for numerical KLT results.
+#[derive(Debug, Clone, Copy)]
+pub struct SurvivorFilterConfig {
+    pub max_error: f32,
+    pub max_movement_px: f32,
+    pub border_margin_px: f32,
+}
+
+impl Default for SurvivorFilterConfig {
+    fn default() -> Self {
+        Self {
+            max_error: 20.0,
+            max_movement_px: 60.0,
+            border_margin_px: 10.0,
+        }
+    }
+}
+
+/// Stateless numerical KLT executor.
+#[derive(Debug, Clone)]
+pub struct KltTracker {
+    params: PyrLKParams,
+    survivor_filter: SurvivorFilterConfig,
+}
+
+impl Default for KltTracker {
+    fn default() -> Self {
+        Self::new(PyrLKParams::default(), SurvivorFilterConfig::default())
+    }
+}
+
+impl KltTracker {
+    pub fn new(params: PyrLKParams, survivor_filter: SurvivorFilterConfig) -> Self {
+        Self {
+            params,
+            survivor_filter,
         }
     }
 
-    /// Replaces the current track set.
-    pub fn set_tracks(&mut self, tracks: Vec<Track>) {
-        self.tracks = tracks;
+    pub fn params(&self) -> &PyrLKParams {
+        &self.params
     }
 
-    /// Tracks current points between raw grayscale images and returns the
-    /// accepted survivors without mutating this state.
+    pub fn survivor_filter(&self) -> SurvivorFilterConfig {
+        self.survivor_filter
+    }
+
     pub fn track(
         &self,
-        prev_img: &Image<u8, 1>,
-        next_img: &Image<u8, 1>,
-        config: &OpticalFlowConfig,
-    ) -> Result<Vec<Track>, PyrLKError> {
-        if self.is_empty() {
+        tracks: &[Track],
+        previous: &Image<u8, 1>,
+        current: &Image<u8, 1>,
+    ) -> Result<Vec<FlowSurvivor>, PyrLKError> {
+        self.track_impl(tracks, None, previous, current)
+    }
+
+    pub fn track_with_initial(
+        &self,
+        tracks: &[Track],
+        initial_pixels: &[[f32; 2]],
+        previous: &Image<u8, 1>,
+        current: &Image<u8, 1>,
+    ) -> Result<Vec<FlowSurvivor>, PyrLKError> {
+        if initial_pixels.len() != tracks.len() {
+            return Err(PyrLKError::InitialFlowLengthMismatch {
+                expected: tracks.len(),
+                provided: initial_pixels.len(),
+            });
+        }
+        self.track_impl(tracks, Some(initial_pixels), previous, current)
+    }
+
+    fn track_impl(
+        &self,
+        tracks: &[Track],
+        initial_pixels: Option<&[[f32; 2]]>,
+        previous: &Image<u8, 1>,
+        current: &Image<u8, 1>,
+    ) -> Result<Vec<FlowSurvivor>, PyrLKError> {
+        if tracks.is_empty() {
             return Ok(Vec::new());
         }
 
-        // Every u8 value is exactly representable as f32.
-        let prev_f32 = prev_img
+        let previous_f32 = previous
             .cast::<f32>()
             .expect("u8 -> f32 image cast is always representable");
-        let next_f32 = next_img
+        let current_f32 = current
             .cast::<f32>()
             .expect("u8 -> f32 image cast is always representable");
-
-        let prev_pts = self.pixels();
+        let previous_pixels: Vec<[f32; 2]> = tracks.iter().map(Track::pixel).collect();
+        let mut params = self.params.clone();
+        params.use_initial_flow = initial_pixels.is_some();
         let result = calc_optical_flow_pyr_lk(
-            &prev_f32,
-            &next_f32,
-            &prev_pts,
-            None,
-            &config.to_pyr_lk_params(),
+            &previous_f32,
+            &current_f32,
+            &previous_pixels,
+            initial_pixels,
+            &params,
         )?;
 
-        let width = next_img.width() as f32;
-        let height = next_img.height() as f32;
-        let margin = config.border_margin_px;
-
-        let mut survivors = Vec::with_capacity(self.tracks.len());
-        for (i, track) in self.tracks.iter().enumerate() {
-            if result.status[i] == 0 {
-                continue; // KLT itself failed for this point.
+        let width = current.width() as f32;
+        let height = current.height() as f32;
+        let mut survivors = Vec::with_capacity(tracks.len());
+        for (index, track) in tracks.iter().enumerate() {
+            let next_pt = result.next_pts[index];
+            if Self::accepts(
+                track,
+                result.status[index],
+                result.error[index],
+                next_pt,
+                [width, height],
+                &self.survivor_filter,
+            ) {
+                survivors.push(FlowSurvivor {
+                    track_id: track.id,
+                    pixel: next_pt,
+                    error: result.error[index],
+                });
             }
-            if result.error[i] > config.max_error {
-                continue;
-            }
-            let next_pt = result.next_pts[i];
-            if next_pt[0] < margin
-                || next_pt[1] < margin
-                || next_pt[0] > width - margin
-                || next_pt[1] > height - margin
-            {
-                continue; // Too close to the edge to trust.
-            }
-            let dx = next_pt[0] - track.pixel[0];
-            let dy = next_pt[1] - track.pixel[1];
-            if (dx * dx + dy * dy).sqrt() > config.max_movement_px {
-                continue; // Implausible jump — likely aliased onto the wrong patch.
-            }
-            survivors.push(Track {
-                track_id: track.track_id,
-                pixel: next_pt,
-                map_point_idx: track.map_point_idx,
-                age: track.age + 1,
-            });
         }
         Ok(survivors)
     }
 
-    /// Rebuilds tracks from `(map_point_idx, keypoint_idx)` matches, preserving
-    /// identity and age for map points already present in the state.
-    pub fn refresh_from_matches(&mut self, matches: &[(usize, usize)], keypoints: &[[f32; 2]]) {
-        let mut old_by_mp: HashMap<usize, Track> = self
-            .tracks
-            .drain(..)
-            .filter_map(|t| t.map_point_idx.map(|mp| (mp, t)))
-            .collect();
-
-        let mut new_tracks = Vec::with_capacity(matches.len());
-        for &(mp_idx, kp_idx) in matches {
-            let Some(&pixel) = keypoints.get(kp_idx) else {
-                continue;
-            };
-            let track = match old_by_mp.remove(&mp_idx) {
-                Some(old) => Track {
-                    track_id: old.track_id,
-                    pixel,
-                    map_point_idx: Some(mp_idx),
-                    age: old.age + 1,
-                },
-                None => {
-                    let mut t = self.new_track(pixel);
-                    t.map_point_idx = Some(mp_idx);
-                    t
-                }
-            };
-            new_tracks.push(track);
+    fn accepts(
+        track: &Track,
+        status: u8,
+        error: f32,
+        next_pixel: [f32; 2],
+        image_size: [f32; 2],
+        filter: &SurvivorFilterConfig,
+    ) -> bool {
+        if status == 0 || !error.is_finite() || error > filter.max_error {
+            return false;
         }
-        self.tracks = new_tracks;
+        if !next_pixel[0].is_finite() || !next_pixel[1].is_finite() {
+            return false;
+        }
+        let margin = filter.border_margin_px;
+        if next_pixel[0] < margin
+            || next_pixel[1] < margin
+            || next_pixel[0] > image_size[0] - margin
+            || next_pixel[1] > image_size[1] - margin
+        {
+            return false;
+        }
+        let dx = next_pixel[0] - track.pixel[0];
+        let dy = next_pixel[1] - track.pixel[1];
+        let max_movement_sq = filter.max_movement_px * filter.max_movement_px;
+        dx * dx + dy * dy <= max_movement_sq
     }
 }
 
-/// Finds the nearest keypoint within `radius_px`.
-fn nearest_keypoint(predicted: [f32; 2], keypoints: &[[f32; 2]], radius_px: f32) -> Option<usize> {
-    let r2 = radius_px * radius_px;
-    let mut best: Option<(usize, f32)> = None;
-    for (i, &kp) in keypoints.iter().enumerate() {
-        let dx = kp[0] - predicted[0];
-        let dy = kp[1] - predicted[1];
-        let d2 = dx * dx + dy * dy;
-        if d2 > r2 {
+/// Deterministically snaps associated survivors to unique detected keypoints.
+///
+/// Candidates are considered greedily by distance, then track ID and
+/// keypoint index. This guarantees one-to-one output but does not promise a
+/// globally maximum-cardinality assignment.
+pub fn snap_unique(
+    tracks: &TrackSet,
+    survivors: &[FlowSurvivor],
+    keypoints: &[[f32; 2]],
+    radius_px: f32,
+) -> Result<Vec<KeypointCorrespondence>, TrackSetError> {
+    let by_id: HashMap<TrackId, &Track> = tracks
+        .tracks
+        .iter()
+        .map(|track| (track.id, track))
+        .collect();
+    let mut seen_survivors = HashSet::with_capacity(survivors.len());
+    for survivor in survivors {
+        if !by_id.contains_key(&survivor.track_id) {
+            return Err(TrackSetError::UnknownTrackId(survivor.track_id));
+        }
+        if !seen_survivors.insert(survivor.track_id) {
+            return Err(TrackSetError::DuplicateTrackId(survivor.track_id));
+        }
+    }
+
+    if radius_px < 0.0 || !radius_px.is_finite() {
+        return Ok(Vec::new());
+    }
+    let radius_sq = radius_px * radius_px;
+    let mut candidates = Vec::new();
+    for survivor in survivors {
+        let track = by_id[&survivor.track_id];
+        let Some(map_point_idx) = track.map_point_idx else {
+            continue;
+        };
+        if !survivor.pixel[0].is_finite() || !survivor.pixel[1].is_finite() {
             continue;
         }
-        match best {
-            Some((_, best_d2)) if d2 >= best_d2 => {}
-            _ => best = Some((i, d2)),
+        for (keypoint_idx, keypoint) in keypoints.iter().enumerate() {
+            let dx = keypoint[0] - survivor.pixel[0];
+            let dy = keypoint[1] - survivor.pixel[1];
+            let distance_sq = dx * dx + dy * dy;
+            if distance_sq.is_finite() && distance_sq <= radius_sq {
+                candidates.push(KeypointCorrespondence {
+                    track_id: survivor.track_id,
+                    map_point_idx,
+                    keypoint_idx,
+                    distance_sq,
+                });
+            }
         }
     }
-    best.map(|(i, _)| i)
-}
 
-/// Snaps associated survivors to detected keypoints, producing
-/// `(map_point_idx, keypoint_idx)` correspondences.
-pub fn snap_survivors(
-    survivors: &[Track],
-    curr_keypoints: &[[f32; 2]],
-    snap_radius_px: f32,
-) -> Vec<(usize, usize)> {
-    let mut correspondences = Vec::new();
-    for t in survivors {
-        if let Some(mp_idx) = t.map_point_idx
-            && let Some(kp_idx) = nearest_keypoint(t.pixel, curr_keypoints, snap_radius_px)
+    candidates.sort_by(|left, right| {
+        left.distance_sq
+            .total_cmp(&right.distance_sq)
+            .then_with(|| left.track_id.cmp(&right.track_id))
+            .then_with(|| left.keypoint_idx.cmp(&right.keypoint_idx))
+            .then_with(|| left.map_point_idx.cmp(&right.map_point_idx))
+    });
+
+    let mut used_tracks = HashSet::new();
+    let mut used_map_points = HashSet::new();
+    let mut used_keypoints = HashSet::new();
+    let mut accepted = Vec::new();
+    for candidate in candidates {
+        if used_tracks.contains(&candidate.track_id)
+            || used_map_points.contains(&candidate.map_point_idx)
+            || used_keypoints.contains(&candidate.keypoint_idx)
         {
-            correspondences.push((mp_idx, kp_idx));
+            continue;
         }
+        used_tracks.insert(candidate.track_id);
+        used_map_points.insert(candidate.map_point_idx);
+        used_keypoints.insert(candidate.keypoint_idx);
+        accepted.push(candidate);
     }
-    correspondences
-}
-
-/// Tracks existing points and snaps survivors to current-frame keypoints.
-pub fn klt_correspondences(
-    track_state: &TrackState,
-    prev_img: &Image<u8, 1>,
-    next_img: &Image<u8, 1>,
-    curr_keypoints: &[[f32; 2]],
-    config: &OpticalFlowConfig,
-    snap_radius_px: f32,
-) -> Result<Vec<(usize, usize)>, PyrLKError> {
-    let survivors = track_state.track(prev_img, next_img, config)?;
-    Ok(snap_survivors(&survivors, curr_keypoints, snap_radius_px))
+    Ok(accepted)
 }
 
 #[cfg(test)]
@@ -289,22 +474,192 @@ mod tests {
     use kornia_image::ImageSize;
 
     #[test]
-    fn new_track_gets_unique_ids() {
-        let mut state = TrackState::new();
-        let a = state.new_track([1.0, 2.0]);
-        let b = state.new_track([3.0, 4.0]);
-        assert_ne!(a.track_id, b.track_id);
-        assert_eq!(a.map_point_idx, None);
-        assert_eq!(a.age, 1);
+    fn spawn_inserts_tracks_with_unique_ids() {
+        let mut tracks = TrackSet::new();
+        let a = tracks.spawn([1.0, 2.0]);
+        let b = tracks.spawn([3.0, 4.0]);
+
+        assert_ne!(a, b);
+        assert_eq!(a.as_u64(), 0);
+        assert_eq!(b.as_u64(), 1);
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks.tracks()[0].id(), a);
+        assert_eq!(tracks.tracks()[0].pixel(), [1.0, 2.0]);
+        assert_eq!(tracks.tracks()[0].map_point_idx(), None);
+        assert_eq!(tracks.tracks()[0].age(), 1);
     }
 
     #[test]
-    fn pixels_are_positional_with_tracks() {
-        let mut state = TrackState::new();
-        let t0 = state.new_track([1.0, 2.0]);
-        let t1 = state.new_track([3.0, 4.0]);
-        state.set_tracks(vec![t0, t1]);
-        assert_eq!(state.pixels(), vec![[1.0, 2.0], [3.0, 4.0]]);
+    fn advance_replaces_tracks_and_increments_age_once() {
+        let mut tracks = TrackSet::new();
+        let kept = tracks.spawn([1.0, 2.0]);
+        tracks.spawn([3.0, 4.0]);
+
+        tracks
+            .advance(vec![FlowSurvivor {
+                track_id: kept,
+                pixel: [2.0, 3.0],
+                error: 0.5,
+            }])
+            .unwrap();
+
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks.tracks()[0].id(), kept);
+        assert_eq!(tracks.tracks()[0].pixel(), [2.0, 3.0]);
+        assert_eq!(tracks.tracks()[0].age(), 2);
+    }
+
+    #[test]
+    fn advance_rejects_unknown_and_duplicate_ids_transactionally() {
+        let mut tracks = TrackSet::new();
+        let id = tracks.spawn([1.0, 2.0]);
+        let before = tracks.tracks().to_vec();
+
+        let duplicate = FlowSurvivor {
+            track_id: id,
+            pixel: [2.0, 3.0],
+            error: 0.5,
+        };
+        assert_eq!(
+            tracks.advance(vec![duplicate, duplicate]),
+            Err(TrackSetError::DuplicateTrackId(id))
+        );
+        assert_eq!(tracks.tracks(), before);
+
+        let unknown = TrackId(u64::MAX);
+        assert_eq!(
+            tracks.advance(vec![FlowSurvivor {
+                track_id: unknown,
+                pixel: [2.0, 3.0],
+                error: 0.5,
+            }]),
+            Err(TrackSetError::UnknownTrackId(unknown))
+        );
+        assert_eq!(tracks.tracks(), before);
+    }
+
+    #[test]
+    fn reconcile_preserves_identity_and_validates_matches() {
+        let mut tracks = TrackSet::new();
+        tracks
+            .reconcile_from_matches(
+                &[MapKeypointMatch {
+                    map_point_idx: 42,
+                    keypoint_idx: 0,
+                }],
+                &[[1.0, 2.0]],
+            )
+            .unwrap();
+        let id_42 = tracks.tracks()[0].id();
+
+        tracks
+            .reconcile_from_matches(
+                &[
+                    MapKeypointMatch {
+                        map_point_idx: 42,
+                        keypoint_idx: 0,
+                    },
+                    MapKeypointMatch {
+                        map_point_idx: 7,
+                        keypoint_idx: 1,
+                    },
+                ],
+                &[[5.0, 6.0], [10.0, 11.0]],
+            )
+            .unwrap();
+
+        let retained = tracks
+            .tracks()
+            .iter()
+            .find(|track| track.map_point_idx() == Some(42))
+            .unwrap();
+        assert_eq!(retained.id(), id_42);
+        assert_eq!(retained.age(), 2);
+        assert_eq!(retained.pixel(), [5.0, 6.0]);
+
+        let new = tracks
+            .tracks()
+            .iter()
+            .find(|track| track.map_point_idx() == Some(7))
+            .unwrap();
+        assert_ne!(new.id(), id_42);
+        assert_eq!(new.age(), 1);
+        let new_id = new.id();
+        let spawned_after_reconcile = tracks.spawn([20.0, 21.0]);
+        assert_ne!(spawned_after_reconcile, id_42);
+        assert_ne!(spawned_after_reconcile, new_id);
+
+        let before = tracks.tracks().to_vec();
+        assert_eq!(
+            tracks.reconcile_from_matches(
+                &[
+                    MapKeypointMatch {
+                        map_point_idx: 42,
+                        keypoint_idx: 0,
+                    },
+                    MapKeypointMatch {
+                        map_point_idx: 42,
+                        keypoint_idx: 1,
+                    },
+                ],
+                &[[0.0, 0.0], [1.0, 1.0]],
+            ),
+            Err(TrackSetError::DuplicateMapPoint(42))
+        );
+        assert_eq!(tracks.tracks(), before);
+
+        assert_eq!(
+            tracks.reconcile_from_matches(
+                &[
+                    MapKeypointMatch {
+                        map_point_idx: 42,
+                        keypoint_idx: 0,
+                    },
+                    MapKeypointMatch {
+                        map_point_idx: 7,
+                        keypoint_idx: 0,
+                    },
+                ],
+                &[[0.0, 0.0]],
+            ),
+            Err(TrackSetError::DuplicateKeypoint(0))
+        );
+        assert_eq!(tracks.tracks(), before);
+
+        assert_eq!(
+            tracks.reconcile_from_matches(
+                &[MapKeypointMatch {
+                    map_point_idx: 42,
+                    keypoint_idx: 3,
+                }],
+                &[[0.0, 0.0]],
+            ),
+            Err(TrackSetError::InvalidKeypointIndex(3))
+        );
+        assert_eq!(tracks.tracks(), before);
+    }
+
+    #[test]
+    fn age_saturates_at_u32_max() {
+        let id = TrackId(0);
+        let mut tracks = TrackSet {
+            next_id: 1,
+            tracks: vec![Track {
+                id,
+                pixel: [1.0, 2.0],
+                map_point_idx: None,
+                age: u32::MAX,
+            }],
+        };
+
+        tracks
+            .advance(vec![FlowSurvivor {
+                track_id: id,
+                pixel: [2.0, 3.0],
+                error: 0.0,
+            }])
+            .unwrap();
+        assert_eq!(tracks.tracks()[0].age(), u32::MAX);
     }
 
     /// Builds a black image with a white square whose corner is trackable.
@@ -331,13 +686,11 @@ mod tests {
         let prev_img = square_image([90, 90]);
         let next_img = square_image([93, 92]); // shifted by (+3, +2)
 
-        let mut state = TrackState::new();
-        // Seed the square's top-left corner, which has gradients on both axes.
-        let t = state.new_track([90.0, 90.0]);
-        state.set_tracks(vec![t]);
+        let mut tracks = TrackSet::new();
+        let id = tracks.spawn([90.0, 90.0]);
 
-        let survivors = state
-            .track(&prev_img, &next_img, &OpticalFlowConfig::default())
+        let survivors = KltTracker::default()
+            .track(tracks.tracks(), &prev_img, &next_img)
             .expect("KLT should succeed on a clean synthetic shift");
 
         assert_eq!(survivors.len(), 1, "the corner should track successfully");
@@ -346,30 +699,235 @@ mod tests {
             (got[0] - 93.0).abs() < 1.5 && (got[1] - 92.0).abs() < 1.5,
             "expected tracked pixel near (93, 92), got {got:?}"
         );
-        assert_eq!(survivors[0].track_id, t.track_id);
-        assert_eq!(survivors[0].age, 2);
+        assert_eq!(survivors[0].track_id, id);
     }
 
     #[test]
-    fn refresh_from_matches_preserves_identity_for_known_map_points() {
-        let mut state = TrackState::new();
-        let mut t0 = state.new_track([1.0, 2.0]);
-        t0.map_point_idx = Some(42);
-        state.set_tracks(vec![t0]);
+    fn tracker_handles_empty_and_explicit_initial_flow() {
+        let image = square_image([90, 90]);
+        let params = PyrLKParams {
+            use_initial_flow: true,
+            ..PyrLKParams::default()
+        };
+        let tracker = KltTracker::new(params, SurvivorFilterConfig::default());
+        assert!(tracker.track(&[], &image, &image).unwrap().is_empty());
 
-        // Map point 42 persists while map point 7 appears for the first time.
-        let keypoints = [[5.0, 6.0], [10.0, 11.0]];
-        state.refresh_from_matches(&[(42, 0), (7, 1)], &keypoints);
+        let mut tracks = TrackSet::new();
+        tracks.spawn([90.0, 90.0]);
+        let mismatch = tracker
+            .track_with_initial(tracks.tracks(), &[], &image, &image)
+            .unwrap_err();
+        assert!(matches!(
+            mismatch,
+            PyrLKError::InitialFlowLengthMismatch {
+                expected: 1,
+                provided: 0
+            }
+        ));
 
-        let tracks = state.tracks();
-        assert_eq!(tracks.len(), 2);
-        let mp42 = tracks.iter().find(|t| t.map_point_idx == Some(42)).unwrap();
-        assert_eq!(mp42.track_id, t0.track_id, "identity must carry forward");
-        assert_eq!(mp42.age, 2);
-        assert_eq!(mp42.pixel, [5.0, 6.0]);
+        // `track` overrides a configured true flag because no initial pixels
+        // were supplied through its type-level contract.
+        assert_eq!(
+            tracker
+                .track(tracks.tracks(), &image, &image)
+                .unwrap()
+                .len(),
+            1
+        );
 
-        let mp7 = tracks.iter().find(|t| t.map_point_idx == Some(7)).unwrap();
-        assert_ne!(mp7.track_id, t0.track_id, "new map point gets a fresh id");
-        assert_eq!(mp7.age, 1);
+        let shifted = square_image([93, 92]);
+        let survivors = tracker
+            .track_with_initial(tracks.tracks(), &[[93.0, 92.0]], &image, &shifted)
+            .unwrap();
+        assert_eq!(survivors.len(), 1);
+        assert!((survivors[0].pixel[0] - 93.0).abs() < 1.5);
+        assert!((survivors[0].pixel[1] - 92.0).abs() < 1.5);
+    }
+
+    #[test]
+    fn survivor_filters_reject_each_failure_mode() {
+        let filter = SurvivorFilterConfig::default();
+        let track = Track {
+            id: TrackId(0),
+            pixel: [50.0, 50.0],
+            map_point_idx: None,
+            age: 1,
+        };
+
+        assert!(!KltTracker::accepts(
+            &track,
+            0,
+            0.0,
+            [51.0, 51.0],
+            [100.0, 100.0],
+            &filter
+        ));
+        assert!(!KltTracker::accepts(
+            &track,
+            1,
+            filter.max_error + 1.0,
+            [51.0, 51.0],
+            [100.0, 100.0],
+            &filter,
+        ));
+        assert!(!KltTracker::accepts(
+            &track,
+            1,
+            0.0,
+            [track.pixel()[0] + filter.max_movement_px + 1.0, 50.0],
+            [200.0, 200.0],
+            &filter,
+        ));
+        assert!(!KltTracker::accepts(
+            &track,
+            1,
+            0.0,
+            [filter.border_margin_px - 1.0, 50.0],
+            [100.0, 100.0],
+            &filter,
+        ));
+        assert!(KltTracker::accepts(
+            &track,
+            1,
+            0.0,
+            [51.0, 51.0],
+            [100.0, 100.0],
+            &filter,
+        ));
+    }
+
+    fn associated_tracks() -> TrackSet {
+        let mut tracks = TrackSet::new();
+        tracks
+            .reconcile_from_matches(
+                &[
+                    MapKeypointMatch {
+                        map_point_idx: 10,
+                        keypoint_idx: 0,
+                    },
+                    MapKeypointMatch {
+                        map_point_idx: 20,
+                        keypoint_idx: 1,
+                    },
+                ],
+                &[[10.0, 10.0], [12.0, 10.0]],
+            )
+            .unwrap();
+        tracks
+    }
+
+    #[test]
+    fn snapping_is_unique_and_deterministic() {
+        let tracks = associated_tracks();
+        let a = tracks.tracks()[0].id();
+        let b = tracks.tracks()[1].id();
+        let survivors = [
+            FlowSurvivor {
+                track_id: a,
+                pixel: [10.0, 10.0],
+                error: 0.0,
+            },
+            FlowSurvivor {
+                track_id: b,
+                pixel: [10.0, 10.0],
+                error: 0.0,
+            },
+        ];
+
+        let first = snap_unique(&tracks, &survivors, &[[10.0, 10.0]], 3.0).unwrap();
+        let second = snap_unique(&tracks, &survivors, &[[10.0, 10.0]], 3.0).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].track_id, a.min(b));
+        assert_eq!(first[0].keypoint_idx, 0);
+    }
+
+    #[test]
+    fn snapping_uses_nearest_keypoint_and_omits_invalid_candidates() {
+        let mut tracks = associated_tracks();
+        let associated = tracks.tracks()[0].id();
+        let unassociated = tracks.spawn([50.0, 50.0]);
+        let survivors = [
+            FlowSurvivor {
+                track_id: associated,
+                pixel: [11.0, 10.0],
+                error: 0.0,
+            },
+            FlowSurvivor {
+                track_id: unassociated,
+                pixel: [50.0, 50.0],
+                error: 0.0,
+            },
+        ];
+
+        let matches = snap_unique(
+            &tracks,
+            &survivors,
+            &[[9.0, 10.0], [11.25, 10.0], [100.0, 100.0]],
+            3.0,
+        )
+        .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].keypoint_idx, 1);
+        assert_eq!(matches[0].distance_sq, 0.0625);
+
+        let unknown = TrackId(u64::MAX);
+        assert_eq!(
+            snap_unique(
+                &tracks,
+                &[FlowSurvivor {
+                    track_id: unknown,
+                    pixel: [0.0, 0.0],
+                    error: 0.0,
+                }],
+                &[],
+                3.0,
+            ),
+            Err(TrackSetError::UnknownTrackId(unknown))
+        );
+
+        assert_eq!(
+            snap_unique(&tracks, &[survivors[0], survivors[0]], &[], 3.0),
+            Err(TrackSetError::DuplicateTrackId(associated))
+        );
+    }
+
+    #[test]
+    fn snapping_never_emits_a_duplicate_map_point() {
+        let a = TrackId(0);
+        let b = TrackId(1);
+        let tracks = TrackSet {
+            next_id: 2,
+            tracks: vec![
+                Track {
+                    id: a,
+                    pixel: [10.0, 10.0],
+                    map_point_idx: Some(42),
+                    age: 1,
+                },
+                Track {
+                    id: b,
+                    pixel: [20.0, 20.0],
+                    map_point_idx: Some(42),
+                    age: 1,
+                },
+            ],
+        };
+        let survivors = [
+            FlowSurvivor {
+                track_id: a,
+                pixel: [10.0, 10.0],
+                error: 0.0,
+            },
+            FlowSurvivor {
+                track_id: b,
+                pixel: [20.0, 20.0],
+                error: 0.0,
+            },
+        ];
+
+        let matches = snap_unique(&tracks, &survivors, &[[10.0, 10.0], [20.0, 20.0]], 1.0).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].map_point_idx, 42);
     }
 }


### PR DESCRIPTION
## Summary

- add persistent KLT feature identity and map-point associations
- make `TrackSet` the sole owner of track identity, age, and lifecycle transitions
- separate stateless numerical flow into `KltTracker`, composing upstream `PyrLKParams` with SLAM-specific survivor filtering
- require initial-flow positions explicitly rather than exposing an incomplete boolean-only configuration
- enforce deterministic one-to-one snapping across tracks, map points, and detected keypoints
- cover lifecycle validation, known shifts, initial flow, survivor filters, and matching conflicts with focused tests

## API boundaries

- `TrackId` prevents mixing track identities with map-point and keypoint indices.
- `TrackSet::spawn`, `advance`, and `reconcile_from_matches` are the only public lifecycle transitions.
- Invalid and duplicate transition inputs return `TrackSetError` without partially changing state.
- `KltTracker::track` and `track_with_initial` compute `FlowSurvivor` records without mutating persistent state.
- `snap_unique` returns named `KeypointCorrespondence` records using deterministic greedy assignment.

## Scope

This is the next focused extraction from #54, based on the current `develop` after #61. It intentionally contains only reusable KLT optical-flow primitives and tests.

Pipeline integration, CLI controls, geometric filtering, robust PnP, skipped-frame recovery, and telemetry remain for later PRs.

## Authorship

- `84634bb` reconstructs the implementation from Astik's original commit `4596336`, preserving Astik as the author and preserving the original author date.
- `793e60a` is a Christie-authored comment-only cleanup.
- `dc357f1` is a Christie-authored ownership and API refactor completed before the new API has downstream consumers.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p kornia-slam estimation::optical_flow` (11 passed)
- `cargo test -p kornia-slam` (47 passed)
- `cargo test -p orb_slam` (20 passed)
- `cargo check --workspace`
- `cargo clippy --all-targets -- -D warnings`

The comment-cleanup commit was mechanically checked after removing comments and blank lines from both revisions; executable code in Astik's implementation commit is unchanged.
