### PR TITLE
slam: land KLT recovery and VI-BA robustification

### DIFF
--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -170,6 +170,7 @@ impl MapProjectionEstimator {
         camera: &PinholeCamera,
         current_keyframe_idx: Option<usize>,
         search_scale: f32,
+        pre_seeded: Option<Vec<(usize, usize)>>,
     ) -> Result<Estimate, MapProjectionRejectReason> {
         let pnp = &self.config.pnp;
 
@@ -239,6 +240,12 @@ impl MapProjectionEstimator {
             })
         };
 
+        if let Some(seeded) = Self::eligible_pre_seeded(pre_seeded, pnp.min_correspondences)
+            && let Ok(estimate) = try_track_and_refine(seeded, candidate_pose)
+        {
+            return Ok(estimate);
+        }
+
         // PnP from projection matches.
         let last_reject = if projection_matches.len() >= pnp.min_correspondences {
             match try_track_and_refine(projection_matches, candidate_pose) {
@@ -281,6 +288,13 @@ impl MapProjectionEstimator {
         }
 
         try_track_and_refine(ref_correspondences, pose_before_tracking)
+    }
+
+    fn eligible_pre_seeded(
+        pre_seeded: Option<Vec<(usize, usize)>>,
+        min_correspondences: usize,
+    ) -> Option<Vec<(usize, usize)>> {
+        pre_seeded.filter(|correspondences| correspondences.len() >= min_correspondences)
     }
 
     /// Reject matches that disagree with reference-to-current epipolar geometry.

--- a/crates/kornia-slam/src/estimation/map_projection/mod.rs
+++ b/crates/kornia-slam/src/estimation/map_projection/mod.rs
@@ -764,6 +764,21 @@ mod matching_tests {
     }
 
     #[test]
+    fn klt_source_is_eligible_at_minimum_size() {
+        let seeded = vec![(0, 0), (1, 1), (2, 2), (3, 3)];
+
+        assert_eq!(
+            MapProjectionEstimator::eligible_pre_seeded(Some(seeded.clone()), 4),
+            Some(seeded)
+        );
+        assert_eq!(
+            MapProjectionEstimator::eligible_pre_seeded(Some(vec![(0, 0); 3]), 4),
+            None
+        );
+        assert_eq!(MapProjectionEstimator::eligible_pre_seeded(None, 4), None);
+    }
+
+    #[test]
     fn test_match_by_projection_simple() {
         let estimator = make_test_estimator();
         let camera = test_camera();

--- a/crates/kornia-slam/src/vi_ba_schur.rs
+++ b/crates/kornia-slam/src/vi_ba_schur.rs
@@ -624,6 +624,10 @@ fn huber_imu_weight(res: &[f64; 15], omega: &[f64; 225], chi2_threshold: f64) ->
     }
 }
 
+fn visual_huber_weight(chi2: f64, chi2_threshold: f64) -> f64 {
+    HuberKernel.weight(chi2, chi2_threshold)
+}
+
 /// Diagonal information matrix from preintegrated IMU covariances.
 /// Uses diagonal approximation (off-diagonal terms ignored).
 /// Replace with full 15×15 inversion once FD tests pass.
@@ -911,7 +915,7 @@ pub fn visual_inertial_bundle_adjust(
             let jx_raw: [f64; 6] = std::array::from_fn(|i| jx_f32[i] as f64);
 
             let chi2_vis = r_raw[0] * r_raw[0] + r_raw[1] * r_raw[1];
-            let hw_vis = HuberKernel.weight(chi2_vis, params.huber_reproj_px_sq);
+            let hw_vis = visual_huber_weight(chi2_vis, params.huber_reproj_px_sq);
             cost_vis += 0.5 * hw_vis * chi2_vis;
             let sqrt_hw_vis = hw_vis.sqrt();
             let r = [r_raw[0] * sqrt_hw_vis, r_raw[1] * sqrt_hw_vis];
@@ -969,7 +973,7 @@ pub fn visual_inertial_bundle_adjust(
                 let (r_z_raw, jpd_raw, jxd_raw) =
                     depth_residual_and_jacobian(pose, point, d_meas as f64, sigma);
                 let chi2_depth = r_z_raw * r_z_raw;
-                let hw_depth = HuberKernel.weight(chi2_depth, params.huber_depth_sigma_sq);
+                let hw_depth = visual_huber_weight(chi2_depth, params.huber_depth_sigma_sq);
                 cost_vis += 0.5 * hw_depth * chi2_depth;
                 let sqrt_hw_depth = hw_depth.sqrt();
                 let r_z = r_z_raw * sqrt_hw_depth;
@@ -1343,7 +1347,7 @@ pub fn visual_inertial_bundle_adjust(
                 camera,
             );
             let chi2_vis = (r_f32[0] * r_f32[0] + r_f32[1] * r_f32[1]) as f64;
-            let hw_vis = HuberKernel.weight(chi2_vis, params.huber_reproj_px_sq);
+            let hw_vis = visual_huber_weight(chi2_vis, params.huber_reproj_px_sq);
             new_cost_vis += 0.5 * hw_vis * chi2_vis;
 
             if let Some(d_meas) = obs.depth_meas {
@@ -1355,7 +1359,7 @@ pub fn visual_inertial_bundle_adjust(
                     sigma,
                 );
                 let chi2_depth = r_z * r_z;
-                let hw_depth = HuberKernel.weight(chi2_depth, params.huber_depth_sigma_sq);
+                let hw_depth = visual_huber_weight(chi2_depth, params.huber_depth_sigma_sq);
                 new_cost_vis += 0.5 * hw_depth * chi2_depth;
             }
         }
@@ -1499,4 +1503,18 @@ pub fn visual_inertial_bundle_adjust(
         converged,
         final_cost,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ViBaParams, visual_huber_weight};
+
+    #[test]
+    fn visual_huber_defaults_and_weights() {
+        let params = ViBaParams::default();
+        assert_eq!(params.huber_reproj_px_sq, 25.0);
+        assert_eq!(params.huber_depth_sigma_sq, 9.0);
+        assert_eq!(visual_huber_weight(4.0, 25.0), 1.0);
+        assert_eq!(visual_huber_weight(100.0, 25.0), 0.5);
+    }
 }

--- a/crates/kornia-slam/src/vi_ba_schur.rs
+++ b/crates/kornia-slam/src/vi_ba_schur.rs
@@ -33,9 +33,9 @@
 //!   * Point parameters are the 3-dim world coordinates.
 //!   * z is clamped to `MIN_Z` to handle mid-iteration cheirality flips.
 //!
-//! Currently supports: identity loss only, fixed-pose anchors, fixed-point
-//! gauge (motion-only BA). Robust kernels and full LM-with-backtracking
-//! are TODO.
+//! Currently supports: Huber-robustified reprojection and IMU-nav
+//! residuals, fixed-pose anchors, fixed-point gauge (motion-only BA).
+//! Full LM-with-backtracking is still TODO.
 
 use faer::Mat;
 use faer::prelude::Solve;
@@ -45,6 +45,7 @@ use thiserror::Error;
 use kornia_3d::ba::{BaError, BaObservation};
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
+use kornia_3d::ransac::{HuberKernel, RobustKernel};
 use kornia_sensors::imu::{ImuBias, PreintegratedImu};
 
 const MIN_Z: f32 = 1e-3;
@@ -130,6 +131,10 @@ pub struct ViBaParams {
     /// (weight = 1.0, full metric constraint) but strongly suppresses the
     /// large residuals that arise from rough post-init velocity estimates.
     pub huber_imu_chi2: f64,
+    /// Squared-pixel Huber scale for reprojection residuals.
+    pub huber_reproj_px_sq: f64,
+    /// Squared-sigma Huber scale for stereo depth residuals.
+    pub huber_depth_sigma_sq: f64,
     /// Scale applied to the IMU edge whose "from" endpoint is a permanently-fixed
     /// keyframe (the one boundary edge linking the active window to the frozen
     /// past). Full-strength coupling to a value that can never be corrected again
@@ -164,6 +169,8 @@ impl Default for ViBaParams {
             imu_t_bc: None,
             imu_weight: 1.0,
             huber_imu_chi2: 16.9, // 9-DOF chi-square at 95 %
+            huber_reproj_px_sq: 25.0,
+            huber_depth_sigma_sq: 9.0,
             boundary_imu_info_scale: 1e-2,
             // sigma = 0.1 m/s²: comfortably above real MEMS accel-bias
             // magnitude, so it's a floor that only bites once the
@@ -899,11 +906,17 @@ pub fn visual_inertial_bundle_adjust(
             // residual_and_jacobians is f32 internally; cast results to f64.
             let (r_f32, jp_f32, jx_f32) = residual_and_jacobians(pose, point, obs.pixel, camera);
 
-            let r = [r_f32[0] as f64, r_f32[1] as f64];
-            let jp: [f64; 12] = std::array::from_fn(|i| jp_f32[i] as f64);
-            let jx: [f64; 6] = std::array::from_fn(|i| jx_f32[i] as f64);
+            let r_raw = [r_f32[0] as f64, r_f32[1] as f64];
+            let jp_raw: [f64; 12] = std::array::from_fn(|i| jp_f32[i] as f64);
+            let jx_raw: [f64; 6] = std::array::from_fn(|i| jx_f32[i] as f64);
 
-            cost_vis += 0.5 * (r[0] * r[0] + r[1] * r[1]);
+            let chi2_vis = r_raw[0] * r_raw[0] + r_raw[1] * r_raw[1];
+            let hw_vis = HuberKernel.weight(chi2_vis, params.huber_reproj_px_sq);
+            cost_vis += 0.5 * hw_vis * chi2_vis;
+            let sqrt_hw_vis = hw_vis.sqrt();
+            let r = [r_raw[0] * sqrt_hw_vis, r_raw[1] * sqrt_hw_vis];
+            let jp: [f64; 12] = std::array::from_fn(|i| jp_raw[i] * sqrt_hw_vis);
+            let jx: [f64; 6] = std::array::from_fn(|i| jx_raw[i] * sqrt_hw_vis);
 
             let pli = kf_local[obs.pose_idx];
             let xli = point_local[obs.point_idx];
@@ -953,9 +966,15 @@ pub fn visual_inertial_bundle_adjust(
             // depth_residual_and_jacobian for why this matters here.
             if let Some(d_meas) = obs.depth_meas {
                 let sigma = (obs.depth_sigma as f64).max(1e-6);
-                let (r_z, jpd, jxd) =
+                let (r_z_raw, jpd_raw, jxd_raw) =
                     depth_residual_and_jacobian(pose, point, d_meas as f64, sigma);
-                cost_vis += 0.5 * r_z * r_z;
+                let chi2_depth = r_z_raw * r_z_raw;
+                let hw_depth = HuberKernel.weight(chi2_depth, params.huber_depth_sigma_sq);
+                cost_vis += 0.5 * hw_depth * chi2_depth;
+                let sqrt_hw_depth = hw_depth.sqrt();
+                let r_z = r_z_raw * sqrt_hw_depth;
+                let jpd: [f64; 6] = std::array::from_fn(|i| jpd_raw[i] * sqrt_hw_depth);
+                let jxd: [f64; 3] = std::array::from_fn(|i| jxd_raw[i] * sqrt_hw_depth);
 
                 if pli >= 0 {
                     let p = pli as usize;
@@ -1323,7 +1342,9 @@ pub fn visual_inertial_bundle_adjust(
                 obs.pixel,
                 camera,
             );
-            new_cost_vis += 0.5 * (r_f32[0] * r_f32[0] + r_f32[1] * r_f32[1]) as f64;
+            let chi2_vis = (r_f32[0] * r_f32[0] + r_f32[1] * r_f32[1]) as f64;
+            let hw_vis = HuberKernel.weight(chi2_vis, params.huber_reproj_px_sq);
+            new_cost_vis += 0.5 * hw_vis * chi2_vis;
 
             if let Some(d_meas) = obs.depth_meas {
                 let sigma = (obs.depth_sigma as f64).max(1e-6);
@@ -1333,7 +1354,9 @@ pub fn visual_inertial_bundle_adjust(
                     d_meas as f64,
                     sigma,
                 );
-                new_cost_vis += 0.5 * r_z * r_z;
+                let chi2_depth = r_z * r_z;
+                let hw_depth = HuberKernel.weight(chi2_depth, params.huber_depth_sigma_sq);
+                new_cost_vis += 0.5 * hw_depth * chi2_depth;
             }
         }
         let mut new_cost_imu = 0.0f64;

--- a/examples/orb_slam/src/main.rs
+++ b/examples/orb_slam/src/main.rs
@@ -529,6 +529,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Main loop ──────────────────────────────────────────────────────────
     let mut trajectory: Vec<[f32; 3]> = Vec::new();
     let mut processed: usize = 0;
+    let mut previous_image: Option<Image<u8, 1>> = None;
 
     while let Some(item) = source.next_frame()? {
         let now = Instant::now();
@@ -625,7 +626,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             keypoints_undist: Vec::new(),
         };
         let t0 = std::time::Instant::now();
-        let result = system.process_frame(frame, timestamp_sec, imu_measurements);
+        let result = system.process_frame(
+            frame,
+            previous_image.as_ref(),
+            &gray_u8,
+            timestamp_sec,
+            imu_measurements,
+        );
         let frame_ms = t0.elapsed().as_secs_f64() * 1000.0;
         let keyframe_idx = system.current_keyframe_idx().unwrap_or(idx);
         let map_point_count = system.num_active_map_points();
@@ -697,6 +704,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 tui::TuiAction::None => {}
             }
         }
+        previous_image = Some(gray_u8);
     }
 
     // Restore terminal before printing the final summary.

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -1633,9 +1633,10 @@ fn apply_reference_pose_correction(
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_reference_pose_correction, format_imu_init_gate};
+    use super::{apply_reference_pose_correction, carry_klt_survivors, format_imu_init_gate};
     use kornia_3d::pose::Pose3d;
     use kornia_algebra::{SO3F64, Vec3F64};
+    use kornia_slam::estimation::optical_flow::{FlowSurvivor, MapKeypointMatch, TrackSet};
 
     fn assert_pose_close(actual: Pose3d, expected: Pose3d) {
         assert!((actual.translation - expected.translation).length() < 1e-10);
@@ -1677,5 +1678,38 @@ mod tests {
             format_imu_init_gate(12, Some(12), Some(32), 7, 10, 1.05, 1.0),
             "[imu_init_gate] start_idx=12 first_idx=Some(12) last_idx=Some(32) kfs=7/10 imu_time=1.05/1.0s"
         );
+    }
+
+    #[test]
+    fn klt_tracks_survive_skipped_frame_and_clear_without_survivors() {
+        let mut tracks = TrackSet::new();
+        tracks
+            .reconcile_from_matches(
+                &[MapKeypointMatch {
+                    map_point_idx: 42,
+                    keypoint_idx: 0,
+                }],
+                &[[10.0, 20.0]],
+            )
+            .unwrap();
+        let track_id = tracks.tracks()[0].id();
+
+        carry_klt_survivors(
+            &mut tracks,
+            Some(vec![FlowSurvivor {
+                track_id,
+                pixel: [12.0, 21.0],
+                error: 0.5,
+            }]),
+        );
+
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks.tracks()[0].id(), track_id);
+        assert_eq!(tracks.tracks()[0].map_point_idx(), Some(42));
+        assert_eq!(tracks.tracks()[0].pixel(), [12.0, 21.0]);
+        assert_eq!(tracks.tracks()[0].age(), 2);
+
+        carry_klt_survivors(&mut tracks, None);
+        assert!(tracks.is_empty());
     }
 }

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -11,9 +11,11 @@ use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::Pose3d;
 use kornia_3d::pose::{TriangulationConfig, triangulate_matched_points};
 use kornia_algebra::{Mat3F64, Vec2F64, Vec3F64};
+use kornia_image::Image;
 use kornia_imgproc::features::{OrbMatchConfig, hamming_distance, match_orb_descriptors};
 use kornia_sensors::imu::{GRAVITY_MAGNITUDE, ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
 use kornia_slam::Frame;
+use kornia_slam::estimation::optical_flow::{KltTracker, MapKeypointMatch, TrackSet, snap_unique};
 use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
 use kornia_slam::estimation::{ImuInitConfig, ImuInitializer, MapProjectionEstimator};
 use kornia_slam::map::{Keyframe, KeyframeJob, LocalMapping, Map, MapPoint, ORB_SCALE_FACTOR};
@@ -77,6 +79,8 @@ pub struct Pipeline {
     imu_viba1_done: bool,
     imu_viba2_done: bool,
     local_mapping: LocalMapping,
+    klt_tracker: KltTracker,
+    track_set: TrackSet,
     // System state
     state: SystemState,
 }
@@ -128,6 +132,8 @@ impl Pipeline {
             imu_init_window_start_sec: None,
             imu_viba1_done: false,
             imu_viba2_done: false,
+            klt_tracker: KltTracker::default(),
+            track_set: TrackSet::new(),
         }
     }
 
@@ -141,6 +147,8 @@ impl Pipeline {
     pub fn process_frame(
         &mut self,
         mut frame: Frame,
+        previous_image: Option<&Image<u8, 1>>,
+        current_image: &Image<u8, 1>,
         timestamp_sec: f64,
         imu_samples: Vec<ImuMeasurement>,
     ) -> TrackingResult {
@@ -158,8 +166,12 @@ impl Pipeline {
 
         match self.state.mode {
             SystemMode::Bootstrap => self.bootstrap_step(frame, timestamp_sec),
-            SystemMode::ImuInit => self.inertial_init_step(frame, timestamp_sec),
-            SystemMode::Tracking => self.tracking_step(frame, timestamp_sec),
+            SystemMode::ImuInit => {
+                self.inertial_init_step(frame, previous_image, current_image, timestamp_sec)
+            }
+            SystemMode::Tracking => {
+                self.tracking_step(frame, previous_image, current_image, timestamp_sec)
+            }
         }
     }
 
@@ -631,8 +643,14 @@ impl Pipeline {
         (pred_cam_to_world.inverse(), v_j)
     }
 
-    fn inertial_init_step(&mut self, frame: Frame, timestamp_sec: f64) -> TrackingResult {
-        let result = self.tracking_step(frame, timestamp_sec);
+    fn inertial_init_step(
+        &mut self,
+        frame: Frame,
+        previous_image: Option<&Image<u8, 1>>,
+        current_image: &Image<u8, 1>,
+        timestamp_sec: f64,
+    ) -> TrackingResult {
+        let result = self.tracking_step(frame, previous_image, current_image, timestamp_sec);
 
         if result.status == TrackingStatus::KeyframeAccepted
             && let Some(start_idx) = self.inertial_init_start_kf_idx
@@ -754,7 +772,13 @@ impl Pipeline {
         result
     }
 
-    fn tracking_step(&mut self, frame: Frame, timestamp_sec: f64) -> TrackingResult {
+    fn tracking_step(
+        &mut self,
+        frame: Frame,
+        previous_image: Option<&Image<u8, 1>>,
+        current_image: &Image<u8, 1>,
+        timestamp_sec: f64,
+    ) -> TrackingResult {
         let image_size = frame.image_size;
         let pose_before = self.state.pose_world_to_cam;
         let prev_timestamp = self.state.last_frame_timestamp_sec;
@@ -798,6 +822,33 @@ impl Pipeline {
             .map_or(0.0, |t0| timestamp_sec - t0);
         let search_scale = self.estimator.config().search_scale_for(currently_lost_for);
 
+        let klt_survivors = if self.track_set.is_empty() {
+            None
+        } else {
+            previous_image.and_then(|previous_image| {
+                self.klt_tracker
+                    .track(self.track_set.tracks(), previous_image, current_image)
+                    .ok()
+            })
+        };
+        let pre_seeded = klt_survivors
+            .as_ref()
+            .and_then(|survivors| {
+                snap_unique(
+                    &self.track_set,
+                    survivors,
+                    &frame.features.keypoints_xy,
+                    3.0,
+                )
+                .ok()
+            })
+            .map(|matches| {
+                matches
+                    .into_iter()
+                    .map(|matched| (matched.map_point_idx, matched.keypoint_idx))
+                    .collect()
+            });
+
         let result = self.estimator.estimate_pose(
             &frame,
             &candidate_pose,
@@ -806,6 +857,7 @@ impl Pipeline {
             &self.camera,
             self.state.current_keyframe_idx,
             search_scale,
+            pre_seeded,
         );
 
         let (mut status, matches, tracked_inliers, reject_reason) = match result {
@@ -820,6 +872,22 @@ impl Pipeline {
                 // freeze the IMU pose prediction.
                 if !self.state.imu_initialized {
                     self.state.velocity = Some(Pose3d::between(&pose_before, &estimate.pose));
+                }
+
+                let track_matches: Vec<MapKeypointMatch> = estimate
+                    .matches
+                    .iter()
+                    .map(|&(map_point_idx, keypoint_idx)| MapKeypointMatch {
+                        map_point_idx,
+                        keypoint_idx,
+                    })
+                    .collect();
+                if self
+                    .track_set
+                    .reconcile_from_matches(&track_matches, &frame.features.keypoints_xy)
+                    .is_err()
+                {
+                    self.track_set = TrackSet::new();
                 }
 
                 (

--- a/examples/orb_slam/src/pipeline.rs
+++ b/examples/orb_slam/src/pipeline.rs
@@ -15,7 +15,9 @@ use kornia_image::Image;
 use kornia_imgproc::features::{OrbMatchConfig, hamming_distance, match_orb_descriptors};
 use kornia_sensors::imu::{GRAVITY_MAGNITUDE, ImuBias, ImuCalib, ImuMeasurement, PreintegratedImu};
 use kornia_slam::Frame;
-use kornia_slam::estimation::optical_flow::{KltTracker, MapKeypointMatch, TrackSet, snap_unique};
+use kornia_slam::estimation::optical_flow::{
+    FlowSurvivor, KltTracker, MapKeypointMatch, TrackSet, snap_unique,
+};
 use kornia_slam::estimation::two_view::{TwoViewInitConfig, try_initialize_two_view};
 use kornia_slam::estimation::{ImuInitConfig, ImuInitializer, MapProjectionEstimator};
 use kornia_slam::map::{Keyframe, KeyframeJob, LocalMapping, Map, MapPoint, ORB_SCALE_FACTOR};
@@ -898,6 +900,8 @@ impl Pipeline {
                 )
             }
             Err(reason) => {
+                carry_klt_survivors(&mut self.track_set, klt_survivors);
+
                 // Carry the predicted pose forward instead of freezing at
                 // pose_before. state.velocity_world was already advanced by
                 // predict_pose_imu above regardless of visual outcome, so
@@ -969,6 +973,7 @@ impl Pipeline {
                     "[lost] frame={} giving up after {:.2}s (map_established={}): resetting",
                     frame.idx, recently_lost_for, map_established,
                 ));
+                self.track_set = TrackSet::new();
                 self.state.reset();
                 return self.bootstrap_step(frame, timestamp_sec);
             }
@@ -1592,6 +1597,12 @@ impl Pipeline {
         }
 
         n_fused
+    }
+}
+
+fn carry_klt_survivors(track_set: &mut TrackSet, survivors: Option<Vec<FlowSurvivor>>) {
+    if survivors.is_none_or(|survivors| track_set.advance(survivors).is_err()) {
+        *track_set = TrackSet::new();
     }
 }
 


### PR DESCRIPTION
## Summary

- land the already-reviewed stacked work from #64 and #65 on `develop`
- recover tracking across skipped frames using persistent KLT correspondences
- robustify VI-BA visual reprojection and stereo-depth residuals with Huber weighting
- retain the regression coverage added by both PRs

## Why this PR is needed

#64 was merged into `feat/robust-pose-estimation`, and #65 was then merged into `feat/klt-skipped-frame-recovery`. GitHub therefore marks both PRs as merged, but neither merge commit nor their five implementation/test commits became ancestors of `develop`.

This promotion PR carries those five missing commits onto `develop`. It adds no new implementation beyond the reviewed #64/#65 stack.

## History

- #54 — original combined implementation, closed after being split into focused PRs
- #64 — KLT pipeline integration and skipped-frame recovery
- #65 — robust VI-BA visual residuals

Authorship from the focused PRs is preserved: Astik remains the author of the reconstructed implementation commits, and Christie remains the author of the regression tests.

## Verification

- the current `develop` tree matches the tree on which this stack was based
- `git diff --check origin/develop...origin/feat/vi-ba-huber-loss`
- prior full-stack validation reported in #65:
  - `cargo fmt --all -- --check`
  - `cargo test -p kornia-slam` (56 passed)
  - `cargo test -p orb_slam` (21 passed)
  - `cargo check --workspace`
  - `cargo clippy --all-targets -- -D warnings`
