### PR TITLE
slam: harden pose estimation against outliers

### DIFF
--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -22,9 +22,11 @@
 
 mod keypoint_grid;
 
+use std::collections::HashMap;
+
 use kornia_3d::camera::PinholeCamera;
-use kornia_3d::pose::Pose3d;
-use kornia_algebra::Vec2F32;
+use kornia_3d::pose::{Pose3d, RansacParams, ransac_fundamental};
+use kornia_algebra::{Vec2F32, Vec2F64};
 use kornia_image::ImageSize;
 use kornia_imgproc::features::hamming_distance;
 
@@ -32,7 +34,7 @@ use super::pnp::{self, PnpConfig};
 use kornia_imgproc::features::{OrbMatchConfig, match_orb_descriptors};
 
 use crate::frame::Frame;
-use crate::map::{Map, MapPoint, ORB_N_LEVELS, ORB_SCALE_FACTOR};
+use crate::map::{Keyframe, Map, MapPoint, ORB_N_LEVELS, ORB_SCALE_FACTOR};
 
 use super::Estimate;
 use keypoint_grid::KeypointGrid;
@@ -79,6 +81,8 @@ pub struct MapProjectionConfig {
     pub search_widen_per_sec: f32,
     /// Upper bound on `search_scale` (see `search_scale_for`).
     pub max_search_scale: f32,
+    /// Fundamental-matrix RANSAC inlier threshold in pixels.
+    pub geometric_filter_threshold_px: f64,
 }
 
 impl Default for MapProjectionConfig {
@@ -99,6 +103,7 @@ impl Default for MapProjectionConfig {
             },
             search_widen_per_sec: 1.0,
             max_search_scale: 4.0,
+            geometric_filter_threshold_px: 1.0,
         }
     }
 }
@@ -188,6 +193,12 @@ impl MapProjectionEstimator {
         let try_track_and_refine = |correspondences: Vec<(usize, usize)>,
                                     pose_init: &Pose3d|
          -> Result<Estimate, MapProjectionRejectReason> {
+            let correspondences = self.geometric_consistency_filter(
+                current_kf,
+                &correspondences,
+                &curr_keypoints_undist,
+                camera,
+            );
             let (mut pose, mut inliers) = self
                 .solve_pnp(
                     map.map_points(),
@@ -270,6 +281,69 @@ impl MapProjectionEstimator {
         }
 
         try_track_and_refine(ref_correspondences, pose_before_tracking)
+    }
+
+    /// Reject matches that disagree with reference-to-current epipolar geometry.
+    /// Matches without a reference-keyframe observation remain unfiltered.
+    fn geometric_consistency_filter(
+        &self,
+        current_kf: Option<&Keyframe>,
+        correspondences: &[(usize, usize)],
+        curr_keypoints_undist: &[[f32; 2]],
+        camera: &PinholeCamera,
+    ) -> Vec<(usize, usize)> {
+        const MIN_PAIRS_FOR_FILTER: usize = 8;
+
+        let Some(current_kf) = current_kf else {
+            return correspondences.to_vec();
+        };
+        let mp_to_desc: HashMap<usize, usize> = current_kf
+            .map_point_by_desc_idx
+            .iter()
+            .enumerate()
+            .filter_map(|(desc_idx, mp_idx)| mp_idx.map(|mp_idx| (mp_idx, desc_idx)))
+            .collect();
+
+        let mut checkable_indices = Vec::new();
+        let mut reference_points = Vec::new();
+        let mut current_points = Vec::new();
+        for (index, &(mp_idx, kp_idx)) in correspondences.iter().enumerate() {
+            let Some(&desc_idx) = mp_to_desc.get(&mp_idx) else {
+                continue;
+            };
+            let Some(reference) = current_kf.frame.undistorted_xy(desc_idx, camera) else {
+                continue;
+            };
+            let Some(&current) = curr_keypoints_undist.get(kp_idx) else {
+                continue;
+            };
+            checkable_indices.push(index);
+            reference_points.push(Vec2F64::new(reference[0] as f64, reference[1] as f64));
+            current_points.push(Vec2F64::new(current[0] as f64, current[1] as f64));
+        }
+
+        if checkable_indices.len() < MIN_PAIRS_FOR_FILTER {
+            return correspondences.to_vec();
+        }
+        let params = RansacParams {
+            threshold: self.config.geometric_filter_threshold_px,
+            ..RansacParams::default()
+        };
+        let Ok(result) = ransac_fundamental(&reference_points, &current_points, &params) else {
+            return correspondences.to_vec();
+        };
+
+        let mut keep = vec![true; correspondences.len()];
+        for (&index, &is_inlier) in checkable_indices.iter().zip(&result.inliers) {
+            if !is_inlier {
+                keep[index] = false;
+            }
+        }
+        correspondences
+            .iter()
+            .zip(keep)
+            .filter_map(|(&correspondence, keep)| keep.then_some(correspondence))
+            .collect()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -620,6 +620,7 @@ mod estimator_tests {
 mod matching_tests {
     use super::*;
     use kornia_algebra::{Mat3F64, Vec3F64};
+    use kornia_imgproc::features::OrbFeatures;
 
     fn make_test_estimator() -> MapProjectionEstimator {
         MapProjectionEstimator::new(MapProjectionConfig::default())
@@ -636,6 +637,116 @@ mod matching_tests {
             p1: 0.0,
             p2: 0.0,
         }
+    }
+
+    fn test_frame(keypoints: Vec<[f32; 2]>) -> Frame {
+        let count = keypoints.len();
+        Frame {
+            idx: 0,
+            features: OrbFeatures {
+                keypoints_xy: keypoints.clone(),
+                orientations: vec![0.0; count],
+                descriptors: vec![[0; 32]; count],
+                octaves: vec![0; count],
+            },
+            pose_world_to_cam: Pose3d::IDENTITY,
+            image_size: ImageSize {
+                width: 640,
+                height: 480,
+            },
+            keypoint_colors: vec![[0; 3]; count],
+            u_right: Vec::new(),
+            depth: Vec::new(),
+            keypoints_undist: keypoints,
+        }
+    }
+
+    fn two_view_keypoints(camera: &PinholeCamera, count: usize) -> (Vec<[f32; 2]>, Vec<[f32; 2]>) {
+        let angle = 5.0_f64.to_radians();
+        let (sin, cos) = angle.sin_cos();
+        let rotation = Mat3F64::from_cols(
+            Vec3F64::new(cos, 0.0, -sin),
+            Vec3F64::new(0.0, 1.0, 0.0),
+            Vec3F64::new(sin, 0.0, cos),
+        );
+        let current_pose = Pose3d::new(rotation, Vec3F64::new(0.2, 0.05, 0.0));
+        let mut random_state = 12_345_678_901_234_567_u64;
+        let random = |state: &mut u64| -> f64 {
+            *state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (*state >> 32) as f64 / 4_294_967_296.0
+        };
+        let mut reference = Vec::with_capacity(count);
+        let mut current = Vec::with_capacity(count);
+        for _ in 0..count {
+            let point = Vec3F64::new(
+                (random(&mut random_state) - 0.5) * 3.0,
+                (random(&mut random_state) - 0.5) * 2.0,
+                random(&mut random_state) * 3.0 + 3.0,
+            );
+            let reference_pixel = camera.project_to_pixel(&point, 0.0).unwrap();
+            let current_pixel = camera
+                .project_to_pixel(&current_pose.transform_point(&point), 0.0)
+                .unwrap();
+            reference.push([reference_pixel.x as f32, reference_pixel.y as f32]);
+            current.push([current_pixel.x as f32, current_pixel.y as f32]);
+        }
+        (reference, current)
+    }
+
+    #[test]
+    fn geometric_filter_rejects_epipolar_outlier() {
+        let estimator = make_test_estimator();
+        let camera = test_camera();
+        let (reference, mut current) = two_view_keypoints(&camera, 30);
+        current[29] = [80.0, 430.0];
+        current.push([10.0, 10.0]);
+
+        let mut keyframe = Keyframe::from_frame(test_frame(reference));
+        for index in 0..30 {
+            keyframe.associate_map_point(index, index);
+        }
+        let mut correspondences: Vec<(usize, usize)> = (0..30).map(|i| (i, i)).collect();
+        let uncheckable = (1000, 30);
+        correspondences.push(uncheckable);
+
+        let filtered = estimator.geometric_consistency_filter(
+            Some(&keyframe),
+            &correspondences,
+            &current,
+            &camera,
+        );
+
+        assert!(!filtered.contains(&(29, 29)));
+        assert!(filtered.contains(&uncheckable));
+        assert_eq!(filtered.len(), 30);
+    }
+
+    #[test]
+    fn geometric_filter_is_noop_without_enough_reference_pairs() {
+        let estimator = make_test_estimator();
+        let camera = test_camera();
+        let (reference, current) = two_view_keypoints(&camera, 7);
+        let mut keyframe = Keyframe::from_frame(test_frame(reference));
+        for index in 0..7 {
+            keyframe.associate_map_point(index, index);
+        }
+        let correspondences: Vec<(usize, usize)> = (0..7).map(|i| (i, i)).collect();
+
+        assert_eq!(
+            estimator.geometric_consistency_filter(
+                Some(&keyframe),
+                &correspondences,
+                &current,
+                &camera,
+            ),
+            correspondences
+        );
+        assert_eq!(
+            estimator.geometric_consistency_filter(None, &correspondences, &current, &camera),
+            correspondences
+        );
     }
 
     #[test]

--- a/crates/kornia-slam/src/estimation/pnp.rs
+++ b/crates/kornia-slam/src/estimation/pnp.rs
@@ -3,6 +3,7 @@
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pnp::{LMRefineParams, refine_pose_lm};
 use kornia_3d::pose::Pose3d;
+use kornia_3d::ransac::RobustKernelKind;
 use kornia_algebra::{Mat3AF32, Mat3F64, Vec2F32, Vec3AF32, Vec3F64};
 
 /// PnP pose-estimation thresholds.
@@ -18,6 +19,12 @@ pub struct PnpConfig {
     pub min_inliers_early: usize,
     /// Minimum inliers to accept a PnP solution.
     pub min_inliers: usize,
+    /// M-estimator kernel applied per residual during LM refinement.
+    pub robust: RobustKernelKind,
+    /// Squared robust-loss scale passed to the LM solver.
+    pub robust_scale_sq: f32,
+    /// Number of hard-exclusion refit rounds.
+    pub outlier_rounds: usize,
 }
 
 impl Default for PnpConfig {
@@ -28,8 +35,24 @@ impl Default for PnpConfig {
             min_correspondences: 4,
             min_inliers_early: 10,
             min_inliers: 30,
+            robust: RobustKernelKind::Huber,
+            robust_scale_sq: 25.0,
+            outlier_rounds: 4,
         }
     }
+}
+
+/// Diagnostic counts from a PnP attempt.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PnpDiagnostics {
+    /// Correspondences passed in before filtering.
+    pub input: usize,
+    /// Correspondences surviving the prior-pose reprojection filter.
+    pub prior_survivors: usize,
+    /// Correspondences entering the last refinement round that ran.
+    pub last_round_active: usize,
+    /// Whether the final LM round reported convergence.
+    pub converged: Option<bool>,
 }
 
 /// Solve PnP from 3D world points and 2D image points with LM refinement.
@@ -43,8 +66,23 @@ pub fn solve_pnp(
     pose_init: &Pose3d,
     config: &PnpConfig,
 ) -> Option<(Pose3d, usize)> {
+    solve_pnp_with_diagnostics(points_world_f64, points_image, camera, pose_init, config).0
+}
+
+/// Solves PnP and returns intermediate correspondence counts.
+pub fn solve_pnp_with_diagnostics(
+    points_world_f64: &[Vec3F64],
+    points_image: &[Vec2F32],
+    camera: &PinholeCamera,
+    pose_init: &Pose3d,
+    config: &PnpConfig,
+) -> (Option<(Pose3d, usize)>, PnpDiagnostics) {
+    let mut diagnostics = PnpDiagnostics {
+        input: points_world_f64.len(),
+        ..PnpDiagnostics::default()
+    };
     if points_world_f64.len() < config.min_correspondences {
-        return None;
+        return (None, diagnostics);
     }
 
     // Filter by reprojection error against the prior pose.
@@ -63,8 +101,9 @@ pub fn solve_pnp(
             prior_inlier_indices.push(i);
         }
     }
+    diagnostics.prior_survivors = prior_inlier_indices.len();
     if prior_inlier_indices.len() < config.min_correspondences {
-        return None;
+        return (None, diagnostics);
     }
 
     // Normalize for the f32 LM solver: express points relative to the prior
@@ -117,30 +156,90 @@ pub fn solve_pnp(
     // Normalized prior translation: t' = s * (t + R * center) = 0.
     let t_init_f32 = Vec3AF32::new(0.0, 0.0, 0.0);
 
-    let lm = refine_pose_lm(
-        &world_inliers,
-        &image_inliers,
-        &k,
-        &r_init_f32,
-        &t_init_f32,
-        None,
-        &LMRefineParams::default(),
-    )
-    .ok()?;
-
-    let r = &lm.rotation;
-    let t = lm.translation;
-    let r_new = Mat3F64::from_cols(
-        Vec3F64::new(r.col(0).x as f64, r.col(0).y as f64, r.col(0).z as f64),
-        Vec3F64::new(r.col(1).x as f64, r.col(1).y as f64, r.col(1).z as f64),
-        Vec3F64::new(r.col(2).x as f64, r.col(2).y as f64, r.col(2).z as f64),
-    );
     // Undo the similarity normalization: the LM pose maps
     // s*(w - center) -> cam, so the world-frame pose is
     // (R_lm, t_lm / s - R_lm * center).
-    let t_lm = Vec3F64::new(t.x as f64, t.y as f64, t.z as f64);
-    let t_new = t_lm / scale - r_new * center;
-    let pose_new = Pose3d::new(r_new, t_new);
+    let unnormalize = |rotation: &Mat3AF32, translation: Vec3AF32| -> Pose3d {
+        let rotation = Mat3F64::from_cols(
+            Vec3F64::new(
+                rotation.col(0).x as f64,
+                rotation.col(0).y as f64,
+                rotation.col(0).z as f64,
+            ),
+            Vec3F64::new(
+                rotation.col(1).x as f64,
+                rotation.col(1).y as f64,
+                rotation.col(1).z as f64,
+            ),
+            Vec3F64::new(
+                rotation.col(2).x as f64,
+                rotation.col(2).y as f64,
+                rotation.col(2).z as f64,
+            ),
+        );
+        let translation = Vec3F64::new(
+            translation.x as f64,
+            translation.y as f64,
+            translation.z as f64,
+        );
+        Pose3d::new(rotation, translation / scale - rotation * center)
+    };
+
+    // Every refinement round starts from the same prior. Between rounds,
+    // observations outside the final reprojection threshold are permanently
+    // removed so a bad intermediate solution cannot compound into the next.
+    let final_threshold_sq = config.final_reproj_threshold_px * config.final_reproj_threshold_px;
+    let rounds = config.outlier_rounds.max(1);
+    let mut active: Vec<usize> = (0..world_inliers.len()).collect();
+    let mut last_lm = None;
+    for round in 0..rounds {
+        if active.len() < config.min_correspondences {
+            return (None, diagnostics);
+        }
+        diagnostics.last_round_active = active.len();
+
+        let active_world: Vec<Vec3AF32> = active.iter().map(|&i| world_inliers[i]).collect();
+        let active_image: Vec<Vec2F32> = active.iter().map(|&i| image_inliers[i]).collect();
+        let Ok(lm) = refine_pose_lm(
+            &active_world,
+            &active_image,
+            &k,
+            &r_init_f32,
+            &t_init_f32,
+            None,
+            &LMRefineParams {
+                robust: config.robust,
+                robust_scale_sq: config.robust_scale_sq,
+                ..LMRefineParams::default()
+            },
+        ) else {
+            return (None, diagnostics);
+        };
+
+        if round + 1 < rounds {
+            let pose = unnormalize(&lm.rotation, lm.translation);
+            active.retain(|&i| {
+                let original_index = prior_inlier_indices[i];
+                camera
+                    .reprojection_error_sq_world(
+                        &pose,
+                        &points_world_f64[original_index],
+                        points_image[original_index].x as f64,
+                        points_image[original_index].y as f64,
+                    )
+                    .is_some_and(|error_sq| error_sq <= final_threshold_sq)
+            });
+        }
+        last_lm = Some(lm);
+    }
+    let Some(lm) = last_lm else {
+        return (None, diagnostics);
+    };
+
+    // The upstream convergence flag is diagnostic only. Real-data solves can
+    // reach the iteration cap while still producing a valid refined pose.
+    diagnostics.converged = lm.converged;
+    let pose_new = unnormalize(&lm.rotation, lm.translation);
 
     let final_inliers = count_reprojection_inliers(
         &pose_new,
@@ -150,7 +249,7 @@ pub fn solve_pnp(
         config.final_reproj_threshold_px,
     );
 
-    Some((pose_new, final_inliers))
+    (Some((pose_new, final_inliers)), diagnostics)
 }
 
 /// Count map-point reprojection inliers given a camera pose.

--- a/crates/kornia-slam/src/estimation/pnp.rs
+++ b/crates/kornia-slam/src/estimation/pnp.rs
@@ -272,3 +272,153 @@ pub fn count_reprojection_inliers(
     }
     inliers
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_camera() -> PinholeCamera {
+        PinholeCamera {
+            fx: 300.0,
+            fy: 300.0,
+            cx: 320.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        }
+    }
+
+    fn synthetic_correspondences(
+        camera: &PinholeCamera,
+        pose: &Pose3d,
+        count: usize,
+    ) -> (Vec<Vec3F64>, Vec<Vec2F32>) {
+        let points_world: Vec<Vec3F64> = (0..count)
+            .map(|i| {
+                let x = (i % 5) as f64 * 0.35 - 0.7;
+                let y = (i / 5) as f64 * 0.28 - 0.7;
+                let z = 4.0 + (i % 4) as f64 * 0.4;
+                Vec3F64::new(x, y, z)
+            })
+            .collect();
+        let points_image = points_world
+            .iter()
+            .map(|point| {
+                let point_camera = pose.transform_point(point);
+                let pixel = camera.project_to_pixel(&point_camera, 0.0).unwrap();
+                Vec2F32::new(pixel.x as f32, pixel.y as f32)
+            })
+            .collect();
+        (points_world, points_image)
+    }
+
+    #[test]
+    fn robust_defaults_match_tracking_configuration() {
+        let config = PnpConfig::default();
+
+        assert_eq!(config.robust, RobustKernelKind::Huber);
+        assert_eq!(config.robust_scale_sq, 25.0);
+        assert_eq!(config.outlier_rounds, 4);
+    }
+
+    #[test]
+    fn diagnostics_report_insufficient_input() {
+        let camera = test_camera();
+        let (points_world, points_image) = synthetic_correspondences(&camera, &Pose3d::IDENTITY, 3);
+
+        let (result, diagnostics) = solve_pnp_with_diagnostics(
+            &points_world,
+            &points_image,
+            &camera,
+            &Pose3d::IDENTITY,
+            &PnpConfig::default(),
+        );
+
+        assert!(result.is_none());
+        assert_eq!(diagnostics.input, 3);
+        assert_eq!(diagnostics.prior_survivors, 0);
+        assert_eq!(diagnostics.last_round_active, 0);
+    }
+
+    #[test]
+    fn diagnostics_report_prior_gate_starvation() {
+        let camera = test_camera();
+        let (points_world, mut points_image) =
+            synthetic_correspondences(&camera, &Pose3d::IDENTITY, 8);
+        for point in &mut points_image {
+            point.x += 100.0;
+        }
+        let config = PnpConfig {
+            prior_reproj_threshold_px: 1.0,
+            ..PnpConfig::default()
+        };
+
+        let (result, diagnostics) = solve_pnp_with_diagnostics(
+            &points_world,
+            &points_image,
+            &camera,
+            &Pose3d::IDENTITY,
+            &config,
+        );
+
+        assert!(result.is_none());
+        assert_eq!(diagnostics.prior_survivors, 0);
+        assert_eq!(diagnostics.last_round_active, 0);
+    }
+
+    #[test]
+    fn solves_clean_synthetic_correspondences() {
+        let camera = test_camera();
+        let expected_pose = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.1, -0.05, 0.15));
+        let (points_world, points_image) = synthetic_correspondences(&camera, &expected_pose, 24);
+        let config = PnpConfig {
+            prior_reproj_threshold_px: 50.0,
+            final_reproj_threshold_px: 1.0,
+            ..PnpConfig::default()
+        };
+
+        let (pose, inliers) = solve_pnp(
+            &points_world,
+            &points_image,
+            &camera,
+            &Pose3d::IDENTITY,
+            &config,
+        )
+        .expect("clean correspondences should solve");
+
+        assert_eq!(inliers, points_world.len());
+        assert!((pose.translation - expected_pose.translation).length() < 1e-3);
+    }
+
+    #[test]
+    fn exclusion_rounds_remove_reprojection_outliers() {
+        let camera = test_camera();
+        let expected_pose = Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.1, -0.05, 0.15));
+        let (points_world, mut points_image) =
+            synthetic_correspondences(&camera, &expected_pose, 30);
+        for point in points_image.iter_mut().step_by(6) {
+            point.x += 30.0;
+            point.y -= 20.0;
+        }
+        let config = PnpConfig {
+            prior_reproj_threshold_px: 100.0,
+            final_reproj_threshold_px: 2.0,
+            ..PnpConfig::default()
+        };
+
+        let (result, diagnostics) = solve_pnp_with_diagnostics(
+            &points_world,
+            &points_image,
+            &camera,
+            &Pose3d::IDENTITY,
+            &config,
+        );
+        let (_, inliers) = result.expect("robust solve should retain the inlier set");
+
+        assert_eq!(diagnostics.prior_survivors, points_world.len());
+        assert!(diagnostics.last_round_active < diagnostics.prior_survivors);
+        assert!(inliers >= 25);
+    }
+}


### PR DESCRIPTION
## Summary

- configure LM PnP with a 5 px Huber loss and four hard-exclusion refit rounds
- expose PnP diagnostics while retaining valid max-iteration solutions
- reject reference-to-current matches that disagree with a 1 px fundamental-matrix RANSAC model
- keep uncheckable matches and make the geometric filter a no-op when the evidence is insufficient
- add deterministic coverage for configuration, diagnostics, clean/outlier PnP solves, and geometric filtering

## Scope

This reconstructs the robust pose-estimation portion of original commit `d211f9e33b4ee660aae590ec98716ede30fb8c52` on top of the current `develop` branch. It deliberately excludes KLT pre-seeding/skipped-frame recovery, tracking diagnostics, telemetry, A/B controls, FPS logging, and unrelated evaluation changes.

## Authorship

- implementation: Astik-2002 <astik.srivastava@research.iiit.ac.in>, preserving the original author date
- tests: Christie Jacob <12036454+cjpurackal@users.noreply.github.com>

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p kornia-slam`
- `cargo test -p orb_slam`
- `cargo check --workspace`
- `cargo clippy --all-targets -- -D warnings`